### PR TITLE
Feature/dockstore 296 tool tab

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
@@ -106,7 +106,7 @@ public class DAGWorkflowTestIT {
         // Repo: test_workflow_cwl
         // Branch: master
         // Test: normal cwl workflow DAG
-        // Return: JSON with 2 nodes and an edge connecting it (nodes:{{untar},{compile}}, edges:{unatr->compile})
+        // Return: JSON with 2 nodes and an edge connecting it (nodes:{{untar},{compile}}, edges:{untar->compile})
 
         final List<String> strings = getJSON("DockstoreTestUser2/test_workflow_cwl", "/1st-workflow.cwl", "cwl", "master");
         int countNode = countNodeInJSON(strings);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
@@ -133,12 +133,10 @@ public class ToolsWorkflowTestIT {
         Assert.assertTrue("tool should have compile as id", strings.get(0).contains("compile"));
         Assert.assertTrue("untar docker and link should be blank", strings.get(0).contains("\"id\":\"untar\","+
                 "\"file\":\"tar-param.cwl\","+
-                "\"class\":\"\","+
-                "\"docker\":\"\"," +
-                "\"link\":\"https://hub.docker.com/_/\""));
+                "\"docker\":\"Not Specified\"," +
+                "\"link\":\"Not Specified\""));
         Assert.assertTrue("compile docker and link should not be blank", strings.get(0).contains("\"id\":\"compile\"," +
                 "\"file\":\"arguments.cwl\","+
-                "\"class\":\"DockerRequirement\","+
                 "\"docker\":\"java:7\"," +
                 "\"link\":\"https://hub.docker.com/_/java\""));
 
@@ -181,14 +179,14 @@ public class ToolsWorkflowTestIT {
         Assert.assertTrue("tool should have cgrep as id", strings.get(0).contains("cgrep"));
         Assert.assertTrue("tool should have have wc as id", strings.get(0).contains("wc"));
         Assert.assertTrue("ps docker and link should be blank", strings.get(0).contains("\"id\":\"ps\","+
-                "\"docker\":\"\","+
-                "\"link\":\"\""));
+                "\"docker\":\"Not Specified\","+
+                "\"link\":\"Not Specified\""));
         Assert.assertTrue("cgrep docker and link should be blank", strings.get(0).contains("\"id\":\"cgrep\","+
-                "\"docker\":\"\","+
-                "\"link\":\"\""));
+                "\"docker\":\"Not Specified\","+
+                "\"link\":\"Not Specified\""));
         Assert.assertTrue("wc docker and link should be blank", strings.get(0).contains("\"id\":\"wc\","+
-                "\"docker\":\"\","+
-                "\"link\":\"\""));
+                "\"docker\":\"Not Specified\","+
+                "\"link\":\"Not Specified\""));
 
     }
 
