### PR TITLE
Feature/wdl file provisioning

### DIFF
--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -44,7 +44,12 @@
             <artifactId>dockstore-launcher</artifactId>
             <version>0.4-alpha.0-SNAPSHOT</version>
         </dependency>
-        
+        <dependency>
+            <groupId>io.dockstore</groupId>
+            <artifactId>dockstore-common</artifactId>
+            <version>0.4-alpha.0-SNAPSHOT</version>
+        </dependency>
+
         <dependency>
             <groupId>com.esotericsoftware.yamlbeans</groupId>
             <artifactId>yamlbeans</artifactId>

--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -49,12 +49,6 @@
             <artifactId>dockstore-common</artifactId>
             <version>0.4-alpha.0-SNAPSHOT</version>
         </dependency>
-
-        <dependency>
-            <groupId>com.esotericsoftware.yamlbeans</groupId>
-            <artifactId>yamlbeans</artifactId>
-            <version>1.09</version>
-        </dependency>
         
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -100,6 +94,11 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+            <version>1.10</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -724,12 +724,12 @@ public class Client {
             Main main = new Main();
             File parameterFile = new File(json);
 
-            final SourceFile cwlFromServer;
+            final SourceFile wdlFromServer;
             try {
                 // Grab WDL from server and store to file
-                cwlFromServer = getDescriptorFromServer(entry, "wdl");
+                wdlFromServer = getDescriptorFromServer(entry, "wdl");
                 final File tempWdl = File.createTempFile("temp", ".wdl", Files.createTempDir());
-                Files.write(cwlFromServer.getContent(), tempWdl, StandardCharsets.UTF_8);
+                Files.write(wdlFromServer.getContent(), tempWdl, StandardCharsets.UTF_8);
 
                 final List<String> wdlRun = Lists.newArrayList(tempWdl.getAbsolutePath(), parameterFile.getAbsolutePath());
                 final scala.collection.immutable.List<String> wdlRunList = scala.collection.JavaConversions.asScalaBuffer(wdlRun).toList();

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -737,13 +737,14 @@ public class Client {
                 Bridge bridge = new Bridge();
                 Map<String, String> wdlInputs = bridge.getInputFiles(tempWdl);
 
-                // Download files and change to local location
+                // Convert parameter JSON to a map
                 WDLFileProvisioning wdlFileProvisioning = new WDLFileProvisioning();
                 Gson gson = new Gson();
                 String jsonString = FileUtils.readFileToString(parameterFile);
                 Map<String, Object> map = new HashMap<>();
                 Map<String, Object> inputJson = gson.fromJson(jsonString, map.getClass());
 
+                // Download files and change to local location
                 // Make a new map of the inputs with updated locations
                 Map<String,Object> fileMap = wdlFileProvisioning.pullFiles(inputJson, wdlInputs);
 

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -25,7 +25,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
@@ -50,6 +49,7 @@ import java.util.regex.Pattern;
 
 import javax.ws.rs.ProcessingException;
 
+import org.apache.commons.configuration.HierarchicalINIConfiguration;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVPrinter;
@@ -59,7 +59,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.http.HttpStatus;
 
-import com.esotericsoftware.yamlbeans.YamlReader;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -1679,14 +1678,11 @@ public class Client {
 
         try {
             configFile = optVal(args, "--config", userHome + File.separator + ".dockstore" + File.separator + "config");
-            InputStreamReader f = new InputStreamReader(new FileInputStream(configFile), Charset.defaultCharset());
-            YamlReader reader = new YamlReader(f);
-            Object object = reader.read();
-            Map map = (Map) object;
+            HierarchicalINIConfiguration config = new HierarchicalINIConfiguration(configFile);
 
             // pull out the variables from the config
-            String token = (String) map.get("token");
-            String serverUrl = (String) map.get("server-url");
+            String token = config.getString("token");
+            String serverUrl = config.getString("server-url");
 
             if (token == null) {
                 err("The token is missing from your config file.");

--- a/dockstore-client/src/main/scala/io/dockstore/client/Bridge.scala
+++ b/dockstore-client/src/main/scala/io/dockstore/client/Bridge.scala
@@ -59,11 +59,9 @@ class Bridge {
 
   def getInputFiles(file: JFile): util.Map[String, String] = {
     val lines = scala.io.Source.fromFile(file).mkString
-    var wdlString = WdlString(lines)
     val ns = NamespaceWithWorkflow.load(lines)
-    val workflowName = ns.workflow.unqualifiedName
 
-    var inputList = new util.HashMap[String, String]()
+    val inputList = new util.HashMap[String, String]()
 
     import scala.collection.JavaConversions._
     ns.workflow.inputs foreach {case(key,value) =>

--- a/dockstore-client/src/main/scala/io/dockstore/client/Bridge.scala
+++ b/dockstore-client/src/main/scala/io/dockstore/client/Bridge.scala
@@ -17,8 +17,11 @@
 package io.dockstore.client
 
 import java.io.{File => JFile}
+import java.util
 
 import wdl4s.formatter.{AnsiSyntaxHighlighter, HtmlSyntaxHighlighter, SyntaxFormatter}
+import wdl4s.types.{WdlArrayType, WdlFileType}
+import wdl4s.values.WdlString
 import wdl4s.{AstTools, _}
 import spray.json._
 
@@ -53,4 +56,22 @@ class Bridge {
         null
     }
   }
+
+  def getInputFiles(file: JFile): util.Map[String, String] = {
+    val lines = scala.io.Source.fromFile(file).mkString
+    var wdlString = WdlString(lines)
+    val ns = NamespaceWithWorkflow.load(lines)
+    val workflowName = ns.workflow.unqualifiedName
+
+    var inputList = new util.HashMap[String, String]()
+
+    import scala.collection.JavaConversions._
+    ns.workflow.inputs foreach {case(key,value) =>
+      if (value.wdlType == WdlFileType || value.wdlType == WdlArrayType(WdlFileType)) {
+        inputList.put(value.fqn, value.wdlType.toWdlString)
+      }
+    }
+    return inputList
+  }
+
 }

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -110,12 +110,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
-            <version>1.10.29</version>
+            <version>${aws.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.10.29</version>
+            <version>${aws.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -107,6 +107,21 @@
             <groupId>io.cwl</groupId>
             <artifactId>cwlavro-tools</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>1.10.29</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>1.10.29</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-vfs2</artifactId>
+            <version>2.0</version>
+        </dependency>
     </dependencies>
     
     <build>

--- a/dockstore-common/src/main/java/io/dockstore/common/FileProvisioning.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/FileProvisioning.java
@@ -3,6 +3,7 @@ package io.dockstore.common;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URI;
 import java.util.List;
 
 
@@ -114,6 +115,43 @@ public class FileProvisioning {
                 } catch (org.apache.commons.vfs2.FileSystemException e) {
                         LOG.error(e.getMessage());
                         throw new RuntimeException("Could not provision input files", e);
+                }
+        }
+
+        public static class PathInfo {
+                private static final Logger LOG = LoggerFactory.getLogger(PathInfo.class);
+                public static final String DCC_STORAGE_SCHEME = "icgc";
+                private boolean objectIdType;
+                private String objectId = "";
+                private boolean localFileType = false;
+
+                public boolean isObjectIdType() {
+                        return objectIdType;
+                }
+
+                public String getObjectId() {
+                        return objectId;
+                }
+
+                public PathInfo(String path) {
+                        try {
+                                URI objectIdentifier = URI.create(path);	// throws IllegalArgumentException if it isn't a valid URI
+                                if (objectIdentifier.getScheme() == null){
+                                        localFileType = true;
+                                }
+                                if (objectIdentifier.getScheme().equalsIgnoreCase(DCC_STORAGE_SCHEME)) {
+                                        objectIdType = true;
+                                        objectId = objectIdentifier.getSchemeSpecificPart().toLowerCase();
+                                }
+                        } catch (IllegalArgumentException | NullPointerException iae) {
+                                // if there is no scheme, then it must be a local file
+                                LOG.warn("Invalid path specified for CWL pre-processor values: " + path);
+                                objectIdType = false;
+                        }
+                }
+
+                public boolean isLocalFileType() {
+                        return localFileType;
                 }
         }
 }

--- a/dockstore-common/src/main/java/io/dockstore/common/FileProvisioning.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/FileProvisioning.java
@@ -1,0 +1,120 @@
+package io.dockstore.common;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+
+
+import org.apache.commons.configuration.HierarchicalINIConfiguration;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.Selectors;
+import org.apache.commons.vfs2.VFS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.SignerFactory;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.S3ClientOptions;
+import com.amazonaws.services.s3.internal.S3Signer;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.google.common.io.Files;
+
+/**
+ * The purpose of this class is to provide general functions to deal with workflow file provisioning.
+ * Created by aduncan on 10/03/16.
+ */
+public class FileProvisioning {
+
+        static {
+                SignerFactory.registerSigner("S3Signer", S3Signer.class);
+        }
+
+        private static final Logger LOG = LoggerFactory.getLogger(FileProvisioning.class);
+
+        public static final String S3_ENDPOINT = "s3.endpoint";
+        public static final String DCC_CLIENT_KEY = "dcc_storage.client";
+
+        private HierarchicalINIConfiguration config;
+        private final Optional<OutputStream> stdoutStream;
+        private final Optional<OutputStream> stderrStream;
+
+        /**
+         * Constructor
+         */
+        public FileProvisioning() {
+                // do not forward stdout and stderr
+                stdoutStream = Optional.absent();
+                stderrStream = Optional.absent();
+        }
+
+        // Which functions to move here? DCC and apache commons ones?
+        public String getStorageClient() {
+                return config.getString(DCC_CLIENT_KEY, "/icgc/dcc-storage/bin/dcc-storage-client");
+        }
+
+        public void downloadFromDccStorage(String objectId, String downloadDir, File downloadDirFileObj, String targetFilePath) {
+                // default layout saves to original_file_name/object_id
+                // file name is the directory and object id is actual file name
+                String client = getStorageClient();
+                String bob = new StringBuilder().append(client).append(" --quiet").append(" download").append(" --object-id ").append(objectId).append(" --output-dir ").append(downloadDir).append(" --output-layout id").toString();
+                Utilities.executeCommand(bob, stdoutStream, stderrStream);
+
+                // downloaded file
+                String downloadPath = downloadDirFileObj.getAbsolutePath() + "/" + objectId;
+                System.out.println("download path: " + downloadPath);
+                File downloadedFileFileObj = new File(downloadPath);
+                File targetPathFileObj = new File(targetFilePath);
+                try {
+                        Files.move(downloadedFileFileObj, targetPathFileObj);
+                } catch (IOException ioe) {
+                        LOG.error(ioe.getMessage());
+                        throw new RuntimeException("Could not move input file: ", ioe);
+                }
+        }
+
+        public void downloadFromS3(String path, String targetFilePath) {
+                AmazonS3 s3Client = new AmazonS3Client(new ClientConfiguration().withSignerOverride("S3Signer"));
+                if (config.containsKey(S3_ENDPOINT)) {
+                        final String endpoint = config.getString(S3_ENDPOINT);
+                        LOG.info("found custom S3 endpoint, setting to {}", endpoint);
+                        s3Client.setEndpoint(endpoint);
+                        s3Client.setS3ClientOptions(new S3ClientOptions().withPathStyleAccess(true));
+                }
+                String trimmedPath = path.replace("s3://", "");
+                List<String> splitPathList = Lists.newArrayList(trimmedPath.split("/"));
+                String bucketName = splitPathList.remove(0);
+
+                S3Object object = s3Client.getObject(new GetObjectRequest(bucketName, Joiner.on("/").join(splitPathList)));
+                try {
+                        FileUtils.copyInputStreamToFile(object.getObjectContent(), new File(targetFilePath));
+                } catch (IOException e) {
+                        LOG.error(e.getMessage());
+                        throw new RuntimeException("Could not provision input files from S3", e);
+                }
+        }
+
+        public void downloadFromHttp(String path, String targetFilePath) {
+                // VFS call, see https://github.com/abashev/vfs-s3/tree/branch-2.3.x and
+                // https://commons.apache.org/proper/commons-vfs/filesystems.html
+                FileSystemManager fsManager;
+                try {
+                        // trigger a copy from the URL to a local file path that's a UUID to avoid collision
+                        fsManager = VFS.getManager();
+                        org.apache.commons.vfs2.FileObject src = fsManager.resolveFile(path);
+                        org.apache.commons.vfs2.FileObject dest = fsManager.resolveFile(new File(targetFilePath).getAbsolutePath());
+                        dest.copyFrom(src, Selectors.SELECT_SELF);
+                } catch (org.apache.commons.vfs2.FileSystemException e) {
+                        LOG.error(e.getMessage());
+                        throw new RuntimeException("Could not provision input files", e);
+                }
+        }
+}
+

--- a/dockstore-common/src/main/java/io/dockstore/common/FileProvisioning.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/FileProvisioning.java
@@ -6,7 +6,7 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.util.List;
 
-
+import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalINIConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.vfs2.FileSystemManager;
@@ -50,10 +50,16 @@ public class FileProvisioning {
         /**
          * Constructor
          */
-        public FileProvisioning() {
+        public FileProvisioning(String configFile) {
                 // do not forward stdout and stderr
                 stdoutStream = Optional.absent();
                 stderrStream = Optional.absent();
+
+                try {
+                        this.config = new HierarchicalINIConfiguration(configFile);
+                } catch (ConfigurationException e) {
+                        e.printStackTrace();
+                }
         }
 
         // Which functions to move here? DCC and apache commons ones?

--- a/dockstore-common/src/main/java/io/dockstore/common/WDLFileProvisioning.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/WDLFileProvisioning.java
@@ -27,12 +27,15 @@ public class WDLFileProvisioning {
 
         private final Optional<OutputStream> stdoutStream;
         private final Optional<OutputStream> stderrStream;
-        private final FileProvisioning fileProvisioning = new FileProvisioning();
+        private final FileProvisioning fileProvisioning;
+        private String configFile;
 
-        public WDLFileProvisioning() {
+        public WDLFileProvisioning(String configFile) {
                 // do not forward stdout and stderr
                 stdoutStream = Optional.absent();
                 stderrStream = Optional.absent();
+                this.configFile = configFile;
+                fileProvisioning = new FileProvisioning(configFile);
         }
 
         /**

--- a/dockstore-common/src/main/java/io/dockstore/common/WDLFileProvisioning.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/WDLFileProvisioning.java
@@ -1,0 +1,176 @@
+package io.dockstore.common;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.util.json.JSONException;
+import com.amazonaws.util.json.JSONObject;
+import com.google.common.base.Optional;
+
+/**
+ * This class deals with file provisioning for WDL
+ * Created by aduncan on 10/03/16.
+ */
+public class WDLFileProvisioning {
+        private static final Logger LOG = LoggerFactory.getLogger(WDLFileProvisioning.class);
+
+        private final Optional<OutputStream> stdoutStream;
+        private final Optional<OutputStream> stderrStream;
+        private final FileProvisioning fileProvisioning = new FileProvisioning();
+
+        public WDLFileProvisioning() {
+                // do not forward stdout and stderr
+                stdoutStream = Optional.absent();
+                stderrStream = Optional.absent();
+        }
+
+        /**
+         * Pulls remote files from S3, DCC or HTTP and stores them locally.
+         * A map is created to replace the input file entries in the input JSON file, where remote paths will be changed to local paths.
+         * @param inputFilesJson Map of all input files from the input JSON file, key = fully qualified name(fqn), value = type (ex. file)
+         * @param originalInputJson Map of input JSON file
+         * @return A new mapping of fully qualified name to input file string or list of input file strings
+         */
+        public Map<String, Object> pullFiles(Map<String, Object> inputFilesJson, Map<String, String> originalInputJson) {
+                // Download remote files into specific local locations
+                Map<String, Object> fileMap = new HashMap<>();
+
+                LOG.info("DOWNLOADING INPUT FILES...");
+
+                // Go through input file fully qualified names
+                for (Map.Entry<String, String> originalInputJsonEntry : originalInputJson.entrySet()) {
+                        LOG.info(originalInputJsonEntry.getKey());
+                        // Find matching name value in JSON parameter file
+                        for (Map.Entry<String, Object> stringObjectEntry : inputFilesJson.entrySet()) {
+                                // If the entry matches
+                                if (stringObjectEntry.getKey().equals(originalInputJsonEntry.getKey())) {
+                                        // Check if File or Array of Files
+                                        if (stringObjectEntry.getValue() instanceof ArrayList) {
+                                                // Iterate through object
+                                                List stringObjectEntryList = (List)stringObjectEntry.getValue();
+                                                ArrayList<String> updatedPaths = new ArrayList<>();
+                                                for (Object entry : stringObjectEntryList) {
+                                                        if (entry instanceof String) {
+                                                                updatedPaths.add(doProcessFile(stringObjectEntry.getKey(), entry.toString()).get(stringObjectEntry.getKey()).toString());
+                                                        }
+                                                }
+
+                                                fileMap.put(stringObjectEntry.getKey(), updatedPaths);
+
+                                        } else if (stringObjectEntry.getValue() instanceof String) {
+                                                // Just a file
+                                                Map<String, Object> tempMap;
+                                                tempMap = doProcessFile(stringObjectEntry.getKey(), stringObjectEntry.getValue().toString());
+                                                fileMap.putAll(tempMap);
+                                        }
+                                }
+                        }
+                }
+
+                return fileMap;
+        }
+
+        /**
+         * Create a mapping of the input files, including newly localized files
+         * @param key Fully Qualified Name
+         * @param path Original Path
+         * @return Mapping of fully qualified name to new input file string or list of new input file strings
+         */
+        public Map<String, Object> doProcessFile(String key, String path) {
+                FileProvisioning.PathInfo pathInfo = new FileProvisioning.PathInfo(path);
+                Map<String, Object> entry = new HashMap<>();
+
+                if (!pathInfo.isLocalFileType()) {
+
+                        LOG.info("PATH TO DOWNLOAD FROM: {} FOR {}", path, key);
+
+                        // Setup local paths
+                        String downloadDir = "cromwell-input/" + UUID.randomUUID();
+                        Utilities.executeCommand("mkdir -p " + downloadDir, stdoutStream, stderrStream);
+                        File downloadDirFileObject = new File(downloadDir);
+                        String targetFilePath = downloadDirFileObject.getAbsolutePath() + "/" + key;
+
+                        if (pathInfo.isObjectIdType()) {
+                                String objectId = pathInfo.getObjectId();
+                                fileProvisioning.downloadFromDccStorage(objectId, downloadDir, downloadDirFileObject, targetFilePath);
+                        } else if (path.startsWith("s3://")) {
+                                fileProvisioning.downloadFromS3(path, targetFilePath);
+                        } else if (!pathInfo.isLocalFileType()) {
+                                fileProvisioning.downloadFromHttp(path, targetFilePath);
+                        }
+                        // key may contain either key:download_URL for array inputs or just cwlInputFileID for scalar input
+                        entry.put(key, targetFilePath);
+                        LOG.info("DOWNLOADED FILE: LOCAL: {} URL: {} => {}", key, path, targetFilePath);
+                } else {
+                        entry.put(key, path);
+                }
+                return entry;
+
+        }
+
+        /**
+         * Creates a new mapping to represent the Input JSON file with updated file paths
+         * @param originalInputJson
+         * @param newInputJson
+         * @return Path to new JSON file
+         */
+        public String createUpdatedInputsJson(Map<String, Object> originalInputJson, Map<String, Object> newInputJson) {
+                JSONObject newJSON = new JSONObject();
+                for (String paramName : originalInputJson.keySet()) {
+                        boolean isNew = false;
+
+                        final Object currentParam = originalInputJson.get(paramName);
+
+                        for (Map.Entry<String, Object> entry : newInputJson.entrySet()) {
+                                if (paramName.equals(entry.getKey())) {
+                                        isNew = true;
+                                        try {
+                                                newJSON.put(entry.getKey(), entry.getValue());
+                                        } catch (JSONException e) {
+                                                e.printStackTrace();
+                                        }
+                                        break;
+                                }
+                        }
+                        if (!isNew) {
+                                try {
+                                        newJSON.put(paramName, currentParam);
+                                } catch (JSONException e) {
+                                        e.printStackTrace();
+                                }
+                        }
+                }
+
+                // Now make a new file
+                writeJob("foo2.json", newJSON);
+                File newFile = new File("foo2.json");
+                return newFile.getAbsolutePath();
+
+        }
+
+        /**
+         * Writes a given JSON object to new file jobOutputPath
+         * @param jobOutputPath Path to output JSON to
+         * @param newJson JSON object to be saved to file
+         */
+        private void writeJob(String jobOutputPath, JSONObject newJson) {
+                try {
+                        //TODO: investigate, why is this replacement occurring?
+                        final String replace = newJson.toString().replace("\\", "");
+                        FileUtils.writeStringToFile(new File(jobOutputPath), replace, StandardCharsets.UTF_8);
+                } catch (IOException e) {
+                        throw new RuntimeException("Could not write job ", e);
+                }
+        }
+}

--- a/dockstore-common/src/main/java/io/dockstore/common/WDLFileProvisioning.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/WDLFileProvisioning.java
@@ -89,7 +89,7 @@ public class WDLFileProvisioning {
          */
         public Map<String, Object> doProcessFile(String key, String path) {
                 FileProvisioning.PathInfo pathInfo = new FileProvisioning.PathInfo(path);
-                Map<String, Object> entry = new HashMap<>();
+                Map<String, Object> jsonEntry = new HashMap<>();
 
                 if (!pathInfo.isLocalFileType()) {
 
@@ -110,12 +110,12 @@ public class WDLFileProvisioning {
                                 fileProvisioning.downloadFromHttp(path, targetFilePath);
                         }
                         // key may contain either key:download_URL for array inputs or just cwlInputFileID for scalar input
-                        entry.put(key, targetFilePath);
+                        jsonEntry.put(key, targetFilePath);
                         LOG.info("DOWNLOADED FILE: LOCAL: {} URL: {} => {}", key, path, targetFilePath);
                 } else {
-                        entry.put(key, path);
+                        jsonEntry.put(key, path);
                 }
-                return entry;
+                return jsonEntry;
 
         }
 
@@ -128,10 +128,12 @@ public class WDLFileProvisioning {
         public String createUpdatedInputsJson(Map<String, Object> originalInputJson, Map<String, Object> newInputJson) {
                 JSONObject newJSON = new JSONObject();
                 for (String paramName : originalInputJson.keySet()) {
-                        boolean isNew = false;
+                        boolean isNew = false; // is the entry from the newInputJson mapping?
 
+                        // Get value of mapping
                         final Object currentParam = originalInputJson.get(paramName);
 
+                        // Iterate through new input mapping until you find a matching FQN
                         for (Map.Entry<String, Object> entry : newInputJson.entrySet()) {
                                 if (paramName.equals(entry.getKey())) {
                                         isNew = true;
@@ -143,6 +145,8 @@ public class WDLFileProvisioning {
                                         break;
                                 }
                         }
+
+                        // If not a file, will just add as is
                         if (!isNew) {
                                 try {
                                         newJSON.put(paramName, currentParam);

--- a/dockstore-common/src/main/java/io/dockstore/common/WDLFileProvisioning.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/WDLFileProvisioning.java
@@ -109,7 +109,7 @@ public class WDLFileProvisioning {
                         } else if (!pathInfo.isLocalFileType()) {
                                 fileProvisioning.downloadFromHttp(path, targetFilePath);
                         }
-                        // key may contain either key:download_URL for array inputs or just cwlInputFileID for scalar input
+
                         jsonEntry.put(key, targetFilePath);
                         LOG.info("DOWNLOADED FILE: LOCAL: {} URL: {} => {}", key, path, targetFilePath);
                 } else {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CromwellIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CromwellIT.java
@@ -72,7 +72,7 @@ public class CromwellIT {
         Bridge bridge = new Bridge();
         Map<String,String> wdlInputs = bridge.getInputFiles(workflowFile);
 
-        WDLFileProvisioning wdlFileProvisioning = new WDLFileProvisioning();
+        WDLFileProvisioning wdlFileProvisioning = new WDLFileProvisioning(ResourceHelpers.resourceFilePath("config_file.txt"));
         Gson gson = new Gson();
         String jsonString = null;
         try {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CromwellIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CromwellIT.java
@@ -17,17 +17,25 @@
 package io.dockstore.client.cli;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
+import com.google.gson.Gson;
 
 import cromwell.Main;
 import io.dockstore.client.Bridge;
+import io.dockstore.common.WDLFileProvisioning;
 import io.dropwizard.testing.ResourceHelpers;
 import scala.collection.JavaConversions;
 import scala.collection.immutable.List;
+
 
 /**
  * This tests integration with the CromWell engine and what will eventually be wdltool.
@@ -55,6 +63,34 @@ public class CromwellIT {
         // run a workflow
         final int run = main.run(wdlRunList);
         Assert.assertTrue(run == 0);
+    }
+    @Test
+    public void fileProvisioning() {
+        Main main = new Main();
+        File workflowFile = new File(ResourceHelpers.resourceFilePath("wdlfileprov.wdl"));
+        File parameterFile = new File(ResourceHelpers.resourceFilePath("wdlfileprov.json"));
+        Bridge bridge = new Bridge();
+        Map<String,String> wdlInputs = bridge.getInputFiles(workflowFile);
+
+        WDLFileProvisioning wdlFileProvisioning = new WDLFileProvisioning();
+        Gson gson = new Gson();
+        String jsonString = null;
+        try {
+            jsonString = FileUtils.readFileToString(parameterFile);
+            Map<String, Object> map = new HashMap<>();
+            Map<String, Object> inputJson = gson.fromJson(jsonString, map.getClass());
+
+            Map<String,Object> fileMap = wdlFileProvisioning.pullFiles(inputJson, wdlInputs);
+
+            String newJsonPath = wdlFileProvisioning.createUpdatedInputsJson(inputJson, fileMap);
+            final java.util.List<String> wdlRun = Lists.newArrayList(workflowFile.getAbsolutePath(), newJsonPath);
+            final List<String> wdlRunList = JavaConversions.asScalaBuffer(wdlRun).toList();
+            // run a workflow
+            final int run = main.run(wdlRunList);
+            Assert.assertTrue(run == 0);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
 }

--- a/dockstore-integration-testing/src/test/resources/wdlfileprov.json
+++ b/dockstore-integration-testing/src/test/resources/wdlfileprov.json
@@ -1,5 +1,4 @@
 {
-  "three_steps.catS3.in_file": "https://s3-us-west-2.amazonaws.com/dockstore.temp/wdlFileProv.rtf",
-  "three_steps.catDCC.in_file": "icgc:00880e28-cff2-59a6-b1f1-3aeaa174f677",
-  "three_steps.catHTTP.in_file": "https://raw.githubusercontent.com/ga4gh/dockstore/develop/README.md"
+  "two_steps.catS3.in_file": "https://s3-us-west-2.amazonaws.com/dockstore.temp/wdlFileProv.rtf",
+  "two_steps.catHTTP.in_file": "https://raw.githubusercontent.com/ga4gh/dockstore/develop/README.md"
 }

--- a/dockstore-integration-testing/src/test/resources/wdlfileprov.json
+++ b/dockstore-integration-testing/src/test/resources/wdlfileprov.json
@@ -1,0 +1,5 @@
+{
+  "three_steps.catS3.in_file": "https://s3-us-west-2.amazonaws.com/dockstore.temp/wdlFileProv.rtf",
+  "three_steps.catDCC.in_file": "icgc:00880e28-cff2-59a6-b1f1-3aeaa174f677",
+  "three_steps.catHTTP.in_file": "https://raw.githubusercontent.com/ga4gh/dockstore/develop/README.md"
+}

--- a/dockstore-integration-testing/src/test/resources/wdlfileprov.wdl
+++ b/dockstore-integration-testing/src/test/resources/wdlfileprov.wdl
@@ -7,15 +7,6 @@ task catS3 {
     File procs = stdout()
   }
 }
-task catDCC {
-  File in_file
-  command {
-    stat ${in_file}
-  }
-  output {
-    File procs = stdout()
-  }
-}
 
 task catHTTP {
   File in_file
@@ -28,8 +19,7 @@ task catHTTP {
 }
 
 
-workflow three_steps {
+workflow two_steps {
   call catS3
-  call catDCC
   call catHTTP
 }

--- a/dockstore-integration-testing/src/test/resources/wdlfileprov.wdl
+++ b/dockstore-integration-testing/src/test/resources/wdlfileprov.wdl
@@ -1,0 +1,35 @@
+task catS3 {
+  File in_file
+  command {
+    cat ${in_file}
+  }
+  output {
+    File procs = stdout()
+  }
+}
+task catDCC {
+  File in_file
+  command {
+    stat ${in_file}
+  }
+  output {
+    File procs = stdout()
+  }
+}
+
+task catHTTP {
+  File in_file
+  command {
+    cat ${in_file}
+  }
+  output {
+    File procs = stdout()
+  }
+}
+
+
+workflow three_steps {
+  call catS3
+  call catDCC
+  call catHTTP
+}

--- a/dockstore-launcher/pom.xml
+++ b/dockstore-launcher/pom.xml
@@ -70,6 +70,7 @@
         <dependency>
           <groupId>org.yaml</groupId>
           <artifactId>snakeyaml</artifactId>
+            <version>1.12</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/dockstore-launcher/src/main/java/io/github/collaboratory/LauncherCWL.java
+++ b/dockstore-launcher/src/main/java/io/github/collaboratory/LauncherCWL.java
@@ -383,7 +383,7 @@ public class LauncherCWL {
     }
 
     private Map<String, Object> runCWLCommand(String cwlFile, String jsonSettings, String workingDir) {
-        String[] s = {"cwltool","--no-user","--non-strict","--outdir", workingDir, cwlFile, jsonSettings};
+        String[] s = {"cwltool","--non-strict","--outdir", workingDir, cwlFile, jsonSettings};
         final ImmutablePair<String, String> execute = Utilities.executeCommand(Joiner.on(" ").join(Arrays.asList(s)), stdoutStream, stderrStream);
         Map<String, Object> obj = (Map<String, Object>)yaml.load(execute.getLeft());
         return obj;

--- a/dockstore-launcher/src/main/java/io/github/collaboratory/LauncherCWL.java
+++ b/dockstore-launcher/src/main/java/io/github/collaboratory/LauncherCWL.java
@@ -21,7 +21,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/dockstore-launcher/src/main/java/io/github/collaboratory/LauncherCWL.java
+++ b/dockstore-launcher/src/main/java/io/github/collaboratory/LauncherCWL.java
@@ -71,6 +71,7 @@ import io.cwl.avro.CommandLineTool;
 import io.cwl.avro.CommandOutputParameter;
 import io.dockstore.common.Utilities;
 import io.dockstore.common.FileProvisioning;
+import io.dockstore.common.FileProvisioning.PathInfo;
 
 
 /**
@@ -565,43 +566,6 @@ public class LauncherCWL {
         } catch (ParseException exp) {
             LOG.error("Unexpected exception:{}", exp.getMessage());
             throw new RuntimeException("Could not parse command-line", exp);
-        }
-    }
-
-    public static class PathInfo {
-        private static final Logger LOG = LoggerFactory.getLogger(PathInfo.class);
-        public static final String DCC_STORAGE_SCHEME = "icgc";
-    	private boolean objectIdType;
-    	private String objectId = "";
-        private boolean localFileType = false;
-    	
-		public boolean isObjectIdType() {
-			return objectIdType;
-		}
-
-		public String getObjectId() {
-			return objectId;
-		}
-		
-		public PathInfo(String path) {
-            try {
-		    	URI objectIdentifier = URI.create(path);	// throws IllegalArgumentException if it isn't a valid URI
-                if (objectIdentifier.getScheme() == null){
-                    localFileType = true;
-                }
-		    	if (objectIdentifier.getScheme().equalsIgnoreCase(DCC_STORAGE_SCHEME)) {
-		    		objectIdType = true;
-		    		objectId = objectIdentifier.getSchemeSpecificPart().toLowerCase();
-		    	}				
-			} catch (IllegalArgumentException | NullPointerException iae) {
-                // if there is no scheme, then it must be a local file
-                LOG.warn("Invalid path specified for CWL pre-processor values: " + path);
-				objectIdType = false;
-			}
-		}
-
-        public boolean isLocalFileType() {
-            return localFileType;
         }
     }
 

--- a/dockstore-launcher/src/main/java/io/github/collaboratory/LauncherCWL.java
+++ b/dockstore-launcher/src/main/java/io/github/collaboratory/LauncherCWL.java
@@ -59,13 +59,10 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.internal.S3Signer;
-import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.amazonaws.services.s3.model.S3Object;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
-import com.google.common.io.Files;
 import com.google.gson.Gson;
 
 import io.cwl.avro.CWL;
@@ -73,6 +70,7 @@ import io.cwl.avro.CommandInputParameter;
 import io.cwl.avro.CommandLineTool;
 import io.cwl.avro.CommandOutputParameter;
 import io.dockstore.common.Utilities;
+import io.dockstore.common.FileProvisioning;
 
 
 /**
@@ -100,6 +98,8 @@ public class LauncherCWL {
     private final Optional<OutputStream> stdoutStream;
     private final Optional<OutputStream> stderrStream;
     private final Gson gson;
+    private final FileProvisioning fileProvisioning = new FileProvisioning();
+
 
     /**
      * Constructor for shell-based launch
@@ -383,7 +383,7 @@ public class LauncherCWL {
     }
 
     private Map<String, Object> runCWLCommand(String cwlFile, String jsonSettings, String workingDir) {
-        String[] s = {"cwltool","--non-strict","--outdir", workingDir, cwlFile, jsonSettings};
+        String[] s = {"cwltool","--no-user","--non-strict","--outdir", workingDir, cwlFile, jsonSettings};
         final ImmutablePair<String, String> execute = Utilities.executeCommand(Joiner.on(" ").join(Arrays.asList(s)), stdoutStream, stderrStream);
         Map<String, Object> obj = (Map<String, Object>)yaml.load(execute.getLeft());
         return obj;
@@ -458,19 +458,6 @@ public class LauncherCWL {
                 throw new RuntimeException("Could not provision output files", e);
             }
         }
-    }
-
-    private String getStorageClient() {
-    	return config.getString(DCC_CLIENT_KEY, "/icgc/dcc-storage/bin/dcc-storage-client");
-    }
-    
-    private void downloadFromDccStorage(String objectId, String downloadDir) {  	
-    	// default layout saves to original_file_name/object_id
-    	// file name is the directory and object id is actual file name
-    	String client = getStorageClient();
-        String bob = new StringBuilder().append(client).append(" --quiet").append(" download").append(" --object-id ").append(objectId)
-                         .append(" --output-dir ").append(downloadDir).append(" --output-layout id").toString();
-        Utilities.executeCommand(bob, stdoutStream, stderrStream);
     }
     
     private Map<String, FileInfo> pullFiles(CommandLineTool cwl, Map<String, Object> inputsOutputs) {
@@ -548,53 +535,11 @@ public class LauncherCWL {
         PathInfo pathInfo = new PathInfo(path);
         if (pathInfo.isObjectIdType()) {
             String objectId = pathInfo.getObjectId();
-            downloadFromDccStorage(objectId, downloadDirectory);
-
-            // downloaded file
-            String downloadPath = downloadDirFileObj.getAbsolutePath() + "/" + objectId;
-            System.out.println("download path: " + downloadPath);
-            File downloadedFileFileObj = new File(downloadPath);
-            File targetPathFileObj = new File(targetFilePath);
-            try {
-                Files.move(downloadedFileFileObj, targetPathFileObj);
-            } catch (IOException ioe) {
-                LOG.error(ioe.getMessage());
-                throw new RuntimeException("Could not move input file: ", ioe);
-            }
+            fileProvisioning.downloadFromDccStorage(objectId, downloadDirectory, downloadDirFileObj, targetFilePath);
         } else if (path.startsWith("s3://")) {
-            AmazonS3 s3Client = new AmazonS3Client(new ClientConfiguration().withSignerOverride("S3Signer"));
-            if (config.containsKey(S3_ENDPOINT)) {
-                final String endpoint = config.getString(S3_ENDPOINT);
-                LOG.info("found custom S3 endpoint, setting to {}", endpoint);
-                s3Client.setEndpoint(endpoint);
-                s3Client.setS3ClientOptions(new S3ClientOptions().withPathStyleAccess(true));
-            }
-            String trimmedPath = path.replace("s3://", "");
-            List<String> splitPathList = Lists.newArrayList(trimmedPath.split("/"));
-            String bucketName = splitPathList.remove(0);
-
-            S3Object object = s3Client.getObject(
-                    new GetObjectRequest(bucketName, Joiner.on("/").join(splitPathList)));
-            try {
-                FileUtils.copyInputStreamToFile(object.getObjectContent(), new File(targetFilePath));
-            } catch (IOException e) {
-                LOG.error(e.getMessage());
-                throw new RuntimeException("Could not provision input files from S3", e);
-            }
+            fileProvisioning.downloadFromS3(path, targetFilePath);
         } else if (!pathInfo.isLocalFileType()) {
-            // VFS call, see https://github.com/abashev/vfs-s3/tree/branch-2.3.x and
-            // https://commons.apache.org/proper/commons-vfs/filesystems.html
-            FileSystemManager fsManager;
-            try {
-                // trigger a copy from the URL to a local file path that's a UUID to avoid collision
-                fsManager = VFS.getManager();
-                FileObject src = fsManager.resolveFile(path);
-                FileObject dest = fsManager.resolveFile(new File(targetFilePath).getAbsolutePath());
-                dest.copyFrom(src, Selectors.SELECT_SELF);
-            } catch (FileSystemException e) {
-                LOG.error(e.getMessage());
-                throw new RuntimeException("Could not provision input files", e);
-            }
+            fileProvisioning.downloadFromHttp(path, targetFilePath);
         }
         if (!pathInfo.isLocalFileType()) {
             // now add this info to a hash so I can later reconstruct a docker -v command

--- a/dockstore-launcher/src/main/java/io/github/collaboratory/LauncherCWL.java
+++ b/dockstore-launcher/src/main/java/io/github/collaboratory/LauncherCWL.java
@@ -98,7 +98,7 @@ public class LauncherCWL {
     private final Optional<OutputStream> stdoutStream;
     private final Optional<OutputStream> stderrStream;
     private final Gson gson;
-    private final FileProvisioning fileProvisioning = new FileProvisioning();
+    private final FileProvisioning fileProvisioning;
 
 
     /**
@@ -118,6 +118,7 @@ public class LauncherCWL {
         stderrStream = Optional.absent();
 
         gson = CWL.getTypeSafeCWLToolDocument();
+        fileProvisioning = new FileProvisioning(configFilePath);
     }
 
     /**
@@ -133,6 +134,8 @@ public class LauncherCWL {
         // programmatically forward stdout and stderr
         this.stdoutStream = Optional.of(stdoutStream);
         this.stderrStream = Optional.of(stderrStream);
+        fileProvisioning = new FileProvisioning(configFilePath);
+
 
         gson = CWL.getTypeSafeCWLToolDocument();
     }

--- a/dockstore-launcher/src/test/java/io/github/collaboratory/LauncherTest.java
+++ b/dockstore-launcher/src/test/java/io/github/collaboratory/LauncherTest.java
@@ -67,6 +67,5 @@ public class LauncherTest {
         launcherCWL.run();
 
         assertTrue(!stdout.toString().isEmpty());
-        assertTrue(!stderr.toString().isEmpty());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -236,11 +236,6 @@
                 <version>3.20.0-GA</version>
             </dependency>
             <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>1.16</version>
-            </dependency>
-            <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>2.4</version>


### PR DESCRIPTION
This pull request:
- adds the ability to use remote files (HTTP, S3, DCC) for cromwell input (JSON only)
- refactored cwl launcher code to work for cromwell too
- dockstore config file can now contain the following info
- adds a test for using S3 and HTTP inputs for cromwell

[s3]
endpoint=...
[dcc_storage]
client=...