### PR TITLE
Fixed issue with manually publishing from the CLI not updating tags p…

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -97,6 +97,21 @@ public class Client {
     public static final int CONNECTION_ERROR = 150;
     public static final int INPUT_ERROR = 3;
 
+    // This should be linked to common, but we won't do this now because we don't want dependencies changing during testing
+    public enum Registry {
+        QUAY_IO("quay.io"), DOCKER_HUB("registry.hub.docker.com");
+        private String value;
+
+        Registry(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
+
     private static void out(String format, Object... args) {
         System.out.println(String.format(format, args));
     }
@@ -471,7 +486,7 @@ public class Client {
             container.setGitUrl(gitURL);
             container.setToolname(toolname);
 
-            if (!"quay.io".equals(registry)) {
+            if (!Registry.QUAY_IO.toString().equals(registry)) {
                 final String versionName = optVal(args, "--version-name", gitReference);
                 final Tag tag = new Tag();
                 tag.setReference(gitReference);

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -461,7 +461,7 @@ public class Client {
             out("  --cwl-path <file>            Path for the CWL document, defaults to /Dockstore.cwl");
             out("  --toolname <toolname>        Name of the tool, can be omitted");
             out("  --registry <registry>        Docker registry, can be omitted, defaults to registry.hub.docker.com");
-            out("  --version-name <version>     Version tag name for Dockerhub containers only, defaults to git-reference");
+            out("  --version-name <version>     Version tag name for Dockerhub containers only, defaults to latest");
             out("");
         } else {
             final String name = reqVal(args, "--name");
@@ -487,7 +487,7 @@ public class Client {
             container.setToolname(toolname);
 
             if (!Registry.QUAY_IO.toString().equals(registry)) {
-                final String versionName = optVal(args, "--version-name", gitReference);
+                final String versionName = optVal(args, "--version-name", "latest");
                 final Tag tag = new Tag();
                 tag.setReference(gitReference);
                 tag.setDockerfilePath(dockerfilePath);

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -446,6 +446,7 @@ public class Client {
             out("  --cwl-path <file>            Path for the CWL document, defaults to /Dockstore.cwl");
             out("  --toolname <toolname>        Name of the tool, can be omitted");
             out("  --registry <registry>        Docker registry, can be omitted, defaults to registry.hub.docker.com");
+            out("  --version-name <version>     Version tag name for Dockerhub containers only, defaults to git-reference");
             out("");
         } else {
             final String name = reqVal(args, "--name");
@@ -469,11 +470,17 @@ public class Client {
             container.setIsRegistered(true);
             container.setGitUrl(gitURL);
             container.setToolname(toolname);
-            final Tag tag = new Tag();
-            tag.setReference(gitReference);
-            tag.setDockerfilePath(dockerfilePath);
-            tag.setCwlPath(cwlPath);
-            container.getTags().add(tag);
+
+            if (!"quay.io".equals(registry)) {
+                final String versionName = optVal(args, "--version-name", gitReference);
+                final Tag tag = new Tag();
+                tag.setReference(gitReference);
+                tag.setDockerfilePath(dockerfilePath);
+                tag.setCwlPath(cwlPath);
+                tag.setName(versionName);
+                container.getTags().add(tag);
+            }
+
             final String fullName = Joiner.on("/").skipNulls().join(registry, namespace, name, toolname);
             try {
                 container = containersApi.registerManual(container);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicET.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicET.java
@@ -467,15 +467,20 @@ public class BasicET {
                         "master", "--toolname", "alternate", "--cwl-path", "/testDir/Dockstore.cwl", "--dockerfile-path", "/testDir/Dockerfile" });
 
                 final CommonTestUtilities.TestingPostgres testingPostgres = getTestingPostgres();
-                final long count = testingPostgres.runSelectStatement("select count(*) from container where toolname = 'alternate' and isregistered='t' and validtrigger='t'", new ScalarHandler<>());
-
+                final long count = testingPostgres.runSelectStatement("select count(*) from container where toolname = 'alternate' and isregistered='t'", new ScalarHandler<>());
                 Assert.assertTrue("there should be 1 entry", count == 1);
+
+                final long count2 = testingPostgres.runSelectStatement("select count(*) from container where toolname = 'alternate'  and validtrigger='t'", new ScalarHandler<>());
+                Assert.assertTrue("there should be 1 valid entry", count2 == 1);
 
                 // Unpublish
                 Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file.txt"), "publish", "--unpub", "registry.hub.docker.com/dockstoretestuser/dockerhubandbitbucket/alternate" });
-                final long count2 = testingPostgres.runSelectStatement("select count(*) from container where toolname = 'alternate' and isregistered='f' and validtrigger='t'", new ScalarHandler<>());
 
-                Assert.assertTrue("there should be 1 entry", count2 == 1);
+                final long count3 = testingPostgres.runSelectStatement("select count(*) from container where toolname = 'alternate' and isregistered='f'", new ScalarHandler<>());
+                Assert.assertTrue("there should be 1 entry", count3 == 1);
+
+                final long count4 = testingPostgres.runSelectStatement("select count(*) from container where toolname = 'alternate' and validtrigger='t'", new ScalarHandler<>());
+                Assert.assertTrue("there should be 1 valid entry", count4 == 1);
         }
 
         /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ResourceUtilities.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ResourceUtilities.java
@@ -82,8 +82,11 @@ public class ResourceUtilities {
         final int waitTime = 30000;
         try {
             ResponseHandler<String> responseHandler = new BasicResponseHandler();
-            RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(waitTime).setConnectTimeout(waitTime).setConnectionRequestTimeout(waitTime).build();
-            httpGet.setConfig(requestConfig);
+            // Give Bitbucket calls longer timeouts
+            if (httpGet.getURI().toString().contains("bitbucket.org")) {
+                RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(waitTime).setConnectTimeout(waitTime).setConnectionRequestTimeout(waitTime).build();
+                httpGet.setConfig(requestConfig);
+            }
             result = Optional.of(client.execute(httpGet, responseHandler));
         } catch (HttpResponseException httpResponseException) {
             LOG.error("getResponseAsString(): caught 'HttpResponseException' while processing request <{}> :=> <{}>", httpGet,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ResourceUtilities.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ResourceUtilities.java
@@ -79,8 +79,11 @@ public class ResourceUtilities {
 
     public static Optional<String> getResponseAsString(HttpGet httpGet, HttpClient client) {
         Optional<String> result = Optional.absent();
+        final int waitTime = 30000;
         try {
             ResponseHandler<String> responseHandler = new BasicResponseHandler();
+            RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(waitTime).setConnectTimeout(waitTime).setConnectionRequestTimeout(waitTime).build();
+            httpGet.setConfig(requestConfig);
             result = Optional.of(client.execute(httpGet, responseHandler));
         } catch (HttpResponseException httpResponseException) {
             LOG.error("getResponseAsString(): caught 'HttpResponseException' while processing request <{}> :=> <{}>", httpGet,


### PR DESCRIPTION
…roperly

Fixes the issue where manually adding a container from the command line will not properly populate its tags.  This was due to the CLI creating a mostly blank tag during manual publish.  The code will only create automatic version tags if no tags exist, so this mostly blank tag was stopping the automatic ones.  Also for the case of a Dockerhub container being manually published, it will create a basic tag that has enough information to do a docker pull.