### PR TITLE
Feature/dockstore launcher output

### DIFF
--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -138,6 +138,16 @@
             <version>2.11.7</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+
     </dependencies>
 
 
@@ -156,6 +166,12 @@
                                 <exclude>META-INF/*.SF</exclude>
                                 <exclude>META-INF/*.DSA</exclude>
                                 <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                        <filter>
+                            <artifact>org.broadinstitute:*</artifact>
+                            <excludes>
+                                <exclude>logback.xml</exclude>
                             </excludes>
                         </filter>
                     </filters>
@@ -259,6 +275,9 @@
                 <targetPath>${basedir}/target</targetPath>
                 <directory>bin</directory>
                 <filtering>true</filtering>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
             </resource>
         </resources>
     </build>

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -425,8 +425,6 @@ public class Client {
             // turn on logback
             ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
             root.setLevel(Level.DEBUG);
-
-            LOG.error("test");
         }
         if (flag(args, "--script") || flag(args, "--s")) {
             SCRIPT.set(true);

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -16,6 +16,26 @@
 
 package io.dockstore.client.cli;
 
+import ch.qos.logback.classic.Level;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import io.dockstore.client.cli.nested.AbstractEntryClient;
+import io.dockstore.client.cli.nested.ToolClient;
+import io.dockstore.client.cli.nested.WorkflowClient;
+import io.swagger.client.ApiClient;
+import io.swagger.client.ApiException;
+import io.swagger.client.Configuration;
+import io.swagger.client.api.ContainersApi;
+import io.swagger.client.api.ContainertagsApi;
+import io.swagger.client.api.GAGHApi;
+import io.swagger.client.api.UsersApi;
+import io.swagger.client.api.WorkflowsApi;
+import io.swagger.client.model.Metadata;
+import org.apache.commons.configuration.HierarchicalINIConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.ProcessingException;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -42,31 +62,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.ws.rs.ProcessingException;
-
-import io.dockstore.client.cli.nested.AbstractEntryClient;
-import org.apache.commons.configuration.HierarchicalINIConfiguration;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.Gson;
-import io.dockstore.client.cli.nested.ToolClient;
-import io.dockstore.client.cli.nested.WorkflowClient;
-import io.swagger.client.ApiClient;
-import io.swagger.client.ApiException;
-import io.swagger.client.Configuration;
-import io.swagger.client.api.ContainersApi;
-import io.swagger.client.api.ContainertagsApi;
-import io.swagger.client.api.GAGHApi;
-import io.swagger.client.api.UsersApi;
-import io.swagger.client.api.WorkflowsApi;
-import io.swagger.client.model.Metadata;
-
+import static io.dockstore.client.cli.ArgumentUtility.Kill;
 import static io.dockstore.client.cli.ArgumentUtility.err;
 import static io.dockstore.client.cli.ArgumentUtility.errorMessage;
 import static io.dockstore.client.cli.ArgumentUtility.exceptionMessage;
 import static io.dockstore.client.cli.ArgumentUtility.flag;
 import static io.dockstore.client.cli.ArgumentUtility.invalid;
-import static io.dockstore.client.cli.ArgumentUtility.Kill;
 import static io.dockstore.client.cli.ArgumentUtility.isHelpRequest;
 import static io.dockstore.client.cli.ArgumentUtility.optVal;
 import static io.dockstore.client.cli.ArgumentUtility.out;
@@ -80,6 +81,8 @@ import static io.dockstore.client.cli.ArgumentUtility.printHelpHeader;
  *
  */
 public class Client {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Client.class);
 
     private String configFile = null;
     private ContainersApi containersApi;
