### PR TITLE
Fix tool dag tab 369

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
@@ -217,4 +217,21 @@ public class DAGWorkflowTestIT {
         Assert.assertTrue("node data should have sorted as tool", strings.get(0).contains("sorted"));
         Assert.assertTrue("edge should connect rev and sorted", strings.get(0).contains("\"source\":\"0\",\"target\":\"1\""));
     }
+
+    @Test
+    public void testDAGCWL1Syntax() throws IOException, TimeoutException, ApiException {
+        // Input: preprocess_vcf.cwl
+        // Repo: OxoG-Dockstore-Tools
+        // Branch: develop
+        // Test: "[pass_filter -> [inputs: ...., outputs: ....]] instead of [id->pass_filter,inputs->....]"
+        // Return: DAG with 17 nodes
+
+        final List<String> strings = getJSON("DockstoreTestUser2/OxoG-Dockstore-Tools", "/preprocess_vcf.cwl", "cwl", "develop");
+        int countNode = countNodeInJSON(strings);
+
+        Assert.assertTrue("JSON should not be blank", strings.size() > 0);
+        Assert.assertEquals("JSON should have two nodes", countNode, 17);
+        Assert.assertTrue("node data should have pass_filter as tool", strings.get(0).contains("pass_filter"));
+        Assert.assertTrue("node data should have merge_vcfs as tool", strings.get(0).contains("merge_vcfs"));
+    }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
@@ -102,7 +102,7 @@ public class DAGWorkflowTestIT {
         //count the number of nodes in the DAG json
         int countNode = 0;
         int last = 0;
-        String node = "tool";
+        String node = "id";
         while(last !=-1){
             last = strings.get(0).indexOf(node,last);
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
@@ -230,7 +230,7 @@ public class DAGWorkflowTestIT {
         int countNode = countNodeInJSON(strings);
 
         Assert.assertTrue("JSON should not be blank", strings.size() > 0);
-        Assert.assertEquals("JSON should have two nodes", countNode, 17);
+        Assert.assertEquals("JSON should have 17 nodes", countNode, 17);
         Assert.assertTrue("node data should have pass_filter as tool", strings.get(0).contains("pass_filter"));
         Assert.assertTrue("node data should have merge_vcfs as tool", strings.get(0).contains("merge_vcfs"));
     }
@@ -247,7 +247,7 @@ public class DAGWorkflowTestIT {
         int countNode = countNodeInJSON(strings);
 
         Assert.assertTrue("JSON should not be blank", strings.size() > 0);
-        Assert.assertEquals("JSON should have two nodes", countNode, 17);
+        Assert.assertEquals("JSON should have 17 nodes", countNode, 17);
         Assert.assertTrue("node 'filter' should have tool link to ubuntu", strings.get(0).contains("\"name\":\"filter\",\"id\":\"2\",\"tool\":\"https://hub.docker.com/_/ubuntu\""));
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
@@ -234,4 +234,20 @@ public class DAGWorkflowTestIT {
         Assert.assertTrue("node data should have pass_filter as tool", strings.get(0).contains("pass_filter"));
         Assert.assertTrue("node data should have merge_vcfs as tool", strings.get(0).contains("merge_vcfs"));
     }
+
+    @Test
+    public void testHintsExpressionTool() throws IOException, TimeoutException, ApiException {
+        // Input: preprocess_vcf.cwl
+        // Repo: OxoG-Dockstore-Tools
+        // Branch: hints_ExpressionTool
+        // Test: "filter has a docker requirement inside expression Tool, linked to ubuntu"
+        // Return: DAG with 17 nodes
+
+        final List<String> strings = getJSON("DockstoreTestUser2/OxoG-Dockstore-Tools", "/preprocess_vcf.cwl", "cwl", "hints_ExpressionTool");
+        int countNode = countNodeInJSON(strings);
+
+        Assert.assertTrue("JSON should not be blank", strings.size() > 0);
+        Assert.assertEquals("JSON should have two nodes", countNode, 17);
+        Assert.assertTrue("node 'filter' should have tool link to ubuntu", strings.get(0).contains("\"name\":\"filter\",\"id\":\"2\",\"tool\":\"https://hub.docker.com/_/ubuntu\""));
+    }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
@@ -262,11 +262,11 @@ public class ToolsWorkflowTestIT {
         Assert.assertTrue("pass_filter should not have docker link", strings.get(0).contains("\"id\":\"pass_filter\","+
                 "\"file\":\"pass-filter.cwl\","+
                 "\"docker\":\"pancancer/pcawg-oxog-tools\"," +
-                "\"link\":\"\""));
+                "\"link\":\"https://hub.docker.com/r/pancancer/pcawg-oxog-tools\""));
         Assert.assertTrue("merge_vcfs should not have docker link", strings.get(0).contains("\"id\":\"merge_vcfs\"," +
                 "\"file\":\"vcf_merge.cwl\","+
                 "\"docker\":\"pancancer/pcawg-oxog-tools\"," +
-                "\"link\":\"\""));
+                "\"link\":\"https://hub.docker.com/r/pancancer/pcawg-oxog-tools\""));
     }
 
     @Test
