### PR TITLE
Added support for extra CWLtool flags from the config file

### DIFF
--- a/dockstore-launcher/src/main/java/io/github/collaboratory/LauncherCWL.java
+++ b/dockstore-launcher/src/main/java/io/github/collaboratory/LauncherCWL.java
@@ -192,7 +192,7 @@ public class LauncherCWL {
 
         // run command
         System.out.println("Calling out to cwltool to run your " + (cwlObject instanceof Workflow ? "workflow" : "tool"));
-        Map<String, Object> outputObj = runCWLCommand(imageDescriptorPath, newJsonPath, globalWorkingDir + "/outputs/", globalWorkingDir + "/working/", config);
+        Map<String, Object> outputObj = runCWLCommand(imageDescriptorPath, newJsonPath, globalWorkingDir + "/outputs/", globalWorkingDir + "/working/");
         System.out.println();
 
         // push output files
@@ -423,7 +423,7 @@ public class LauncherCWL {
         return new File(workingDir + "/launcher-" + uuid).getAbsolutePath();
     }
 
-    private Map<String, Object> runCWLCommand(String cwlFile, String jsonSettings, String outputDir, String workingDir, HierarchicalINIConfiguration config) {
+    private Map<String, Object> runCWLCommand(String cwlFile, String jsonSettings, String outputDir, String workingDir) {
         String[] s = {"cwltool","--enable-dev","--non-strict","--enable-net","--outdir", outputDir, "--tmpdir-prefix", workingDir, cwlFile, jsonSettings};
 
         // Get extras from config file


### PR DESCRIPTION
Adds support for extra CWLtool command line options/flags based on config file information.
Use the key cwltool-extra-parameters in the config file. String together multiple parameters using commas.

Ex.
cwltool-extra-parameters: --debug, --leave-container, --leave-tmpdir

[X] Check that you pass the basic style checks and unit tests by running `mvn clean install` 

