### PR TITLE
Feature/dockstore 328 streamline tool path

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralET.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralET.java
@@ -552,7 +552,6 @@ public class GeneralET {
                 toolsApi.refresh(toolTest.getId());
 
                 toolTest.setDefaultCwlPath("/test1.cwl");
-                toolsApi.refresh(toolTest.getId());
                 toolsApi.updateTagContainerPath(toolTest.getId(),toolTest);
                 toolsApi.refresh(toolTest.getId());
 
@@ -593,7 +592,6 @@ public class GeneralET {
                 toolsApi.refresh(toolTest.getId());
 
                 toolTest.setDefaultWdlPath("/test1.wdl");
-                toolsApi.refresh(toolTest.getId());
                 toolsApi.updateTagContainerPath(toolTest.getId(),toolTest);
                 toolsApi.refresh(toolTest.getId());
 
@@ -634,7 +632,6 @@ public class GeneralET {
                 toolsApi.refresh(toolTest.getId());
 
                 toolTest.setDefaultDockerfilePath("/test1/Dockerfile");
-                toolsApi.refresh(toolTest.getId());
                 toolsApi.updateTagContainerPath(toolTest.getId(),toolTest);
                 toolsApi.refresh(toolTest.getId());
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -245,8 +245,8 @@ public class DockerRepoResource {
     @Timed
     @UnitOfWork
     @Path("/{containerId}/updateTagPaths")
-    @ApiOperation(value = "Change the workflow paths", notes = "Tag correspond to each row of the versions table listing all information for a docker repo tag", response = Tag.class, responseContainer = "List")
-    public Set<Tag> updateTagContainerPath(@ApiParam(hidden = true) @Auth User user,
+    @ApiOperation(value = "Change the workflow paths", notes = "Tag correspond to each row of the versions table listing all information for a docker repo tag",  response = Tool.class)
+    public Tool updateTagContainerPath(@ApiParam(hidden = true) @Auth User user,
                                                @ApiParam(value = "Tool to modify.", required = true) @PathParam("containerId") Long containerId,
                                                @ApiParam(value = "Tool with updated information", required = true) Tool tool){
 
@@ -264,7 +264,7 @@ public class DockerRepoResource {
             tag.setDockerfilePath(tool.getDefaultDockerfilePath());
         }
 
-        return tags;
+        return c;
     }
 
     @GET

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -252,6 +252,10 @@ public class DockerRepoResource {
 
         Tool c = toolDAO.findById(containerId);
 
+        //use helper to check the user and the entry
+        Helper.checkEntry(c);
+        Helper.checkUser(user, c);
+
         //update the workflow path in all workflowVersions
         Set<Tag> tags = c.getTags();
         for(Tag tag : tags){

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -241,6 +241,28 @@ public class DockerRepoResource {
 
     }
 
+    @PUT
+    @Timed
+    @UnitOfWork
+    @Path("/{containerId}/updateTagPaths")
+    @ApiOperation(value = "Change the workflow paths", notes = "Tag correspond to each row of the versions table listing all information for a docker repo tag", response = Tag.class, responseContainer = "List")
+    public Set<Tag> updateTagContainerPath(@ApiParam(hidden = true) @Auth User user,
+                                               @ApiParam(value = "Tool to modify.", required = true) @PathParam("containerId") Long containerId,
+                                               @ApiParam(value = "Tool with updated information", required = true) Tool tool){
+
+        Tool c = toolDAO.findById(containerId);
+
+        //update the workflow path in all workflowVersions
+        Set<Tag> tags = c.getTags();
+        for(Tag tag : tags){
+            tag.setCwlPath(tool.getDefaultCwlPath());
+            tag.setWdlPath(tool.getDefaultWdlPath());
+            tag.setDockerfilePath(tool.getDefaultDockerfilePath());
+        }
+
+        return tags;
+    }
+
     @GET
     @Timed
     @UnitOfWork

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -1028,6 +1028,25 @@ paths:
         default: {description: successful operation}
       summary: Delete tag linked to a container
       tags: [containertags]
+  /containers/{containerId}/updateTagPaths:
+    put:
+      description: Tag correspond to each row of the versions table listing all information for a docker repo tag
+      operationId: updateTagContainerPath
+      parameters:
+      - {description: Tool to modify., format: int64, in: path, name: containerId,
+        required: true, type: integer}
+      - description: Tool with updated information
+        in: body
+        name: body
+        required: true
+        schema: {$ref: '#/definitions/DockstoreTool'}
+      produces: [application/json]
+      responses:
+        200:
+          description: successful operation
+          schema: {$ref: '#/definitions/DockstoreTool'}
+      summary: Change the workflow paths
+      tags: [containers]
   /containers/{containerId}/users:
     get:
       description: ''


### PR DESCRIPTION
Same thing as Workflow in https://github.com/ga4gh/dockstore/pull/327
Related issue: https://github.com/ga4gh/dockstore/issues/328
Related pull request: https://github.com/ga4gh/dockstore-ui/pull/65

This pull request has the webservice added for tool. It will change the descriptor path on each tag when the default path is changed. To avoid merge conflict, it's better to add the test later after the workflow pull request is merged.