### PR TITLE
Allow use of yaml parameter files

### DIFF
--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -158,6 +158,15 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
 
     </dependencies>
 

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -88,7 +88,6 @@ public class Client {
 
     private String configFile = null;
     private ContainersApi containersApi;
-    private WorkflowsApi workflowsApi;
     private GAGHApi ga4ghApi;
 
     public static final int PADDING = 3;
@@ -128,7 +127,7 @@ public class Client {
      *
      * @return path for the dockstore
      */
-    public static String getInstallLocation() {
+    static String getInstallLocation() {
         String installLocation = null;
 
         String executable = "dockstore";
@@ -156,7 +155,7 @@ public class Client {
      * @param installLocation path for the dockstore CLI script
      * @return the current version of the dockstore CLI script
      */
-    public static String getCurrentVersion(String installLocation) {
+    static String getCurrentVersion(String installLocation) {
         String currentVersion = null;
         File file = new File(installLocation);
         String line = null;
@@ -414,35 +413,42 @@ public class Client {
                         out("   dockstore --upgrade-unstable"); // takes you to the newest unstable version
                     }
                 } else {    //current is not the most stable version
-                    if(optVal.equals("stable")){
+                    switch (optVal) {
+                    case "stable":
                         out("Upgrading to most recent stable release (" + currentVersion + " -> " + latestVersion + ")");
-                        downloadURL(browserDownloadUrl,installLocation);
+                        downloadURL(browserDownloadUrl, installLocation);
                         out("Download complete. You are now on version " + latestVersion + " of Dockstore.");
-                    }else if(optVal.equals("none")){
-                        if(compareVersion(currentVersion)){
+                        break;
+                    case "none":
+                        if (compareVersion(currentVersion)) {
                             // current version is the latest unstable version
                             out("You are currently on the latest unstable version. If you wish to upgrade to the latest stable version, please use the following command:");
                             out("   dockstore --upgrade-stable");
-                        }else{
+                        } else {
                             // current version is the older unstable version
                             // upgrade to latest stable version
                             out("Upgrading to most recent stable release (" + currentVersion + " -> " + latestVersion + ")");
-                            downloadURL(browserDownloadUrl,installLocation);
+                            downloadURL(browserDownloadUrl, installLocation);
                             out("Download complete. You are now on version " + latestVersion + " of Dockstore.");
                         }
-                    }else if(optVal.equals("unstable")){
-                        if(Objects.equals(currentVersion, latestUnstable)){
+                        break;
+                    case "unstable":
+                        if (Objects.equals(currentVersion, latestUnstable)) {
                             // current version is the latest unstable version
                             out("You are currently on the latest unstable version. If you wish to upgrade to the latest stable version, please use the following command:");
                             out("   dockstore --upgrade-stable");
-                        }else{
+                        } else {
                             //user wants to upgrade to newest unstable version
                             upgradeURL = getUnstableURL(latestUnstable, mapRel);
                             out("Downloading version " + latestUnstable + " of Dockstore.");
-                            downloadURL(upgradeURL,installLocation);
+                            downloadURL(upgradeURL, installLocation);
                             out("Download complete. You are now on version " + latestUnstable + " of Dockstore.");
                         }
+                        break;
+                    default:
+                        /** do nothing */
                     }
+
                 }
             } catch (IOException e) {
                 exceptionMessage(e, "Could not connect to Github. You may have reached your rate limit.", IO_ERROR);
@@ -524,7 +530,7 @@ public class Client {
         }
     }
 
-    public static void setObjectMapper(ObjectMapper objectMapper){
+    static void setObjectMapper(ObjectMapper objectMapper){
         Client.objectMapper = objectMapper;
     }
 
@@ -656,7 +662,6 @@ public class Client {
             defaultApiClient.setBasePath(serverUrl);
 
             this.containersApi = new ContainersApi(defaultApiClient);
-            this.workflowsApi = new WorkflowsApi(defaultApiClient);
             this.ga4ghApi = new GAGHApi(defaultApiClient);
 
             ToolClient toolClient = new ToolClient(containersApi, new ContainertagsApi(defaultApiClient), new UsersApi(defaultApiClient), this);
@@ -758,7 +763,7 @@ public class Client {
         return configFile;
     }
 
-    public void setConfigFile(String configFile) {
+    void setConfigFile(String configFile) {
         this.configFile = configFile;
     }
 }

--- a/dockstore-client/src/test/resources/1st-tool.cwl
+++ b/dockstore-client/src/test/resources/1st-tool.cwl
@@ -1,0 +1,9 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: echo
+inputs:
+  message:
+    type: string
+    inputBinding:
+      position: 1
+outputs: []

--- a/dockstore-client/src/test/resources/echo-job.yml
+++ b/dockstore-client/src/test/resources/echo-job.yml
@@ -1,0 +1,1 @@
+message: Hello world!

--- a/pom.xml
+++ b/pom.xml
@@ -610,7 +610,11 @@
                 <artifactId>commons-beanutils</artifactId>
                 <version>1.9.2</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>20090211</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Minor feature, #348, allows users (especially those coming from http://www.commonwl.org/v1.0/UserGuide.html#Wrapping_Command_Line_Tools ) to use yaml parameter files instead of json. 

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` 