@@ -291,6 +291,6 @@ public class ToolsWorkflowTestIT {
         Assert.assertTrue("merge_vcfs should not have docker link", strings.get(0).contains("\"id\":\"merge_vcfs\"," +
                 "\"file\":\"vcf_merge.cwl\","+
                 "\"docker\":\"pancancer/pcawg-oxog-tools\"," +
-                "\"link\":\"\""));
+                "\"link\":\"https://hub.docker.com/r/pancancer/pcawg-oxog-tools\""));
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
@@ -243,4 +243,29 @@ public class ToolsWorkflowTestIT {
                 "\"link\":\"https://hub.docker.com/_/debian\""));
 
     }
+
+    @Test
+    public void testToolCWL1Syntax() throws IOException, TimeoutException, ApiException {
+        // Input: preprocess_vcf.cwl
+        // Repo: OxoG-Dockstore-Tools
+        // Branch: develop
+        // Test: "[pass_filter -> [inputs: ...., outputs: ....]] instead of [id->pass_filter,inputs->....]"
+        // Return: JSON string contains five tools, all have docker requirement, but no link to it since the link is invalid
+
+        final List<String> strings = getJSON("DockstoreTestUser2/OxoG-Dockstore-Tools", "/preprocess_vcf.cwl", "cwl", "develop");
+        int countNode = countToolInJSON(strings);
+
+        Assert.assertTrue("JSON should not be blank", strings.size() > 0);
+        Assert.assertEquals("JSON should have two tools", countNode, 5);
+        Assert.assertTrue("tool data should have pass_filter as id", strings.get(0).contains("pass_filter"));
+        Assert.assertTrue("tool data should have merge_vcfs as id", strings.get(0).contains("merge_vcfs"));
+        Assert.assertTrue("pass_filter should not have docker link", strings.get(0).contains("\"id\":\"pass_filter\","+
+                "\"file\":\"pass-filter.cwl\","+
+                "\"docker\":\"pancancer/pcawg-oxog-tools\"," +
+                "\"link\":\"\""));
+        Assert.assertTrue("merge_vcfs should not have docker link", strings.get(0).contains("\"id\":\"merge_vcfs\"," +
+                "\"file\":\"vcf_merge.cwl\","+
+                "\"docker\":\"pancancer/pcawg-oxog-tools\"," +
+                "\"link\":\"\""));
+    }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
@@ -256,7 +256,7 @@ public class ToolsWorkflowTestIT {
         int countNode = countToolInJSON(strings);
 
         Assert.assertTrue("JSON should not be blank", strings.size() > 0);
-        Assert.assertEquals("JSON should have two tools", countNode, 5);
+        Assert.assertEquals("JSON should have 5 tools", countNode, 5);
         Assert.assertTrue("tool data should have pass_filter as id", strings.get(0).contains("pass_filter"));
         Assert.assertTrue("tool data should have merge_vcfs as id", strings.get(0).contains("merge_vcfs"));
         Assert.assertTrue("pass_filter should not have docker link", strings.get(0).contains("\"id\":\"pass_filter\","+
@@ -281,7 +281,7 @@ public class ToolsWorkflowTestIT {
         int countNode = countToolInJSON(strings);
 
         Assert.assertTrue("JSON should not be blank", strings.size() > 0);
-        Assert.assertEquals("JSON should have two tools", countNode, 5);
+        Assert.assertEquals("JSON should have 5 tools", countNode, 5);
         Assert.assertTrue("tool data should have pass_filter as id", strings.get(0).contains("pass_filter"));
         Assert.assertTrue("tool data should have merge_vcfs as id", strings.get(0).contains("merge_vcfs"));
         Assert.assertTrue("pass_filter should not have docker link", strings.get(0).contains("\"id\":\"pass_filter\","+

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
@@ -268,4 +268,29 @@ public class ToolsWorkflowTestIT {
                 "\"docker\":\"pancancer/pcawg-oxog-tools\"," +
                 "\"link\":\"\""));
     }
+
+    @Test
+    public void testToolCWL1SyntaxCorrectLink() throws IOException, TimeoutException, ApiException {
+        // Input: preprocess_vcf.cwl
+        // Repo: OxoG-Dockstore-Tools
+        // Branch: correct_docker_link
+        // Test: "pass_filter should have a link to quay repo"
+        // Return: JSON string contains five tools, all have docker requirement, but no link to it since the link is invalid
+
+        final List<String> strings = getJSON("DockstoreTestUser2/OxoG-Dockstore-Tools", "/preprocess_vcf.cwl", "cwl", "correct_docker_link");
+        int countNode = countToolInJSON(strings);
+
+        Assert.assertTrue("JSON should not be blank", strings.size() > 0);
+        Assert.assertEquals("JSON should have two tools", countNode, 5);
+        Assert.assertTrue("tool data should have pass_filter as id", strings.get(0).contains("pass_filter"));
+        Assert.assertTrue("tool data should have merge_vcfs as id", strings.get(0).contains("merge_vcfs"));
+        Assert.assertTrue("pass_filter should not have docker link", strings.get(0).contains("\"id\":\"pass_filter\","+
+                "\"file\":\"pass-filter.cwl\","+
+                "\"docker\":\"quay.io/pancancer/pcawg-oxog-tools\"," +
+                "\"link\":\"https://quay.io/repository/pancancer/pcawg-oxog-tools\""));
+        Assert.assertTrue("merge_vcfs should not have docker link", strings.get(0).contains("\"id\":\"merge_vcfs\"," +
+                "\"file\":\"vcf_merge.cwl\","+
+                "\"docker\":\"pancancer/pcawg-oxog-tools\"," +
+                "\"link\":\"\""));
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1130,13 +1130,17 @@ public class WorkflowResource {
 
         // TODO: How to deal with multiple entries of a tool? For now just grab the first
         if (dockerEntry.startsWith("quay.io/")) {
-            Tool tool = toolDAO.findByPath(dockerEntry).get(0);
-            if (tool != null) {
-                url = dockstorePath + dockerEntry;
-            } else {
+            Tool tool;
+            if(toolDAO.findByPath(dockerEntry).size() !=0){
+                tool = toolDAO.findByPath(dockerEntry).get(0);
+                if (tool != null) {
+                    url = dockstorePath + dockerEntry;
+                } else {
+                    url = dockerEntry.replaceFirst("quay\\.io/", quayIOPath);
+                }
+            }else {
                 url = dockerEntry.replaceFirst("quay\\.io/", quayIOPath);
             }
-
         } else {
             String[] parts = dockerEntry.split("/");
             if (parts.length == 2) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -911,7 +911,7 @@ public class WorkflowResource {
         Integer index = 0;
         Map<String, Pair<String, String>> toolID = new HashMap<>();     // map for toolID and toolName
         Map<String, Pair<String, String>> toolDocker = new HashMap<>(); // map for docker
-        ArrayList<Pair<String, String>> nodePairs = new ArrayList<>();
+        ArrayList<Pair<String, String>> nodePairs = new ArrayList<>();  // array for dag nodes
         String result = null;
 
         InputStream is = IOUtils.toInputStream(content, StandardCharsets.UTF_8);
@@ -1015,7 +1015,7 @@ public class WorkflowResource {
                                 }
                             }
                         }else{
-                            if(type.equals(Type.DAG)){ //IFF it is has ExpressionTool and DAG
+                            if(type.equals(Type.DAG)){ //IFF it is has ExpressionTool and Type is DAG
                                 nodePairs.add(new MutablePair<>(stepIdValue.replaceFirst("#", ""), dockerPullURL));
                             }
                         }
@@ -1034,7 +1034,7 @@ public class WorkflowResource {
     }
 
     /**
-     * This method will
+     * This method will get the docker environment inside an expressionTool
      * @param fileMap
      * @return dockerEnv
      */
@@ -1049,7 +1049,7 @@ public class WorkflowResource {
             hasReq = true;
             reqInsideRun = (Map<String, Object>)fileMap.get("hints");
         }
-        if(hasReq){
+        if(hasReq){ //if expression tool has requirements/hints
             if(reqInsideRun.get("class").equals("DockerRequirement")){
                 dockerEnv = reqInsideRun.get("dockerPull").toString();
             }
@@ -1178,6 +1178,7 @@ public class WorkflowResource {
             nodeEntry.put("data", dataEntry);
             nodes.add(nodeEntry);
 
+            //TODO: edges are all currently pointing from idCount-1 to idCount, this is not always true
             if (idCount > 0) {
                 Map<String, Object> edgeEntry = new HashMap<>();
                 Map<String, String> sourceTarget = new HashMap<>();


### PR DESCRIPTION
Related issue: https://github.com/ga4gh/dockstore/issues/369
- Tool and DAG tab webservice now will check for syntax from CWL 1.0
- Two tests added using sample from https://github.com/DockstoreTestUser2/OxoG-Dockstore-Tools 
Main difference between previous content check with this pull request is on the data types. Since CWL 1.0 now does not require "`- id: someID`" at the beginning of each step's tool, instead the user can just write "`someID: ...`" in the CWL workflow file. This will create different data types and will result on some errors in the webservice such as "Map class cannot be cast to ArrayList", etc. 
- Code is refactored by separating some of the code into a new methods
- In the future, more testing need to be done in case there is more data types found that cannot be cast.
- NOTE: current implementation of DAG is not exactly correct since the edges is just connecting the node with `... -> idCount-1 -> idCount -> idCount+1 -> ...`

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