@@ -237,12 +235,10 @@ public class ToolsWorkflowTestIT {
         Assert.assertTrue("tool data should have sorted as id", strings.get(0).contains("sorted"));
         Assert.assertTrue("untar docker and link should use default docker req from workflow", strings.get(0).contains("\"id\":\"rev\","+
                 "\"file\":\"revtool.cwl\","+
-                "\"class\":\"DockerRequirement\","+
                 "\"docker\":\"debian:8\"," +
                 "\"link\":\"https://hub.docker.com/_/debian\""));
         Assert.assertTrue("compile docker and link should use default docker req from workflow", strings.get(0).contains("\"id\":\"sorted\"," +
                 "\"file\":\"sorttool.cwl\","+
-                "\"class\":\"DockerRequirement\","+
                 "\"docker\":\"debian:8\"," +
                 "\"link\":\"https://hub.docker.com/_/debian\""));
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
@@ -46,9 +46,9 @@ import java.util.concurrent.TimeoutException;
 import static io.dockstore.common.CommonTestUtilities.clearStateMakePrivate2;
 
 /**
- * Created by jpatricia on 24/06/16.
+ * Created by jpatricia on 04/07/16.
  */
-public class DAGWorkflowTestIT {
+public class ToolsWorkflowTestIT {
 
     @ClassRule
     public static final DropwizardAppRule<DockstoreWebserviceConfiguration> RULE = new DropwizardAppRule<>(
@@ -92,102 +92,122 @@ public class DAGWorkflowTestIT {
 
         //getting the dag json string
         final String basePath = WorkflowET.getWebClient().getBasePath();
-        URL url = new URL(basePath + "/workflows/" +githubWorkflow.getId()+"/dag/" + master.get().getId() );
+        URL url = new URL(basePath + "/workflows/" +githubWorkflow.getId()+"/tools/" + master.get().getId() );
         List<String> strings = Resources.readLines(url, Charset.forName("UTF-8"));
 
         return strings;
     }
 
-    private int countNodeInJSON(List<String> strings){
+    private int countToolInJSON(List<String> strings){
         //count the number of nodes in the DAG json
-        int countNode = 0;
+        int countTool = 0;
         int last = 0;
-        String node = "tool";
+        String tool = "id";
         while(last !=-1){
-            last = strings.get(0).indexOf(node,last);
+            last = strings.get(0).indexOf(tool,last);
 
             if(last !=-1){
-                countNode++;
-                last += node.length();
+                countTool++;
+                last += tool.length();
             }
         }
 
-        return countNode;
+        return countTool;
     }
 
 
     @Test
-    public void testWorkflowDAGCWL() throws IOException, TimeoutException, ApiException {
+    public void testWorkflowToolCWL() throws IOException, TimeoutException, ApiException {
         // Input: 1st-workflow.cwl
         // Repo: test_workflow_cwl
         // Branch: master
         // Test: normal cwl workflow DAG
-        // Return: JSON with 2 nodes and an edge connecting it (nodes:{{untar},{compile}}, edges:{untar->compile})
+        // Return: JSON string with two tools, only one tool has a docker requirement
 
         final List<String> strings = getJSON("DockstoreTestUser2/test_workflow_cwl", "/1st-workflow.cwl", "cwl", "master");
-        int countNode = countNodeInJSON(strings);
+        int countNode = countToolInJSON(strings);
 
         Assert.assertTrue("JSON should not be blank", strings.size() > 0);
-        Assert.assertEquals("JSON should have two nodes", countNode, 2);
-        Assert.assertTrue("node data should have untar as tool", strings.get(0).contains("untar"));
-        Assert.assertTrue("node data should have compile as tool", strings.get(0).contains("compile"));
-        Assert.assertTrue("edge should connect untar and compile", strings.get(0).contains("\"source\":\"0\",\"target\":\"1\""));
+        Assert.assertEquals("JSON should have two tools", countNode, 2);
+        Assert.assertTrue("tool should have untar as id", strings.get(0).contains("untar"));
+        Assert.assertTrue("tool should have compile as id", strings.get(0).contains("compile"));
+        Assert.assertTrue("untar docker and link should be blank", strings.get(0).contains("\"id\":\"untar\","+
+                "\"file\":\"tar-param.cwl\","+
+                "\"class\":\"\","+
+                "\"docker\":\"\"," +
+                "\"link\":\"\""));
+        Assert.assertTrue("compile docker and link should not be blank", strings.get(0).contains("\"id\":\"compile\"," +
+                "\"file\":\"arguments.cwl\","+
+                "\"class\":\"DockerRequirement\","+
+                "\"docker\":\"java:7\"," +
+                "\"link\":\"https://hub.docker.com/_/java\""));
 
     }
 
     @Test
-    public void testWorkflowDAGWDLSingleNode() throws IOException, TimeoutException, ApiException {
+    public void testWorkflowToolWDLSingleNode() throws IOException, TimeoutException, ApiException {
         // Input: hello.wdl
         // Repo: test_workflow_wdl
         // Branch: master
         // Test: normal wdl workflow DAG, single node
-        // Return: JSON with a node and no edge (nodes:{{hello}},edges:{}
+        // Return: JSON string with one tool with docker requirement
 
         final List<String> strings = getJSON("DockstoreTestUser2/test_workflow_wdl", "/hello.wdl", "wdl", "master");
-        int countNode = countNodeInJSON(strings);
+        int countNode = countToolInJSON(strings);
 
         Assert.assertTrue("JSON should not be blank", strings.size() > 0);
-        Assert.assertEquals("JSON should have one node", countNode,1);
-        Assert.assertTrue("node data should have hello as task", strings.get(0).contains("hello"));
-        Assert.assertTrue("should have no edge", strings.get(0).contains("\"edges\":[]"));
+        Assert.assertEquals("JSON should have one tool", countNode,1);
+        Assert.assertTrue("tool should have hello as id", strings.get(0).contains("hello"));
+        Assert.assertTrue("hello docker and link should not be blank", strings.get(0).contains("\"id\":\"hello\","+
+                "\"docker\":\"ubuntu:latest\","+
+                "\"link\":\"https://hub.docker.com/_/ubuntu\""));
+
     }
 
     @Test
-    public void testWorkflowDAGWDLMultipleNodes() throws IOException, TimeoutException, ApiException {
+    public void testWorkflowToolWDLMultipleNodes() throws IOException, TimeoutException, ApiException {
         // Input: hello.wdl
         // Repo: hello-dockstore-workflow
         // Branch: master
         // Test: normal wdl workflow DAG, multiple nodes
-        // Return: JSON with a node and no edge (nodes:{{ps},{cgrep},{wc}},edges:{ps->cgrep, cgrep->wc}
+        // Return: JSON string with three tools and all of them have no docker requirement
 
         final List<String> strings = getJSON("DockstoreTestUser2/hello-dockstore-workflow", "/Dockstore.wdl", "wdl", "testWDL");
-        int countNode = countNodeInJSON(strings);
+        int countNode = countToolInJSON(strings);
 
         Assert.assertTrue("JSON should not be blank", strings.size() > 0);
-        Assert.assertEquals("JSON should have three nodes", countNode,3);
-        Assert.assertTrue("node data should have ps as tool", strings.get(0).contains("ps"));
-        Assert.assertTrue("node data should have cgrep as tool", strings.get(0).contains("cgrep"));
-        Assert.assertTrue("node data should have wc as tool", strings.get(0).contains("wc"));
-        Assert.assertTrue("should have no edge", strings.get(0).contains("\"source\":\"0\",\"target\":\"1\""));
-        Assert.assertTrue("should have no edge", strings.get(0).contains("\"source\":\"1\",\"target\":\"2\""));
+        Assert.assertEquals("JSON should have three tools", countNode,3);
+        Assert.assertTrue("tool should have ps as id", strings.get(0).contains("ps"));
+        Assert.assertTrue("tool should have cgrep as id", strings.get(0).contains("cgrep"));
+        Assert.assertTrue("tool should have have wc as id", strings.get(0).contains("wc"));
+        Assert.assertTrue("ps docker and link should be blank", strings.get(0).contains("\"id\":\"ps\","+
+                "\"docker\":\"\","+
+                "\"link\":\"\""));
+        Assert.assertTrue("cgrep docker and link should be blank", strings.get(0).contains("\"id\":\"cgrep\","+
+                "\"docker\":\"\","+
+                "\"link\":\"\""));
+        Assert.assertTrue("wc docker and link should be blank", strings.get(0).contains("\"id\":\"wc\","+
+                "\"docker\":\"\","+
+                "\"link\":\"\""));
+
     }
 
     @Test
-    public void testWorkflowDAGCWLMissingTool() throws IOException, TimeoutException, ApiException {
+    public void testWorkflowToolCWLMissingTool() throws IOException, TimeoutException, ApiException {
         // Input: Dockstore.cwl
         // Repo: hello-dockstore-workflow
         // Branch: testCWL
         // Test: Repo does not have required tool files called by workflow file
-        // Return: JSON not blank, but it will have empty nodes and edges (nodes:{},edges:{})
+        // Return: JSON string blank array
 
         final List<String> strings = getJSON("DockstoreTestUser2/hello-dockstore-workflow", "/Dockstore.cwl", "cwl", "testCWL");
 
         //JSON will have node:[] and edges:[]
-        Assert.assertEquals("JSON should not have any data for nodes and edges", strings.size(),1);
+        Assert.assertEquals("JSON should not have any data tools", strings.size(),1);
     }
 
     @Test
-    public void testWorkflowDAGWDLMissingTask() throws IOException, TimeoutException, ApiException {
+    public void testWorkflowToolWDLMissingTask() throws IOException, TimeoutException, ApiException {
         // Input: hello.wdl
         // Repo: test_workflow_wdl
         // Branch: missing_docker
@@ -201,20 +221,30 @@ public class DAGWorkflowTestIT {
     }
 
     @Test
-    public void testDAGImportSyntax() throws IOException, TimeoutException, ApiException {
+    public void testToolImportSyntax() throws IOException, TimeoutException, ApiException {
         // Input: Dockstore.cwl
         // Repo: dockstore-whalesay-imports
         // Branch: master
         // Test: "run: {import:.....}"
-        // Return: DAG with two nodes and an edge connecting it (nodes:{{rev},{sorted}}, edges:{rev->sorted})
+        // Return: JSON string contains the two tools, both have docker requirement
 
         final List<String> strings = getJSON("DockstoreTestUser2/dockstore-whalesay-imports", "/Dockstore.cwl", "cwl", "master");
-        int countNode = countNodeInJSON(strings);
+        int countNode = countToolInJSON(strings);
 
         Assert.assertTrue("JSON should not be blank", strings.size() > 0);
-        Assert.assertEquals("JSON should have two nodes", countNode, 2);
-        Assert.assertTrue("node data should have rev as tool", strings.get(0).contains("rev"));
-        Assert.assertTrue("node data should have sorted as tool", strings.get(0).contains("sorted"));
-        Assert.assertTrue("edge should connect rev and sorted", strings.get(0).contains("\"source\":\"0\",\"target\":\"1\""));
+        Assert.assertEquals("JSON should have two tools", countNode, 2);
+        Assert.assertTrue("tool data should have rev as id", strings.get(0).contains("rev"));
+        Assert.assertTrue("tool data should have sorted as id", strings.get(0).contains("sorted"));
+        Assert.assertTrue("untar docker and link should be blank", strings.get(0).contains("\"id\":\"rev\","+
+                "\"file\":\"revtool.cwl\","+
+                "\"class\":\"DockerRequirement\","+
+                "\"docker\":\"debian:8\"," +
+                "\"link\":\"https://hub.docker.com/_/debian\""));
+        Assert.assertTrue("compile docker and link should be blank", strings.get(0).contains("\"id\":\"sorted\"," +
+                "\"file\":\"sorttool.cwl\","+
+                "\"class\":\"DockerRequirement\","+
+                "\"docker\":\"debian:8\"," +
+                "\"link\":\"https://hub.docker.com/_/debian\""));
+
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
@@ -235,12 +235,12 @@ public class ToolsWorkflowTestIT {
         Assert.assertEquals("JSON should have two tools", countNode, 2);
         Assert.assertTrue("tool data should have rev as id", strings.get(0).contains("rev"));
         Assert.assertTrue("tool data should have sorted as id", strings.get(0).contains("sorted"));
-        Assert.assertTrue("untar docker and link should be blank", strings.get(0).contains("\"id\":\"rev\","+
+        Assert.assertTrue("untar docker and link should use default docker req from workflow", strings.get(0).contains("\"id\":\"rev\","+
                 "\"file\":\"revtool.cwl\","+
                 "\"class\":\"DockerRequirement\","+
                 "\"docker\":\"debian:8\"," +
                 "\"link\":\"https://hub.docker.com/_/debian\""));
-        Assert.assertTrue("compile docker and link should be blank", strings.get(0).contains("\"id\":\"sorted\"," +
+        Assert.assertTrue("compile docker and link should use default docker req from workflow", strings.get(0).contains("\"id\":\"sorted\"," +
                 "\"file\":\"sorttool.cwl\","+
                 "\"class\":\"DockerRequirement\","+
                 "\"docker\":\"debian:8\"," +

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
@@ -135,7 +135,7 @@ public class ToolsWorkflowTestIT {
                 "\"file\":\"tar-param.cwl\","+
                 "\"class\":\"\","+
                 "\"docker\":\"\"," +
-                "\"link\":\"\""));
+                "\"link\":\"https://hub.docker.com/_/\""));
         Assert.assertTrue("compile docker and link should not be blank", strings.get(0).contains("\"id\":\"compile\"," +
                 "\"file\":\"arguments.cwl\","+
                 "\"class\":\"DockerRequirement\","+

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -844,7 +844,7 @@ public class WorkflowResource {
         for (Map.Entry<String, Seq> entry : callToTask.entrySet()) {
             String taskID = entry.getKey();
             Seq taskDocker = entry.getValue();  //still in form of Seq, need to get first element or head of the list
-            if(type.equals(Type.TOOLS)){
+            if(type == Type.TOOLS){
                 if (taskDocker != null){
                     String dockerName = taskDocker.head().toString();
                     taskContent.put(taskID, new MutablePair<>(dockerName, getURLFromEntry(dockerName)));
@@ -864,9 +864,9 @@ public class WorkflowResource {
         }
 
         //call and return the Json string transformer
-        if(type.equals(Type.TOOLS)){
+        if(type == Type.TOOLS){
             result = getJSONTableToolContentWDL(taskContent);
-        }else if(type.equals(Type.DAG)){
+        }else if(type == Type.DAG){
             result = setupJSONDAG(nodePairs);
         }
 
@@ -939,7 +939,7 @@ public class WorkflowResource {
                             for (Map<String, Object> requirement : requirements) {
                                 if (requirement.get("class").equals("DockerRequirement")) {
                                     defaultDockerEnv = requirement.get("dockerPull").toString();
-                                    if(type.equals(Type.TOOLS)){
+                                    if(type == Type.TOOLS){
                                         //get the docker file and link
                                         dockerPullURL = getURLFromEntry((String)requirement.get("dockerPull"));
                                         //put the tool ID and docker information into two different maps
@@ -957,7 +957,7 @@ public class WorkflowResource {
                     }
 
                     if (defaultDocker) {
-                        if(type.equals(Type.TOOLS)) {
+                        if(type == Type.TOOLS) {
                             // no docker requirement
                             if(defaultDockerEnv.equals("")){
                                 defaultDockerEnv = "Not Specified";
@@ -978,9 +978,9 @@ public class WorkflowResource {
         }
 
         //call and return the Json string transformer
-        if(type.equals(Type.TOOLS)){
+        if(type == Type.TOOLS){
             result = getJSONTableToolContentCWL(toolID, toolDocker);
-        }else if(type.equals(Type.DAG)){
+        }else if(type == Type.DAG){
             result = setupJSONDAG(nodePairs);
         }
         return result;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -110,7 +110,7 @@ public class WorkflowResource {
 
     private static final Logger LOG = LoggerFactory.getLogger(WorkflowResource.class);
 
-    enum workflowType {
+    private enum workflowType {
         DAG, TOOLS
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -699,6 +699,7 @@ public class WorkflowResource {
         Workflow workflow = workflowDAO.findById(workflowId);
         WorkflowVersion workflowVersion = getWorkflowVersion(workflow, workflowVersionId);
         SourceFile mainDescriptor = getMainDescriptorFile(workflowVersion);
+        String result = null;
 
         if(mainDescriptor != null) {
             File tmpDir = Files.createTempDir();
@@ -722,12 +723,12 @@ public class WorkflowResource {
             }
 
             if (workflow.getDescriptorType().equals("wdl")) {
-                return getContentWDL(tempMainDescriptor,"dag");
+                result = getContentWDL(tempMainDescriptor,"dag");
             } else {
-                return getContentCWL(tempMainDescriptor, tmpDir,"dag");
+                result = getContentCWL(tempMainDescriptor, tmpDir,"dag");
             }
         }
-        return null;
+        return result;
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -887,6 +887,7 @@ public class WorkflowResource {
                     for (Map <String, Object> requirement : requirements) {
                         if (requirement.get("class").equals("DockerRequirement")) {
                             defaultDockerEnv = requirement.get("dockerPull").toString();
+                            classHints = (String) requirement.get("class");
                         }
                     }
                 }
@@ -943,7 +944,7 @@ public class WorkflowResource {
                                 // no docker requirement, put the content as blank values
                                 Map<String, Pair<String, String>> dockerPull = new HashMap<>(); // this will be inserted into toolDocker
                                 toolID.put(index.toString(), new MutablePair<>(step.get("id").toString(), fileName));
-                                dockerPull.put(classHints, new MutablePair<>(defaultDockerEnv, dockerPullURL));
+                                dockerPull.put(classHints, new MutablePair<>(defaultDockerEnv, getURLFromEntry(defaultDockerEnv)));
                                 toolDocker.put(index.toString(), dockerPull);
                                 index++;
                             }else{


### PR DESCRIPTION
Related issue: ga4gh/dockstore#296
Related pull request: https://github.com/ga4gh/dockstore-ui/pull/63 

- Webservice for 'Tools' tab is implemented. The code is combined with the code for getting the DAG json.
- Information provided in json for
   * CWL: ID, filename, docker, docker link
   * WDL: ID, docker, docker link
- If the tool does not have any docker requirement specified, it will be, by default, changed to the docker requirement of the workflow. If the workflow also does not specify any docker requirement, then the 'docker' and 'link' field will have 'Not Specified'
- If required tools are missing from Github Repo, the json will return blank, or []
- Integration test 'ToolsWorkflowTestIT' is very similar to DAG's integration test 'DAGWorkflowTestIT'