### PR TITLE
Implement a cache for Dockstore to reduce our load on GitHub

### DIFF
--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -418,6 +418,16 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-urlconnection</artifactId>
+        </dependency>
+
+
     </dependencies>
 
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.util.EnumSet;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.http.client.HttpClient;
 import org.eclipse.jetty.servlet.FilterHolder;
@@ -146,7 +147,8 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
             }
             cache = new Cache(tempDir, cacheSize);
         }
-        OkHttpClient okHttpClient = new OkHttpClient().newBuilder().cache(cache).build();
+        // match HttpURLConnection which does not have a timeout by default
+        OkHttpClient okHttpClient = new OkHttpClient().newBuilder().cache(cache).connectTimeout(0, TimeUnit.SECONDS).readTimeout(0, TimeUnit.SECONDS).writeTimeout(0, TimeUnit.SECONDS).build();
         try {
             // this can only be called once per JVM, a factory exception is thrown in our tests
             URL.setURLStreamHandlerFactory(new OkUrlFactory(okHttpClient));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -16,6 +16,10 @@
 
 package io.dockstore.webservice;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
 import java.util.EnumSet;
 
 import org.apache.http.client.HttpClient;
@@ -72,6 +76,9 @@ import io.swagger.api.impl.ToolsApiServiceImpl;
 import io.swagger.jaxrs.config.BeanConfig;
 import io.swagger.jaxrs.listing.ApiListingResource;
 import io.swagger.jaxrs.listing.SwaggerSerializers;
+import okhttp3.Cache;
+import okhttp3.OkHttpClient;
+import okhttp3.OkUrlFactory;
 
 import static javax.servlet.DispatcherType.REQUEST;
 import static org.eclipse.jetty.servlets.CrossOriginFilter.ACCESS_CONTROL_ALLOW_METHODS_HEADER;
@@ -87,6 +94,10 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
 
     private static final Logger LOG = LoggerFactory.getLogger(DockstoreWebserviceApplication.class);
     public static final String GA4GH_API_PATH = "/api/v1";
+    private static final int BYTES_IN_KILOBYTE = 1024;
+    private static final int KILOBYTES_IN_MEGABYTE = 1024;
+    private static final int CACHE_IN_MB = 100;
+    private static Cache cache = null;
 
     public static void main(String[] args) throws Exception {
         new DockstoreWebserviceApplication().run(args);
@@ -123,6 +134,30 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
                 return configuration.getDataSourceFactory();
             }
         });
+
+        if (cache == null) {
+            int cacheSize = CACHE_IN_MB * BYTES_IN_KILOBYTE * KILOBYTES_IN_MEGABYTE; // 100 MiB
+            final File tempDir;
+            try {
+                tempDir = Files.createTempDirectory("dockstore-web-cache-").toFile();
+            } catch (IOException e) {
+                LOG.error("Could no create web cache");
+                throw new RuntimeException(e);
+            }
+            cache = new Cache(tempDir, cacheSize);
+        }
+        OkHttpClient okHttpClient = new OkHttpClient().newBuilder().cache(cache).build();
+        try {
+            // this can only be called once per JVM, a factory exception is thrown in our tests
+            URL.setURLStreamHandlerFactory(new OkUrlFactory(okHttpClient));
+        } catch(Error factoryException){
+            if (factoryException.getMessage().contains("factory already defined")){
+                LOG.info("OkHttpClient already registered, skipping");
+            } else{
+                LOG.error("Could no create web cache, factory exception");
+                throw new RuntimeException(factoryException);
+            }
+        }
     }
 
     @Override
@@ -152,6 +187,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         final LabelDAO labelDAO = new LabelDAO(hibernate.getSessionFactory());
         final FileDAO fileDAO = new FileDAO(hibernate.getSessionFactory());
 
+        LOG.info("Cache directory for OkHttp is: " + cache.directory().getAbsolutePath());
         LOG.info("This is our custom logger saying that we're about to load authenticators");
         // setup authentication
         SimpleAuthenticator authenticator = new SimpleAuthenticator(tokenDAO);

--- a/pom.xml
+++ b/pom.xml
@@ -453,6 +453,18 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>${okhttp.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp-urlconnection</artifactId>
+                <version>${okhttp.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
* use OkHttp to cache responses from GitHub 
* reduces personal refresh load by between 40% and 50%
This addresses #154 

Thanks to @jonan for the tip.  