### PR TITLE
Feature/register quay no auto builds

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -1148,10 +1148,12 @@ public class Client {
                 final String cwlPath = optVal(args, "--cwl-path", container.getDefaultCwlPath());
                 final String dockerfilePath = optVal(args, "--dockerfile-path", container.getDefaultDockerfilePath());
                 final String toolname = optVal(args, "--toolname", container.getToolname());
+                final String gitUrl = optVal(args, "--git-url", container.getGitUrl());
 
                 container.setDefaultCwlPath(cwlPath);
                 container.setDefaultDockerfilePath(dockerfilePath);
                 container.setToolname(toolname);
+                container.setGitUrl(gitUrl);
 
                 Container result = containersApi.updateContainer(containerId, container);
                 out("The container has been updated.");

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -1171,7 +1171,7 @@ public class Client {
         out("------------------");
         out("See https://www.dockstore.org for more information");
         out("");
-        out("dockstore updateContainer --entry <path to tool> --cwl-path <cwl path> --dockerfile-path <dockerfile path> --toolname <toolname>         :  Updates some fields for a container");
+        out("dockstore updateContainer --entry <path to tool> --cwl-path <cwl path> --dockerfile-path <dockerfile path> --toolname <toolname> --git-url <git-url>         :  Updates some fields for a container");
         out("");
         out("------------------");
         out("");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/Helper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/Helper.java
@@ -598,7 +598,14 @@ public final class Helper {
         List<Container> apiContainers = new ArrayList<>();
 
         // Find a container with the given container's Path as it's tool path
-        Container duplicatePath = containerDAO.findByToolPath(container.getPath(), "");
+        Container duplicatePath = null;
+        List<Container> containersList = containerDAO.findByPath(container.getPath());
+        for(Container c : containersList) {
+            if (c.getMode() != ContainerMode.MANUAL_IMAGE_PATH) {
+                duplicatePath = c;
+                break;
+            }
+        }
 
         // If exists, check conditions to see if it should be changed to auto (in sync with quay tags and git repo)
         if (container.getMode() == ContainerMode.MANUAL_IMAGE_PATH && duplicatePath != null  && container.getRegistry().toString().equals(

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/Helper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/Helper.java
@@ -597,7 +597,7 @@ public final class Helper {
 
         List<Container> apiContainers = new ArrayList<>();
 
-        // Find a container with the given container's Path as it's tool path
+        // Find a container with the given container's Path and is not manual
         Container duplicatePath = null;
         List<Container> containersList = containerDAO.findByPath(container.getPath());
         for(Container c : containersList) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Container.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Container.java
@@ -195,6 +195,9 @@ public class Container {
         validTrigger = container.getValidTrigger();
         author = container.getAuthor();
 
+        // Only overwrite the giturl if the new git url is not empty (no value)
+        // This will stop the case where there are no autobuilds for a quay repo, but a manual git repo has been set.
+        //  Giturl will only be changed if the git repo from quay has an autobuild
         if (!container.getGitUrl().isEmpty()) {
             gitUrl = container.getGitUrl();
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Container.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Container.java
@@ -195,7 +195,9 @@ public class Container {
         validTrigger = container.getValidTrigger();
         author = container.getAuthor();
 
-        gitUrl = container.getGitUrl();
+        if (!container.getGitUrl().isEmpty()) {
+            gitUrl = container.getGitUrl();
+        }
     }
 
     @JsonProperty
@@ -482,5 +484,6 @@ public class Container {
         defaultCwlPath = container.getDefaultCwlPath();
         defaultDockerfilePath = container.getDefaultDockerfilePath();
         toolname = container.getToolname();
+        gitUrl = container.getGitUrl();
     }
 }


### PR DESCRIPTION
This fixes issues #19 and #120 , also adds tests for them.
For the case of #19, you can manually add quay containers with no autobuilds and they will work fine, but if they are quickregistered/auto you will need to use the command line updateContainer to manually set the git url.  Currently this can not be done through the UI (#117)