@@ -419,6 +422,11 @@ public class Client {
 
         if (flag(args, "--debug") || flag(args, "--d")) {
             DEBUG.set(true);
+            // turn on logback
+            ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
+            root.setLevel(Level.DEBUG);
+
+            LOG.error("test");
         }
         if (flag(args, "--script") || flag(args, "--s")) {
             SCRIPT.set(true);

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -563,8 +563,7 @@ public abstract class AbstractEntryClient {
                     final String finalString = gson.toJson(element);
                     final File tempJson = File.createTempFile("parameter", ".json", Files.createTempDir());
                     FileUtils.write(tempJson, finalString);
-                    final LauncherCWL cwlLauncher = new LauncherCWL(getConfigFile(), tempCWL.getAbsolutePath(), tempJson.getAbsolutePath(),
-                            System.out, System.err);
+                    final LauncherCWL cwlLauncher = new LauncherCWL(getConfigFile(), tempCWL.getAbsolutePath(), tempJson.getAbsolutePath());
                     if (this instanceof WorkflowClient) {
                         cwlLauncher.run(Workflow.class);
                     } else {
@@ -572,7 +571,7 @@ public abstract class AbstractEntryClient {
                     }
                 }
             } else {
-                final LauncherCWL cwlLauncher = new LauncherCWL(getConfigFile(), tempCWL.getAbsolutePath(), jsonRun, System.out, System.err);
+                final LauncherCWL cwlLauncher = new LauncherCWL(getConfigFile(), tempCWL.getAbsolutePath(), jsonRun);
                 if (this instanceof WorkflowClient) {
                     cwlLauncher.run(Workflow.class);
                 } else {
@@ -615,8 +614,7 @@ public abstract class AbstractEntryClient {
 
                     // final String stringMapAsString = gson.toJson(stringMap);
                     // Files.write(stringMapAsString, tempJson, StandardCharsets.UTF_8);
-                    final LauncherCWL cwlLauncher = new LauncherCWL(this.getConfigFile(), tempCWL.getAbsolutePath(), tempJson.getAbsolutePath(),
-                            System.out, System.err);
+                    final LauncherCWL cwlLauncher = new LauncherCWL(this.getConfigFile(), tempCWL.getAbsolutePath(), tempJson.getAbsolutePath());
                     if (this instanceof WorkflowClient) {
                         cwlLauncher.run(Workflow.class);
                     } else {

--- a/dockstore-client/src/main/resources/logback.xml
+++ b/dockstore-client/src/main/resources/logback.xml
@@ -1,0 +1,30 @@
+<!--
+  ~    Copyright 2016 OICR
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="error">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/dockstore-client/src/test/resources/logback-test.xml
+++ b/dockstore-client/src/test/resources/logback-test.xml
@@ -1,0 +1,30 @@
+<!--
+  ~    Copyright 2016 OICR
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/dockstore-client/src/test/resources/logback-test.xml
+++ b/dockstore-client/src/test/resources/logback-test.xml
@@ -15,7 +15,6 @@
   -->
 
 <configuration>
-
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
@@ -24,7 +23,7 @@
         </encoder>
     </appender>
 
-    <root level="debug">
+    <root level="warn">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -122,6 +122,12 @@
             <artifactId>commons-vfs2</artifactId>
             <version>2.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+        </dependency>
+
     </dependencies>
     
     <build>

--- a/dockstore-common/src/main/java/io/dockstore/common/FileProvisioning.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/FileProvisioning.java
@@ -31,15 +31,21 @@ import com.google.common.io.Files;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalINIConfiguration;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.net.io.CopyStreamEvent;
+import org.apache.commons.net.io.CopyStreamListener;
+import org.apache.commons.net.io.Util;
 import org.apache.commons.vfs2.FileSystemManager;
-import org.apache.commons.vfs2.Selectors;
 import org.apache.commons.vfs2.VFS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 import java.net.URI;
 import java.util.List;
 
@@ -49,137 +55,177 @@ import java.util.List;
  */
 public class FileProvisioning {
 
-        static {
-                SignerFactory.registerSigner("S3Signer", S3Signer.class);
+    static {
+        SignerFactory.registerSigner("S3Signer", S3Signer.class);
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileProvisioning.class);
+
+    private static final String S3_ENDPOINT = "s3.endpoint";
+    private static final String DCC_CLIENT_KEY = "dcc_storage.client";
+
+    private HierarchicalINIConfiguration config;
+    private final Optional<OutputStream> stdoutStream;
+    private final Optional<OutputStream> stderrStream;
+
+    /**
+     * Constructor
+     */
+    public FileProvisioning(String configFile) {
+        // do not forward stdout and stderr
+        stdoutStream = Optional.absent();
+        stderrStream = Optional.absent();
+
+        try {
+            this.config = new HierarchicalINIConfiguration(configFile);
+        } catch (ConfigurationException e) {
+            e.printStackTrace();
         }
+    }
 
-        private static final Logger LOG = LoggerFactory.getLogger(FileProvisioning.class);
+    // Which functions to move here? DCC and apache commons ones?
+    private String getStorageClient() {
+        return config.getString(DCC_CLIENT_KEY, "/icgc/dcc-storage/bin/dcc-storage-client");
+    }
 
-        private static final String S3_ENDPOINT = "s3.endpoint";
-        private static final String DCC_CLIENT_KEY = "dcc_storage.client";
+    public void downloadFromDccStorage(String objectId, String downloadDir, File downloadDirFileObj, String targetFilePath) {
+        // default layout saves to original_file_name/object_id
+        // file name is the directory and object id is actual file name
+        String client = getStorageClient();
+        String bob =
+                client + " --quiet" + " download" + " --object-id " + objectId + " --output-dir " + downloadDir + " --output-layout id";
+        Utilities.executeCommand(bob, stdoutStream, stderrStream);
 
-        private HierarchicalINIConfiguration config;
-        private final Optional<OutputStream> stdoutStream;
-        private final Optional<OutputStream> stderrStream;
-
-        /**
-         * Constructor
-         */
-        public FileProvisioning(String configFile) {
-                // do not forward stdout and stderr
-                stdoutStream = Optional.absent();
-                stderrStream = Optional.absent();
-
-                try {
-                        this.config = new HierarchicalINIConfiguration(configFile);
-                } catch (ConfigurationException e) {
-                        e.printStackTrace();
-                }
+        // downloaded file
+        String downloadPath = downloadDirFileObj.getAbsolutePath() + "/" + objectId;
+        System.out.println("download path: " + downloadPath);
+        File downloadedFileFileObj = new File(downloadPath);
+        File targetPathFileObj = new File(targetFilePath);
+        try {
+            Files.move(downloadedFileFileObj, targetPathFileObj);
+        } catch (IOException ioe) {
+            LOG.error(ioe.getMessage());
+            throw new RuntimeException("Could not move input file: ", ioe);
         }
+    }
 
-        // Which functions to move here? DCC and apache commons ones?
-        private String getStorageClient() {
-                return config.getString(DCC_CLIENT_KEY, "/icgc/dcc-storage/bin/dcc-storage-client");
+    public void downloadFromS3(String path, String targetFilePath) {
+        AmazonS3 s3Client = getAmazonS3Client(config);
+        String trimmedPath = path.replace("s3://", "");
+        List<String> splitPathList = Lists.newArrayList(trimmedPath.split("/"));
+        String bucketName = splitPathList.remove(0);
+
+        S3Object object = s3Client.getObject(new GetObjectRequest(bucketName, Joiner.on("/").join(splitPathList)));
+        try {
+            FileUtils.copyInputStreamToFile(object.getObjectContent(), new File(targetFilePath));
+        } catch (IOException e) {
+            LOG.error(e.getMessage());
+            throw new RuntimeException("Could not provision input files from S3", e);
         }
+    }
 
-        public void downloadFromDccStorage(String objectId, String downloadDir, File downloadDirFileObj, String targetFilePath) {
-                // default layout saves to original_file_name/object_id
-                // file name is the directory and object id is actual file name
-                String client = getStorageClient();
-                String bob = client + " --quiet" + " download" + " --object-id " + objectId + " --output-dir " + downloadDir
-                        + " --output-layout id";
-                Utilities.executeCommand(bob, stdoutStream, stderrStream);
-
-                // downloaded file
-                String downloadPath = downloadDirFileObj.getAbsolutePath() + "/" + objectId;
-                System.out.println("download path: " + downloadPath);
-                File downloadedFileFileObj = new File(downloadPath);
-                File targetPathFileObj = new File(targetFilePath);
-                try {
-                        Files.move(downloadedFileFileObj, targetPathFileObj);
-                } catch (IOException ioe) {
-                        LOG.error(ioe.getMessage());
-                        throw new RuntimeException("Could not move input file: ", ioe);
-                }
+    public static AmazonS3 getAmazonS3Client(HierarchicalINIConfiguration config) {
+        AmazonS3 s3Client = new AmazonS3Client(new ClientConfiguration().withSignerOverride("S3Signer"));
+        if (config.containsKey(S3_ENDPOINT)) {
+            final String endpoint = config.getString(S3_ENDPOINT);
+            LOG.info("found custom S3 endpoint, setting to {}", endpoint);
+            s3Client.setEndpoint(endpoint);
+            s3Client.setS3ClientOptions(new S3ClientOptions().withPathStyleAccess(true));
         }
+        return s3Client;
+    }
 
-        public void downloadFromS3(String path, String targetFilePath) {
-                AmazonS3 s3Client = getAmazonS3Client(config);
-                String trimmedPath = path.replace("s3://", "");
-                List<String> splitPathList = Lists.newArrayList(trimmedPath.split("/"));
-                String bucketName = splitPathList.remove(0);
+    public void downloadFromHttp(String path, String targetFilePath) {
+        // VFS call, see https://github.com/abashev/vfs-s3/tree/branch-2.3.x and
+        // https://commons.apache.org/proper/commons-vfs/filesystems.html
+        FileSystemManager fsManager;
+        try {
+            // trigger a copy from the URL to a local file path that's a UUID to avoid collision
+            fsManager = VFS.getManager();
+            org.apache.commons.vfs2.FileObject src = fsManager.resolveFile(path);
+            org.apache.commons.vfs2.FileObject dest = fsManager.resolveFile(new File(targetFilePath).getAbsolutePath());
+            InputStream inputStream = src.getContent().getInputStream();
+            CopyStreamListener listener = new CopyStreamListener() {
+                boolean printedBefore = false;
 
-                S3Object object = s3Client.getObject(new GetObjectRequest(bucketName, Joiner.on("/").join(splitPathList)));
-                try {
-                        FileUtils.copyInputStreamToFile(object.getObjectContent(), new File(targetFilePath));
-                } catch (IOException e) {
-                        LOG.error(e.getMessage());
-                        throw new RuntimeException("Could not provision input files from S3", e);
-                }
-        }
-
-        public static AmazonS3 getAmazonS3Client(HierarchicalINIConfiguration config) {
-                AmazonS3 s3Client = new AmazonS3Client(new ClientConfiguration().withSignerOverride("S3Signer"));
-                if (config.containsKey(S3_ENDPOINT)) {
-                        final String endpoint = config.getString(S3_ENDPOINT);
-                        LOG.info("found custom S3 endpoint, setting to {}", endpoint);
-                        s3Client.setEndpoint(endpoint);
-                        s3Client.setS3ClientOptions(new S3ClientOptions().withPathStyleAccess(true));
-                }
-                return s3Client;
-        }
-
-        public void downloadFromHttp(String path, String targetFilePath) {
-                // VFS call, see https://github.com/abashev/vfs-s3/tree/branch-2.3.x and
-                // https://commons.apache.org/proper/commons-vfs/filesystems.html
-                FileSystemManager fsManager;
-                try {
-                        // trigger a copy from the URL to a local file path that's a UUID to avoid collision
-                        fsManager = VFS.getManager();
-                        org.apache.commons.vfs2.FileObject src = fsManager.resolveFile(path);
-                        org.apache.commons.vfs2.FileObject dest = fsManager.resolveFile(new File(targetFilePath).getAbsolutePath());
-                        dest.copyFrom(src, Selectors.SELECT_SELF);
-                } catch (org.apache.commons.vfs2.FileSystemException e) {
-                        LOG.error(e.getMessage());
-                        throw new RuntimeException("Could not provision input files", e);
-                }
-        }
-
-        public static class PathInfo {
-                private static final Logger LOG = LoggerFactory.getLogger(PathInfo.class);
-                public static final String DCC_STORAGE_SCHEME = "icgc";
-                private boolean objectIdType;
-                private String objectId = "";
-                private boolean localFileType = false;
-
-                public boolean isObjectIdType() {
-                        return objectIdType;
+                @Override public void bytesTransferred(CopyStreamEvent event) {
+                    /** do nothing */
                 }
 
-                public String getObjectId() {
-                        return objectId;
-                }
-
-                public PathInfo(String path) {
-                        try {
-                                URI objectIdentifier = URI.create(path);	// throws IllegalArgumentException if it isn't a valid URI
-                                if (objectIdentifier.getScheme() == null){
-                                        localFileType = true;
-                                }
-                                if (objectIdentifier.getScheme().equalsIgnoreCase(DCC_STORAGE_SCHEME)) {
-                                        objectIdType = true;
-                                        objectId = objectIdentifier.getSchemeSpecificPart().toLowerCase();
-                                }
-                        } catch (IllegalArgumentException | NullPointerException iae) {
-                                // if there is no scheme, then it must be a local file
-                                LOG.warn("Invalid path specified for CWL pre-processor values: " + path);
-                                objectIdType = false;
+                @Override public void bytesTransferred(long totalBytesTransferred, int bytesTransferred, long streamSize) {
+                    if (printedBefore) {
+                        System.out.print('\r');
+                    }
+                    BigDecimal numerator = BigDecimal.valueOf(totalBytesTransferred);
+                    BigDecimal denominator = BigDecimal.valueOf(streamSize);
+                    BigDecimal fraction = numerator.divide(denominator, new MathContext(2, RoundingMode.HALF_EVEN));
+                    BigDecimal outOfTwenty = fraction.multiply(new BigDecimal(20));
+                    BigDecimal percentage = fraction.movePointRight(2);
+                    StringBuilder builder = new StringBuilder();
+                    builder.append("[");
+                    for (int i = 0; i < 20; i++) {
+                        if (i < outOfTwenty.intValue()) {
+                            builder.append("#");
+                        } else {
+                            builder.append(" ");
                         }
+                    }
+                    builder.append("] ");
+                    builder.append(percentage.toPlainString() + "%");
+                    System.out.print(builder);
+                    printedBefore = true;
                 }
-
-                public boolean isLocalFileType() {
-                        return localFileType;
-                }
+            };
+            try (OutputStream outputStream = dest.getContent().getOutputStream()) {
+                Util.copyStream(inputStream, outputStream, Util.DEFAULT_COPY_BUFFER_SIZE, src.getContent().getSize(), listener);
+            } catch (IOException e) {
+                throw new RuntimeException("Could not provision input files", e);
+            } finally {
+                inputStream.close();
+                System.out.println();
+            }
+            // dest.copyFrom(src, Selectors.SELECT_SELF);
+        } catch (IOException e) {
+            LOG.error(e.getMessage());
+            throw new RuntimeException("Could not provision input files", e);
         }
+    }
+
+    public static class PathInfo {
+        private static final Logger LOG = LoggerFactory.getLogger(PathInfo.class);
+        public static final String DCC_STORAGE_SCHEME = "icgc";
+        private boolean objectIdType;
+        private String objectId = "";
+        private boolean localFileType = false;
+
+        public boolean isObjectIdType() {
+            return objectIdType;
+        }
+
+        public String getObjectId() {
+            return objectId;
+        }
+
+        public PathInfo(String path) {
+            try {
+                URI objectIdentifier = URI.create(path);    // throws IllegalArgumentException if it isn't a valid URI
+                if (objectIdentifier.getScheme() == null) {
+                    localFileType = true;
+                }
+                if (objectIdentifier.getScheme().equalsIgnoreCase(DCC_STORAGE_SCHEME)) {
+                    objectIdType = true;
+                    objectId = objectIdentifier.getSchemeSpecificPart().toLowerCase();
+                }
+            } catch (IllegalArgumentException | NullPointerException iae) {
+                // if there is no scheme, then it must be a local file
+                LOG.warn("Invalid path specified for CWL pre-processor values: " + path);
+                objectIdType = false;
+            }
+        }
+
+        public boolean isLocalFileType() {
+            return localFileType;
+        }
+    }
 }
 

--- a/dockstore-common/src/main/java/io/dockstore/common/FileProvisioning.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/FileProvisioning.java
@@ -18,28 +18,35 @@ package io.dockstore.common;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.SignerFactory;
+import com.amazonaws.event.ProgressEvent;
+import com.amazonaws.event.ProgressEventType;
+import com.amazonaws.event.ProgressListener;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.internal.S3Signer;
 import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalINIConfiguration;
-import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.net.io.CopyStreamEvent;
 import org.apache.commons.net.io.CopyStreamListener;
 import org.apache.commons.net.io.Util;
+import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemManager;
 import org.apache.commons.vfs2.VFS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -88,13 +95,13 @@ public class FileProvisioning {
         return config.getString(DCC_CLIENT_KEY, "/icgc/dcc-storage/bin/dcc-storage-client");
     }
 
-    public void downloadFromDccStorage(String objectId, String downloadDir, File downloadDirFileObj, String targetFilePath) {
+    private void downloadFromDccStorage(String objectId, String downloadDir, File downloadDirFileObj, String targetFilePath) {
         // default layout saves to original_file_name/object_id
         // file name is the directory and object id is actual file name
         String client = getStorageClient();
         String bob =
                 client + " --quiet" + " download" + " --object-id " + objectId + " --output-dir " + downloadDir + " --output-layout id";
-        Utilities.executeCommand(bob, stdoutStream, stderrStream);
+        Utilities.executeCommand(bob);
 
         // downloaded file
         String downloadPath = downloadDirFileObj.getAbsolutePath() + "/" + objectId;
@@ -109,7 +116,7 @@ public class FileProvisioning {
         }
     }
 
-    public void downloadFromS3(String path, String targetFilePath) {
+    private void downloadFromS3(String path, String targetFilePath) {
         AmazonS3 s3Client = getAmazonS3Client(config);
         String trimmedPath = path.replace("s3://", "");
         List<String> splitPathList = Lists.newArrayList(trimmedPath.split("/"));
@@ -117,14 +124,17 @@ public class FileProvisioning {
 
         S3Object object = s3Client.getObject(new GetObjectRequest(bucketName, Joiner.on("/").join(splitPathList)));
         try {
-            FileUtils.copyInputStreamToFile(object.getObjectContent(), new File(targetFilePath));
+            FileOutputStream outputStream = new FileOutputStream(new File(targetFilePath));
+            S3ObjectInputStream inputStream = object.getObjectContent();
+            long inputSize = object.getObjectMetadata().getContentLength();
+            copyFromInputStreamToOutputStream(inputStream, inputSize, outputStream);
         } catch (IOException e) {
             LOG.error(e.getMessage());
             throw new RuntimeException("Could not provision input files from S3", e);
         }
     }
 
-    public static AmazonS3 getAmazonS3Client(HierarchicalINIConfiguration config) {
+    private static AmazonS3 getAmazonS3Client(HierarchicalINIConfiguration config) {
         AmazonS3 s3Client = new AmazonS3Client(new ClientConfiguration().withSignerOverride("S3Signer"));
         if (config.containsKey(S3_ENDPOINT)) {
             final String endpoint = config.getString(S3_ENDPOINT);
@@ -135,55 +145,18 @@ public class FileProvisioning {
         return s3Client;
     }
 
-    public void downloadFromHttp(String path, String targetFilePath) {
+    private void downloadFromHttp(String path, String targetFilePath) {
         // VFS call, see https://github.com/abashev/vfs-s3/tree/branch-2.3.x and
         // https://commons.apache.org/proper/commons-vfs/filesystems.html
-        FileSystemManager fsManager;
         try {
             // trigger a copy from the URL to a local file path that's a UUID to avoid collision
-            fsManager = VFS.getManager();
+            FileSystemManager fsManager = VFS.getManager();
             org.apache.commons.vfs2.FileObject src = fsManager.resolveFile(path);
             org.apache.commons.vfs2.FileObject dest = fsManager.resolveFile(new File(targetFilePath).getAbsolutePath());
             InputStream inputStream = src.getContent().getInputStream();
-            CopyStreamListener listener = new CopyStreamListener() {
-                boolean printedBefore = false;
-
-                @Override public void bytesTransferred(CopyStreamEvent event) {
-                    /** do nothing */
-                }
-
-                @Override public void bytesTransferred(long totalBytesTransferred, int bytesTransferred, long streamSize) {
-                    if (printedBefore) {
-                        System.out.print('\r');
-                    }
-                    BigDecimal numerator = BigDecimal.valueOf(totalBytesTransferred);
-                    BigDecimal denominator = BigDecimal.valueOf(streamSize);
-                    BigDecimal fraction = numerator.divide(denominator, new MathContext(2, RoundingMode.HALF_EVEN));
-                    BigDecimal outOfTwenty = fraction.multiply(new BigDecimal(20));
-                    BigDecimal percentage = fraction.movePointRight(2);
-                    StringBuilder builder = new StringBuilder();
-                    builder.append("[");
-                    for (int i = 0; i < 20; i++) {
-                        if (i < outOfTwenty.intValue()) {
-                            builder.append("#");
-                        } else {
-                            builder.append(" ");
-                        }
-                    }
-                    builder.append("] ");
-                    builder.append(percentage.toPlainString() + "%");
-                    System.out.print(builder);
-                    printedBefore = true;
-                }
-            };
-            try (OutputStream outputStream = dest.getContent().getOutputStream()) {
-                Util.copyStream(inputStream, outputStream, Util.DEFAULT_COPY_BUFFER_SIZE, src.getContent().getSize(), listener);
-            } catch (IOException e) {
-                throw new RuntimeException("Could not provision input files", e);
-            } finally {
-                inputStream.close();
-                System.out.println();
-            }
+            long inputSize = src.getContent().getSize();
+            OutputStream outputSteam = dest.getContent().getOutputStream();
+            copyFromInputStreamToOutputStream(inputStream, inputSize, outputSteam);
             // dest.copyFrom(src, Selectors.SELECT_SELF);
         } catch (IOException e) {
             LOG.error(e.getMessage());
@@ -191,18 +164,142 @@ public class FileProvisioning {
         }
     }
 
+    public void provisionInputFile(String path, String downloadDirectory, File downloadDirFileObj, String targetFilePath,
+            PathInfo pathInfo) {
+        if (pathInfo.isObjectIdType()) {
+            String objectId = pathInfo.getObjectId();
+            this.downloadFromDccStorage(objectId, downloadDirectory, downloadDirFileObj, targetFilePath);
+        } else if (path.startsWith("s3://")) {
+            this.downloadFromS3(path, targetFilePath);
+        } else if (!pathInfo.isLocalFileType()) {
+            this.downloadFromHttp(path, targetFilePath);
+        }
+    }
+
+    public void provisionOutputFile(FileInfo file, String cwlOutputPath) {
+        File sourceFile = new File(cwlOutputPath);
+        long inputSize = sourceFile.length();
+        if (file.getUrl().startsWith("s3://")) {
+            AmazonS3 s3Client = FileProvisioning.getAmazonS3Client(config);
+            String trimmedPath = file.getUrl().replace("s3://", "");
+            List<String> splitPathList = Lists.newArrayList(trimmedPath.split("/"));
+            String bucketName = splitPathList.remove(0);
+
+            PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, Joiner.on("/").join(splitPathList), sourceFile);
+            putObjectRequest.setGeneralProgressListener(new ProgressListener() {
+                ProgressPrinter printer = new ProgressPrinter();
+                long runningTotal = 0;
+                @Override public void progressChanged(ProgressEvent progressEvent) {
+                    if (progressEvent.getEventType() == ProgressEventType.REQUEST_BYTE_TRANSFER_EVENT){
+                        runningTotal += progressEvent.getBytesTransferred();
+                    }
+                    printer.handleProgress(runningTotal, inputSize);
+                }
+            });
+            try {
+                s3Client.putObject(putObjectRequest);
+            } finally{
+                System.out.println();
+            }
+        } else {
+            try {
+                FileSystemManager fsManager;
+                // trigger a copy from the URL to a local file path that's a UUID to avoid collision
+                fsManager = VFS.getManager();
+                // check for a local file path
+                FileObject dest = fsManager.resolveFile(file.getUrl());
+                FileObject src = fsManager.resolveFile(sourceFile.getAbsolutePath());
+                copyFromInputStreamToOutputStream(src.getContent().getInputStream(), inputSize, dest.getContent().getOutputStream());
+            } catch (IOException e) {
+                throw new RuntimeException("Could not provision output files", e);
+            }
+        }
+    }
+
+    private static class ProgressPrinter {
+        static final int SIZE_OF_PROGRESS_BAR = 50;
+        boolean printedBefore = false;
+        BigDecimal progress = new BigDecimal(0);
+
+        void handleProgress(long totalBytesTransferred, long streamSize) {
+
+            BigDecimal numerator = BigDecimal.valueOf(totalBytesTransferred);
+            BigDecimal denominator = BigDecimal.valueOf(streamSize);
+            BigDecimal fraction = numerator.divide(denominator, new MathContext(2, RoundingMode.HALF_EVEN));
+            if (fraction.equals(progress)) {
+                /** don't bother refreshing if no progress made */
+                return;
+            }
+
+            BigDecimal outOfTwenty = fraction.multiply(new BigDecimal(SIZE_OF_PROGRESS_BAR));
+            BigDecimal percentage = fraction.movePointRight(2);
+            StringBuilder builder = new StringBuilder();
+            if (printedBefore) {
+                builder.append('\r');
+            }
+
+            builder.append("[");
+            for (int i = 0; i < SIZE_OF_PROGRESS_BAR; i++) {
+                if (i < outOfTwenty.intValue()) {
+                    builder.append("#");
+                } else {
+                    builder.append(" ");
+                }
+            }
+
+            builder.append("] ");
+            builder.append(percentage.toPlainString()).append("%");
+
+            System.out.print(builder);
+            // track progress
+            printedBefore = true;
+            progress = fraction;
+        }
+    }
+
+    /**
+     * Copy from stream to stream while displaying progress
+     *
+     * @param inputStream source
+     * @param inputSize   total size
+     * @param outputSteam destination
+     * @throws IOException
+     */
+    private static void copyFromInputStreamToOutputStream(InputStream inputStream, long inputSize, OutputStream outputSteam)
+            throws IOException {
+        CopyStreamListener listener = new CopyStreamListener() {
+            ProgressPrinter printer = new ProgressPrinter();
+
+            @Override public void bytesTransferred(CopyStreamEvent event) {
+                /** do nothing */
+            }
+
+            @Override public void bytesTransferred(long totalBytesTransferred, int bytesTransferred, long streamSize) {
+                printer.handleProgress(totalBytesTransferred, streamSize);
+            }
+        };
+        try (OutputStream outputStream = outputSteam) {
+            Util.copyStream(inputStream, outputStream, Util.DEFAULT_COPY_BUFFER_SIZE, inputSize, listener);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not provision input files", e);
+        } finally {
+            IOUtils.closeQuietly(inputStream);
+            System.out.println();
+        }
+    }
+
     public static class PathInfo {
         private static final Logger LOG = LoggerFactory.getLogger(PathInfo.class);
-        public static final String DCC_STORAGE_SCHEME = "icgc";
+        static final String DCC_STORAGE_SCHEME = "icgc";
         private boolean objectIdType;
         private String objectId = "";
         private boolean localFileType = false;
 
-        public boolean isObjectIdType() {
+        boolean isObjectIdType() {
             return objectIdType;
         }
 
-        public String getObjectId() {
+        String getObjectId() {
             return objectId;
         }
 
@@ -218,13 +315,37 @@ public class FileProvisioning {
                 }
             } catch (IllegalArgumentException | NullPointerException iae) {
                 // if there is no scheme, then it must be a local file
-                LOG.warn("Invalid path specified for CWL pre-processor values: " + path);
+                LOG.info("Invalid or local path specified for CWL pre-processor values: " + path);
                 objectIdType = false;
             }
         }
 
         public boolean isLocalFileType() {
             return localFileType;
+        }
+    }
+
+    /**
+     * Describes a single File
+     */
+    public static class FileInfo {
+        private String localPath;
+        private String url;
+
+        public String getLocalPath() {
+            return localPath;
+        }
+
+        public void setLocalPath(String localPath) {
+            this.localPath = localPath;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(String url) {
+            this.url = url;
         }
     }
 }

--- a/dockstore-common/src/main/java/io/dockstore/common/FileProvisioning.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/FileProvisioning.java
@@ -248,7 +248,7 @@ public class FileProvisioning {
             }
 
             builder.append("] ");
-            builder.append(percentage.toPlainString()).append("%");
+            builder.append(percentage.setScale(0,BigDecimal.ROUND_HALF_EVEN).toPlainString()).append("%");
 
             System.out.print(builder);
             // track progress

--- a/dockstore-common/src/main/java/io/dockstore/common/Utilities.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/Utilities.java
@@ -17,6 +17,7 @@
 package io.dockstore.common;
 
 import com.google.common.base.Optional;
+import com.google.common.io.ByteStreams;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalINIConfiguration;
 import org.apache.commons.exec.CommandLine;
@@ -53,8 +54,12 @@ public class Utilities {
         }
     }
 
-    public static ImmutablePair<String, String> executeCommand(String command, Optional<OutputStream> stdoutStream, Optional<OutputStream> stderrStream) {
-        return executeCommand(command, true, stdoutStream, stderrStream);
+    public static ImmutablePair<String, String> executeCommand(String command) {
+        return executeCommand(command, true, Optional.of(ByteStreams.nullOutputStream()) , Optional.of(ByteStreams.nullOutputStream()));
+    }
+
+    public static ImmutablePair<String, String> executeCommand(String command, OutputStream stdoutStream, OutputStream stderrStream) {
+        return executeCommand(command, true, Optional.of(stdoutStream), Optional.of(stderrStream));
     }
 
     /**
@@ -86,7 +91,7 @@ public class Utilities {
                 Executor executor = new DefaultExecutor();
                 executor.setExitValue(0);
                 if (dumpOutput) {
-                    System.out.println("CMD: " + command);
+                    LOG.info("CMD: " + command);
                 }
                 // get stdout and stderr
                 executor.setStreamHandler(new PumpStreamHandler(stdout, stderr));

--- a/dockstore-common/src/main/java/io/dockstore/common/Utilities.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/Utilities.java
@@ -16,12 +16,7 @@
 
 package io.dockstore.common;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-
+import com.google.common.base.Optional;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalINIConfiguration;
 import org.apache.commons.exec.CommandLine;
@@ -35,7 +30,11 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Optional;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  *
@@ -63,7 +62,8 @@ public class Utilities {
      * @param command the command to execute
      * @return the stdout and stderr
      */
-    public static ImmutablePair<String, String> executeCommand(String command, final boolean dumpOutput, Optional<OutputStream> stdoutStream, Optional<OutputStream> stderrStream) {
+    private static ImmutablePair<String, String> executeCommand(String command, final boolean dumpOutput,
+            Optional<OutputStream> stdoutStream, Optional<OutputStream> stderrStream) {
         // TODO: limit our output in case the called program goes crazy
 
         // these are for returning the output for use by this
@@ -102,10 +102,10 @@ public class Utilities {
                 throw new RuntimeException("problems running command: " + command, e);
             } finally {
                 if (dumpOutput) {
-                    System.out.println("exit code: " + resultHandler.getExitValue());
+                    LOG.info("exit code: " + resultHandler.getExitValue());
                     try {
-                        System.err.println("stderr was: " + localStdErrStream.toString(utf8));
-                        System.out.println("stdout was: " + localStdoutStream.toString(utf8));
+                        LOG.debug("stderr was: " + localStdErrStream.toString(utf8));
+                        LOG.debug("stdout was: " + localStdoutStream.toString(utf8));
                     } catch (UnsupportedEncodingException e) {
                         throw new RuntimeException("utf-8 does not exist?", e);
                     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MockedIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MockedIT.java
@@ -16,22 +16,7 @@
 
 package io.dockstore.client.cli;
 
-import java.io.File;
-import java.io.IOException;
-
 import io.dockstore.client.cli.nested.ToolClient;
-import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-
 import io.dockstore.webservice.DockstoreWebserviceApplication;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dropwizard.testing.ResourceHelpers;
@@ -41,11 +26,26 @@ import io.swagger.client.api.UsersApi;
 import io.swagger.client.model.SourceFile;
 import io.swagger.client.model.User;
 import io.swagger.quay.client.api.UserApi;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+import java.io.IOException;
 
 import static io.dockstore.common.CommonTestUtilities.clearState;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
@@ -112,7 +112,7 @@ public class MockedIT {
     @Test
     public void runLaunchOneJson() throws IOException, ApiException {
         Client.main(new String[] { "--config", ClientIT.getConfigFileLocation(true), "tool", "launch", "--entry",
-            "quay.io/collaboratory/dockstore-tool-linux-sort", "--json", ResourceHelpers.resourceFilePath("testOneRun.json"), "--debug" });
+            "quay.io/collaboratory/dockstore-tool-linux-sort", "--json", ResourceHelpers.resourceFilePath("testOneRun.json") });
     }
 
     @Test

--- a/dockstore-launcher/pom.xml
+++ b/dockstore-launcher/pom.xml
@@ -46,11 +46,6 @@
             <version>1.1.1</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-vfs2</artifactId>
-            <version>2.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
         </dependency>

--- a/dockstore-launcher/src/main/java/io/github/collaboratory/LauncherCWL.java
+++ b/dockstore-launcher/src/main/java/io/github/collaboratory/LauncherCWL.java
@@ -16,23 +16,6 @@
 
 package io.github.collaboratory;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.UUID;
-
 import com.amazonaws.auth.SignerFactory;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.internal.S3Signer;
@@ -47,8 +30,6 @@ import io.cwl.avro.CommandOutputParameter;
 import io.cwl.avro.Workflow;
 import io.cwl.avro.WorkflowOutputParameter;
 import io.dockstore.common.FileProvisioning;
-import io.dockstore.common.FileProvisioning.PathInfo;
-import io.dockstore.common.Utilities;
 import io.dockstore.common.FileProvisioning.PathInfo;
 import io.dockstore.common.Utilities;
 import org.apache.commons.cli.CommandLine;
@@ -429,6 +410,7 @@ public class LauncherCWL {
         UUID uuid = UUID.randomUUID();
         // setup directories
         globalWorkingDir = workingDir + "/launcher-" + uuid;
+        System.out.println("Creating directories for run of Dockstore launcher with uuid: " + uuid);
         Utilities.executeCommand("mkdir -p " + workingDir + "/launcher-" + uuid, stdoutStream, stderrStream);
         Utilities.executeCommand("mkdir -p " + workingDir + "/launcher-" + uuid + "/configs", stdoutStream, stderrStream);
         Utilities.executeCommand("mkdir -p " + workingDir + "/launcher-" + uuid + "/working", stdoutStream, stderrStream);
@@ -521,14 +503,12 @@ public class LauncherCWL {
 
         // for each file input from the CWL
         for (Object file : files) {
-
             // pull back the name of the input from the CWL
             LOG.info(file.toString());
             // remove the hash from the cwlInputFileID
             final Method getId = file.getClass().getDeclaredMethod("getId");
             String cwlInputFileID = getId.invoke(file).toString().substring(1);
             LOG.info("ID: {}", cwlInputFileID);
-
             pullFilesHelper(inputsOutputs, fileMap, cwlInputFileID);
         }
         } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException  e) {
@@ -587,6 +567,7 @@ public class LauncherCWL {
 
         // set up output paths
         String downloadDirectory = globalWorkingDir + "/inputs/" + UUID.randomUUID();
+        System.out.println("Downloading: " + cwlInputFileID + " from " + path + " into directory: " + downloadDirectory);
         Utilities.executeCommand("mkdir -p " + downloadDirectory, stdoutStream, stderrStream);
         File downloadDirFileObj = new File(downloadDirectory);
 

--- a/dockstore-launcher/src/main/java/io/github/collaboratory/LauncherCWL.java
+++ b/dockstore-launcher/src/main/java/io/github/collaboratory/LauncherCWL.java
@@ -16,23 +16,25 @@
 
 package io.github.collaboratory;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.UUID;
-
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.SignerFactory;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.S3ClientOptions;
+import com.amazonaws.services.s3.internal.S3Signer;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.google.gson.Gson;
+import io.cwl.avro.CWL;
+import io.cwl.avro.CommandLineTool;
+import io.cwl.avro.CommandOutputParameter;
+import io.cwl.avro.Workflow;
+import io.cwl.avro.WorkflowOutputParameter;
+import io.dockstore.common.FileProvisioning;
+import io.dockstore.common.FileProvisioning.PathInfo;
+import io.dockstore.common.Utilities;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -54,26 +56,22 @@ import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.SignerFactory;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.S3ClientOptions;
-import com.amazonaws.services.s3.internal.S3Signer;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
-import com.google.gson.Gson;
-
-import io.cwl.avro.CWL;
-import io.cwl.avro.CommandLineTool;
-import io.cwl.avro.CommandOutputParameter;
-import io.cwl.avro.Workflow;
-import io.cwl.avro.WorkflowOutputParameter;
-import io.dockstore.common.FileProvisioning;
-import io.dockstore.common.FileProvisioning.PathInfo;
-import io.dockstore.common.Utilities;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
 
 /**
  * @author boconnor 9/24/15
@@ -88,9 +86,8 @@ public class LauncherCWL {
 
     private static final Logger LOG = LoggerFactory.getLogger(LauncherCWL.class);
 
-    public static final String S3_ENDPOINT = "s3.endpoint";
-    public static final String WORKING_DIRECTORY = "working-directory";
-    public static final String DCC_CLIENT_KEY = "dcc_storage.client";
+    private static final String S3_ENDPOINT = "s3.endpoint";
+    private static final String WORKING_DIRECTORY = "working-directory";
     private final String configFilePath;
     private final String imageDescriptorPath;
     private final String runtimeDescriptorPath;

--- a/dockstore-launcher/src/main/java/io/github/collaboratory/LauncherCWL.java
+++ b/dockstore-launcher/src/main/java/io/github/collaboratory/LauncherCWL.java
@@ -17,12 +17,8 @@
 package io.github.collaboratory;
 
 import com.amazonaws.auth.SignerFactory;
-import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.internal.S3Signer;
-import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import io.cwl.avro.CWL;
 import io.cwl.avro.CommandLineTool;
@@ -41,11 +37,6 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalINIConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.vfs2.FileObject;
-import org.apache.commons.vfs2.FileSystemException;
-import org.apache.commons.vfs2.FileSystemManager;
-import org.apache.commons.vfs2.Selectors;
-import org.apache.commons.vfs2.VFS;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.slf4j.Logger;
@@ -57,10 +48,12 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -91,8 +84,6 @@ public class LauncherCWL {
     private HierarchicalINIConfiguration config;
     private String globalWorkingDir;
     private final Yaml yaml = new Yaml(new SafeConstructor());
-    private final Optional<OutputStream> stdoutStream;
-    private final Optional<OutputStream> stderrStream;
     private final Gson gson;
     private final FileProvisioning fileProvisioning;
 
@@ -109,9 +100,6 @@ public class LauncherCWL {
         configFilePath = line.getOptionValue("config");
         imageDescriptorPath = line.getOptionValue("descriptor");
         runtimeDescriptorPath = line.getOptionValue("job");
-        // do not forward stdout and stderr
-        stdoutStream = Optional.absent();
-        stderrStream = Optional.absent();
 
         gson = CWL.getTypeSafeCWLToolDocument();
         fileProvisioning = new FileProvisioning(configFilePath);
@@ -123,13 +111,10 @@ public class LauncherCWL {
      * @param imageDescriptorPath descriptor for the tool itself
      * @param runtimeDescriptorPath descriptor for this run of the tool
      */
-    public LauncherCWL(String configFilePath, String imageDescriptorPath, String runtimeDescriptorPath, OutputStream stdoutStream, OutputStream stderrStream){
+    public LauncherCWL(String configFilePath, String imageDescriptorPath, String runtimeDescriptorPath){
         this.configFilePath = configFilePath;
         this.imageDescriptorPath = imageDescriptorPath;
         this.runtimeDescriptorPath = runtimeDescriptorPath;
-        // programmatically forward stdout and stderr
-        this.stdoutStream = Optional.of(stdoutStream);
-        this.stderrStream = Optional.of(stderrStream);
         fileProvisioning = new FileProvisioning(configFilePath);
 
 
@@ -165,9 +150,10 @@ public class LauncherCWL {
         // setup directories
         globalWorkingDir = setupDirectories();
 
-        Map<String, FileInfo> inputsId2dockerMountMap;
-        Map<String, List<FileInfo>> outputMap;
+        Map<String, FileProvisioning.FileInfo> inputsId2dockerMountMap;
+        Map<String, List<FileProvisioning.FileInfo>> outputMap;
 
+        System.out.println("Provisioning your input files to your local machine");
         if (cwlObject instanceof Workflow){
             Workflow workflow = (Workflow)cwlObject;
             // pull input files
@@ -190,10 +176,12 @@ public class LauncherCWL {
         String newJsonPath = createUpdatedInputsAndOutputsJson(inputsId2dockerMountMap, outputMap, inputsAndOutputsJson);
 
         // run command
-        LOG.info("RUNNING COMMAND");
+        System.out.println("Calling out to cwltool to run your " + (cwlObject instanceof Workflow ? "workflow" : "tool"));
         Map<String, Object> outputObj = runCWLCommand(imageDescriptorPath, newJsonPath, globalWorkingDir + "/outputs/");
+        System.out.println();
 
         // push output files
+        System.out.println("Provisioning your output files to their final destinations");
         pushOutputFiles(outputMap, outputObj);
     }
 
@@ -203,9 +191,9 @@ public class LauncherCWL {
      * @param inputsOutputs inputs and output from json document
      * @return a map containing all output files either singly or in arrays
      */
-    private Map<String, List<FileInfo>> prepUploadsTool(CommandLineTool cwl, Map<String, Object> inputsOutputs) {
+    private Map<String, List<FileProvisioning.FileInfo>> prepUploadsTool(CommandLineTool cwl, Map<String, Object> inputsOutputs) {
 
-        Map<String, List<FileInfo>> fileMap = new HashMap<>();
+        Map<String, List<FileProvisioning.FileInfo>> fileMap = new HashMap<>();
 
         LOG.info("PREPPING UPLOADS...");
 
@@ -224,9 +212,9 @@ public class LauncherCWL {
         return fileMap;
     }
 
-    private Map<String, List<FileInfo>> prepUploadsWorkflow(Workflow workflow, Map<String, Object> inputsOutputs) {
+    private Map<String, List<FileProvisioning.FileInfo>> prepUploadsWorkflow(Workflow workflow, Map<String, Object> inputsOutputs) {
 
-        Map<String, List<FileInfo>> fileMap = new HashMap<>();
+        Map<String, List<FileProvisioning.FileInfo>> fileMap = new HashMap<>();
 
         LOG.info("PREPPING UPLOADS...");
 
@@ -245,7 +233,7 @@ public class LauncherCWL {
         return fileMap;
     }
 
-    private void prepUploadsHelper(Map<String, Object> inputsOutputs, Map<String, List<FileInfo>> fileMap, String cwlID) {
+    private void prepUploadsHelper(Map<String, Object> inputsOutputs, Map<String, List<FileProvisioning.FileInfo>> fileMap, String cwlID) {
         // now that I have an input name from the CWL I can find it in the JSON parameterization for this run
         LOG.info("JSON: {}", inputsOutputs);
         for (Entry<String, Object> stringObjectEntry : inputsOutputs.entrySet()) {
@@ -275,7 +263,7 @@ public class LauncherCWL {
      * @param cwlID
      * @param key
      */
-    private void handleOutputFile(Map<String, List<FileInfo>> fileMap, final String cwlID, Map<String, Object> param, final String key) {
+    private void handleOutputFile(Map<String, List<FileProvisioning.FileInfo>> fileMap, final String cwlID, Map<String, Object> param, final String key) {
         String path = (String) param.get("path");
         // if it's the current one
         LOG.info("PATH TO UPLOAD TO: {} FOR {} FOR {}", path, cwlID, key);
@@ -287,7 +275,7 @@ public class LauncherCWL {
         File filePathObj = new File(cwlID);
         //String newDirectory = globalWorkingDir + "/outputs/" + UUID.randomUUID().toString();
         String newDirectory = globalWorkingDir + "/outputs";
-        Utilities.executeCommand("mkdir -p " + newDirectory, stdoutStream, stderrStream);
+        Utilities.executeCommand("mkdir -p " + newDirectory);
         File newDirectoryFile = new File(newDirectory);
         String uuidPath = newDirectoryFile.getAbsolutePath() + "/" + filePathObj.getName();
 
@@ -295,9 +283,8 @@ public class LauncherCWL {
         // https://commons.apache.org/proper/commons-vfs/filesystems.html
 
         // now add this info to a hash so I can later reconstruct a docker -v command
-        FileInfo new1 = new FileInfo();
+        FileProvisioning.FileInfo new1 = new FileProvisioning.FileInfo();
         new1.setUrl(path);
-        new1.setDockerPath(cwlID);
         new1.setLocalPath(uuidPath);
         fileMap.putIfAbsent(cwlID, new ArrayList<>());
         fileMap.get(cwlID).add(new1);
@@ -312,7 +299,7 @@ public class LauncherCWL {
      * @param inputsAndOutputsJson
      * @return
      */
-    private String createUpdatedInputsAndOutputsJson(Map<String, FileInfo> fileMap, Map<String, List<FileInfo>> outputMap, Map<String, Object> inputsAndOutputsJson) {
+    private String createUpdatedInputsAndOutputsJson(Map<String, FileProvisioning.FileInfo> fileMap, Map<String, List<FileProvisioning.FileInfo>> outputMap, Map<String, Object> inputsAndOutputsJson) {
 
         JSONObject newJSON = new JSONObject();
 
@@ -410,30 +397,44 @@ public class LauncherCWL {
         UUID uuid = UUID.randomUUID();
         // setup directories
         globalWorkingDir = workingDir + "/launcher-" + uuid;
-        System.out.println("Creating directories for run of Dockstore launcher with uuid: " + uuid);
-        Utilities.executeCommand("mkdir -p " + workingDir + "/launcher-" + uuid, stdoutStream, stderrStream);
-        Utilities.executeCommand("mkdir -p " + workingDir + "/launcher-" + uuid + "/configs", stdoutStream, stderrStream);
-        Utilities.executeCommand("mkdir -p " + workingDir + "/launcher-" + uuid + "/working", stdoutStream, stderrStream);
-        Utilities.executeCommand("mkdir -p " + workingDir + "/launcher-" + uuid + "/inputs", stdoutStream, stderrStream);
-        Utilities.executeCommand("mkdir -p " + workingDir + "/launcher-" + uuid + "/logs", stdoutStream, stderrStream);
-        Utilities.executeCommand("mkdir -p " + workingDir + "/launcher-" + uuid + "/outputs", stdoutStream, stderrStream);
+        System.out.println("Creating directories for run of Dockstore launcher at: " + globalWorkingDir);
+        Utilities.executeCommand("mkdir -p " + workingDir + "/launcher-" + uuid);
+        Utilities.executeCommand("mkdir -p " + workingDir + "/launcher-" + uuid + "/configs");
+        Utilities.executeCommand("mkdir -p " + workingDir + "/launcher-" + uuid + "/working");
+        Utilities.executeCommand("mkdir -p " + workingDir + "/launcher-" + uuid + "/inputs");
+        Utilities.executeCommand("mkdir -p " + workingDir + "/launcher-" + uuid + "/logs");
+        Utilities.executeCommand("mkdir -p " + workingDir + "/launcher-" + uuid + "/outputs");
 
         return new File(workingDir + "/launcher-" + uuid).getAbsolutePath();
     }
 
     private Map<String, Object> runCWLCommand(String cwlFile, String jsonSettings, String workingDir) {
         String[] s = {"cwltool","--non-strict","--enable-net","--outdir", workingDir, cwlFile, jsonSettings};
-        final ImmutablePair<String, String> execute = Utilities.executeCommand(Joiner.on(" ").join(Arrays.asList(s)), stdoutStream, stderrStream);
+        final ImmutablePair<String, String> execute = Utilities.executeCommand(Joiner.on(" ").join(Arrays.asList(s)));
+        // mutate stderr and stdout into format for output
+        System.out.println("cwltool stdout:\n"+execute.getLeft().replaceAll("(?m)^", "\t"));
+        System.out.println("cwltool stderr:\n"+execute.getRight().replaceAll("(?m)^", "\t"));
+        Path path = Paths.get(workingDir);
+        try {
+            Path txt = Files.createFile(Paths.get(workingDir +  ".cwltool.stdout.txt"));
+            Files.write(txt, execute.getLeft().getBytes(StandardCharsets.UTF_8));
+            System.out.println("Saving copy of cwltool stdout to: " + txt.toAbsolutePath().toString());
+            Path txt2 = Files.createFile(Paths.get(workingDir +  ".cwltool.stderr.txt"));
+            Files.write(txt2, execute.getRight().getBytes(StandardCharsets.UTF_8));
+            System.out.println("Saving copy of cwltool stderr to: " + txt2.toAbsolutePath().toString());
+        } catch (IOException e) {
+            throw new RuntimeException("unable to save cwltool output", e);
+        }
         Map<String, Object> obj = (Map<String, Object>)yaml.load(execute.getLeft());
         return obj;
     }
 
-    private void pushOutputFiles(Map<String, List<FileInfo>> fileMap, Map<String, Object> outputObject) {
+    private void pushOutputFiles(Map<String, List<FileProvisioning.FileInfo>> fileMap, Map<String, Object> outputObject) {
 
         LOG.info("UPLOADING FILES...");
 
         for (String key : fileMap.keySet()) {
-            List<FileInfo> files = fileMap.get(key);
+            List<FileProvisioning.FileInfo> files = fileMap.get(key);
 
             if ((outputObject.get(key) instanceof List)){
                 List<Map<String, String>> cwltoolOutput = (List)outputObject.get(key);
@@ -441,13 +442,13 @@ public class LauncherCWL {
                 assert(cwltoolOutput.size() == files.size());
                 // for through each one and handle it, we have to assume that the order matches?
                 final Iterator<Map<String, String>> iterator = cwltoolOutput.iterator();
-                for(FileInfo info : files){
+                for(FileProvisioning.FileInfo info : files){
                     final Map<String, String> cwlToolOutputEntry = iterator.next();
                     provisionOutputFile(key, info, cwlToolOutputEntry);
                 }
             }else {
                 assert(files.size() == 1);
-                FileInfo file = files.get(0);
+                FileProvisioning.FileInfo file = files.get(0);
                 final Map<String, String> fileMapDataStructure = (Map) (outputObject).get(key);
                 provisionOutputFile(key, file, fileMapDataStructure);
             }
@@ -460,39 +461,19 @@ public class LauncherCWL {
      * @param file information on the final resting place for the output file
      * @param fileMapDataStructure the CWLtool output which contains the path to the file after cwltool is done with it
      */
-    private void provisionOutputFile(final String key, FileInfo file, final Map<String, String> fileMapDataStructure) {
+    private void provisionOutputFile(final String key, FileProvisioning.FileInfo file, final Map<String, String> fileMapDataStructure) {
         String cwlOutputPath = fileMapDataStructure.get("path");
         if (!fileMapDataStructure.get("class").equalsIgnoreCase("File")){
             System.err.println(cwlOutputPath + " is not a file, ignoring");
             return;
         }
         LOG.info("NAME: {} URL: {} FILENAME: {} CWL OUTPUT PATH: {}", file.getLocalPath(), file.getUrl(), key, cwlOutputPath);
-
-        if (file.getUrl().startsWith("s3://")) {
-            AmazonS3 s3Client = FileProvisioning.getAmazonS3Client(config);
-            String trimmedPath = file.getUrl().replace("s3://", "");
-            List<String> splitPathList = Lists.newArrayList(trimmedPath.split("/"));
-            String bucketName = splitPathList.remove(0);
-
-            s3Client.putObject(new PutObjectRequest(bucketName, Joiner.on("/").join(splitPathList), new File(cwlOutputPath)));
-        } else {
-            try {
-                FileSystemManager fsManager;
-                // trigger a copy from the URL to a local file path that's a UUID to avoid collision
-                fsManager = VFS.getManager();
-                // check for a local file path
-
-                FileObject dest = fsManager.resolveFile(file.getUrl());
-                FileObject src = fsManager.resolveFile(new File(cwlOutputPath).getAbsolutePath());
-                dest.copyFrom(src, Selectors.SELECT_SELF);
-            } catch (FileSystemException e) {
-                throw new RuntimeException("Could not provision output files", e);
-            }
-        }
+        System.out.println("Uploading: #" + key + " from " + cwlOutputPath + " to : " + file.getUrl());
+        fileProvisioning.provisionOutputFile(file, cwlOutputPath);
     }
-    
-    private Map<String, FileInfo> pullFiles(Object cwlObject,  Map<String, Object> inputsOutputs) {
-        Map<String, FileInfo> fileMap = new HashMap<>();
+
+    private Map<String, FileProvisioning.FileInfo> pullFiles(Object cwlObject,  Map<String, Object> inputsOutputs) {
+        Map<String, FileProvisioning.FileInfo> fileMap = new HashMap<>();
 
         LOG.info("DOWNLOADING INPUT FILES...");
 
@@ -518,7 +499,7 @@ public class LauncherCWL {
         return fileMap;
     }
 
-    private void pullFilesHelper(Map<String, Object> inputsOutputs, Map<String, FileInfo> fileMap, String cwlInputFileID) {
+    private void pullFilesHelper(Map<String, Object> inputsOutputs, Map<String, FileProvisioning.FileInfo> fileMap, String cwlInputFileID) {
         // now that I have an input name from the CWL I can find it in the JSON parameterization for this run
         LOG.info("JSON: {}", inputsOutputs);
         for (Entry<String, Object> stringObjectEntry : inputsOutputs.entrySet()) {
@@ -559,7 +540,7 @@ public class LauncherCWL {
      * @param cwlInputFileID looks like the descriptor for a particular path+class pair in the parameter json file, starts with a hash in the CWL file
      * @param fileMap store information on each added file as a return type
      */
-    private void doProcessFile(final String key, final String path, final String cwlInputFileID, Map<String, FileInfo> fileMap) {
+    private void doProcessFile(final String key, final String path, final String cwlInputFileID, Map<String, FileProvisioning.FileInfo> fileMap) {
 
         // key is unique for that key:download URL, cwlInputFileID is just the key
 
@@ -567,34 +548,28 @@ public class LauncherCWL {
 
         // set up output paths
         String downloadDirectory = globalWorkingDir + "/inputs/" + UUID.randomUUID();
-        System.out.println("Downloading: " + cwlInputFileID + " from " + path + " into directory: " + downloadDirectory);
-        Utilities.executeCommand("mkdir -p " + downloadDirectory, stdoutStream, stderrStream);
+        System.out.println("Downloading: #" + cwlInputFileID + " from " + path + " into directory: " + downloadDirectory);
+        Utilities.executeCommand("mkdir -p " + downloadDirectory);
         File downloadDirFileObj = new File(downloadDirectory);
 
         String targetFilePath = downloadDirFileObj.getAbsolutePath() + "/" + cwlInputFileID;
 
         // expects URI in "path": "icgc:eef47481-670d-4139-ab5b-1dad808a92d9"
         PathInfo pathInfo = new PathInfo(path);
-        if (pathInfo.isObjectIdType()) {
-            String objectId = pathInfo.getObjectId();
-            fileProvisioning.downloadFromDccStorage(objectId, downloadDirectory, downloadDirFileObj, targetFilePath);
-        } else if (path.startsWith("s3://")) {
-            fileProvisioning.downloadFromS3(path, targetFilePath);
-        } else if (!pathInfo.isLocalFileType()) {
-            fileProvisioning.downloadFromHttp(path, targetFilePath);
-        }
+        fileProvisioning.provisionInputFile(path, downloadDirectory, downloadDirFileObj, targetFilePath, pathInfo);
         if (!pathInfo.isLocalFileType()) {
             // now add this info to a hash so I can later reconstruct a docker -v command
-            FileInfo info = new FileInfo();
+            FileProvisioning.FileInfo info = new FileProvisioning.FileInfo();
             info.setLocalPath(targetFilePath);
             info.setLocalPath(targetFilePath);
-            info.setDockerPath(cwlInputFileID);
             info.setUrl(path);
             // key may contain either key:download_URL for array inputs or just cwlInputFileID for scalar input
             fileMap.put(key, info);
             LOG.info("DOWNLOADED FILE: LOCAL: {} URL: {}", cwlInputFileID, path);
         }
     }
+
+
 
     private CommandLine parseCommandLine(CommandLineParser parser, String[] args) {
         try {
@@ -609,49 +584,6 @@ public class LauncherCWL {
             throw new RuntimeException("Could not parse command-line", exp);
         }
     }
-
-    /**
-     * Describes a single File
-     */
-    public static class FileInfo {
-        private String localPath;
-        private String dockerPath;
-        private String url;
-        private String defaultLocalPath;
-
-        public String getLocalPath() {
-            return localPath;
-        }
-
-        public void setLocalPath(String localPath) {
-            this.localPath = localPath;
-        }
-
-        public String getDockerPath() {
-            return dockerPath;
-        }
-
-        public void setDockerPath(String dockerPath) {
-            this.dockerPath = dockerPath;
-        }
-
-        public String getUrl() {
-            return url;
-        }
-
-        public void setUrl(String url) {
-            this.url = url;
-        }
-
-        public String getDefaultLocalPath() {
-            return defaultLocalPath;
-        }
-
-        public void setDefaultLocalPath(String defaultLocalPath) {
-            this.defaultLocalPath = defaultLocalPath;
-        }
-    }
-
 
     public static void main(String[] args) {
         final LauncherCWL launcherCWL = new LauncherCWL(args);

--- a/dockstore-launcher/src/test/java/io/github/collaboratory/LauncherTest.java
+++ b/dockstore-launcher/src/test/java/io/github/collaboratory/LauncherTest.java
@@ -16,18 +16,16 @@
 
 package io.github.collaboratory;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-
+import com.amazonaws.AmazonClientException;
+import io.cwl.avro.CommandLineTool;
+import io.cwl.avro.Workflow;
 import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import com.amazonaws.AmazonClientException;
-
-import io.cwl.avro.CommandLineTool;
-import io.cwl.avro.Workflow;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
 
 import static org.junit.Assert.assertTrue;
 
@@ -66,7 +64,7 @@ public class LauncherTest {
             expectedEx.expect(AmazonClientException.class);
             expectedEx.expectMessage("Unable to load AWS credentials from any provider in the chain");
         }
-        final LauncherCWL launcherCWL = new LauncherCWL(iniFile.getAbsolutePath(), cwlFile.getAbsolutePath(), jobFile.getAbsolutePath(), stdout, stderr);
+        final LauncherCWL launcherCWL = new LauncherCWL(iniFile.getAbsolutePath(), cwlFile.getAbsolutePath(), jobFile.getAbsolutePath());
         launcherCWL.run(CommandLineTool.class);
 
         assertTrue(!stdout.toString().isEmpty());
@@ -84,7 +82,7 @@ public class LauncherTest {
             expectedEx.expect(AmazonClientException.class);
             expectedEx.expectMessage("Unable to load AWS credentials from any provider in the chain");
         }
-        final LauncherCWL launcherCWL = new LauncherCWL(iniFile.getAbsolutePath(), cwlFile.getAbsolutePath(), jobFile.getAbsolutePath(), stdout, stderr);
+        final LauncherCWL launcherCWL = new LauncherCWL(iniFile.getAbsolutePath(), cwlFile.getAbsolutePath(), jobFile.getAbsolutePath());
         launcherCWL.run(Workflow.class);
 
         assertTrue(!stdout.toString().isEmpty());

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <jersey-version>2.22.1</jersey-version>
         <junit-version>4.12</junit-version>
         <logback.version>1.1.3</logback.version>
-        <aws.version>1.10.29</aws.version>
+        <aws.version>1.10.77</aws.version>
         <powermock.version>1.6.4</powermock.version>
         <mockito.version>1.10.19</mockito.version>
         <cwlavro.version>1.0</cwlavro.version>

--- a/pom.xml
+++ b/pom.xml
@@ -479,6 +479,12 @@
                 <version>1.15</version>
             </dependency>
 
+            <dependency>
+                <groupId>commons-net</groupId>
+                <artifactId>commons-net</artifactId>
+                <version>3.3</version>
+            </dependency>
+
             <!--  cwl management -->
             <dependency>
                 <groupId>io.cwl</groupId>


### PR DESCRIPTION
* CWL Launcher now displays source and destination for file provisioning
* File provisioning displays progress indicators 
* Launcher now saves stderr and stdout from cwltool
* makes debug mode display debug level output from logback as well as from jersey swagger client

Still requires:
* wdl/cromwell support
* dcc storage support for progress indicator

Tackles #168 and #226 