### PR TITLE
Squash error when release version does not exist

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -265,8 +265,10 @@ public class Client {
             //id will be bigger if newer, prerelease=true if unstable
             //newer return true, older return false
             return prerelease.equals("true") && (idCurrent > idLatest);
-        }catch (MalformedURLException e) {
+        } catch (MalformedURLException e) {
             exceptionMessage(e,"Failed to open URL",CLIENT_ERROR);
+        } catch(NumberFormatException e){
+           return true;
         }
         return false;
     }


### PR DESCRIPTION
* i.e. when testing a new release version (as opposed to a SNAPSHOT), `dockstore --version` dies with an exception since the tag has not been created yet