### PR TITLE
Feature/wdl file prov for dirs

### DIFF
--- a/dockstore-integration-testing/dir_testdir/testdir_testfile.txt
+++ b/dockstore-integration-testing/dir_testdir/testdir_testfile.txt
@@ -1,0 +1,1 @@
+This file exists so that the dir_testdir folder can exist on git. Git does not support empty folders.

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowET.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowET.java
@@ -375,6 +375,14 @@ public class GeneralWorkflowET {
                         ResourceHelpers.resourceFilePath("wdl.json"), "--descriptor", "wdl", "--script", "--local-entry" });
         }
 
+        /**
+         * Tests that a developer can launch a WDL workflow with a File input being a directory
+         */
+        @Test
+        public void testLocalLaunchWDLWithDir() {
+                Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "launch", "--entry", ResourceHelpers.resourceFilePath("directorytest.wdl") , "--json",
+                        ResourceHelpers.resourceFilePath("directorytest.json"), "--descriptor", "wdl", "--script", "--local-entry" });
+        }
 
         /**
          * Tests that a developer can launch a WDL workflow locally, with an HTTP/HTTPS URL

--- a/dockstore-integration-testing/src/test/resources/directorytest.json
+++ b/dockstore-integration-testing/src/test/resources/directorytest.json
@@ -1,0 +1,4 @@
+{
+  "dir_check.stat.dir": "dir_testdir",
+  "dir_check.stat.file": "hello.wdl"
+}

--- a/dockstore-integration-testing/src/test/resources/directorytest.wdl
+++ b/dockstore-integration-testing/src/test/resources/directorytest.wdl
@@ -1,0 +1,13 @@
+task stat {
+  File dir
+  File file
+  command {
+    stat ${dir} ${file}
+  }
+  output {
+    String outf = read_string(stdout())
+  }
+}
+workflow dir_check {
+  call stat
+}

--- a/dockstore-launcher/src/main/java/io/dockstore/common/WDLFileProvisioning.java
+++ b/dockstore-launcher/src/main/java/io/dockstore/common/WDLFileProvisioning.java
@@ -111,14 +111,23 @@ public class WDLFileProvisioning {
                 LOG.info("PATH TO DOWNLOAD FROM: {} FOR {}", path, key);
 
                 // Setup local paths
-                String downloadDir = "cromwell-input/" + uniqueHash;
-                Utilities.executeCommand("mkdir -p " + downloadDir);
-                File downloadDirFileObject = new File(downloadDir);
-                final Path targetFilePath = Paths.get(downloadDirFileObject.getAbsolutePath(), filename);
+                String downloadDirPath = "cromwell-input/" + uniqueHash;
 
+                // Check if download dir exists
+                File downloadDir = new File(downloadDirPath);
+                if (!downloadDir.exists()) {
+                    Utilities.executeCommand("mkdir -p " + downloadDirPath);
+                }
+
+                final Path targetFilePath = Paths.get(downloadDir.getAbsolutePath(), filename);
+
+                File targetFile = new File(targetFilePath.toString());
                 System.out.println("Downloading: " + key + " from " + path + " to: " + targetFilePath);
-                fileProvisioning.provisionInputFile(path, targetFilePath, pathInfo);
-
+                if (targetFile.isDirectory()) {
+                    Utilities.executeCommand("mkdir -p " + targetFile);
+                } else {
+                    fileProvisioning.provisionInputFile(path, targetFilePath, pathInfo);
+                }
                 jsonEntry.put(key, targetFilePath);
                 LOG.info("DOWNLOADED FILE: LOCAL: {} URL: {} => {}", key, path, targetFilePath);
                 return jsonEntry;

--- a/dockstore-launcher/src/main/java/io/dockstore/common/WDLFileProvisioning.java
+++ b/dockstore-launcher/src/main/java/io/dockstore/common/WDLFileProvisioning.java
@@ -124,7 +124,7 @@ public class WDLFileProvisioning {
                 File targetFile = new File(targetFilePath.toString());
                 System.out.println("Downloading: " + key + " from " + path + " to: " + targetFilePath);
                 if (targetFile.isDirectory()) {
-                    Utilities.executeCommand("mkdir -p " + targetFile);
+                    Utilities.executeCommand("mkdir -p " + targetFilePath.toString());
                 } else {
                     fileProvisioning.provisionInputFile(path, targetFilePath, pathInfo);
                 }

--- a/dockstore-launcher/src/main/java/io/dockstore/common/WDLFileProvisioning.java
+++ b/dockstore-launcher/src/main/java/io/dockstore/common/WDLFileProvisioning.java
@@ -121,9 +121,9 @@ public class WDLFileProvisioning {
 
                 final Path targetFilePath = Paths.get(downloadDir.getAbsolutePath(), filename);
 
-                File targetFile = new File(targetFilePath.toString());
+                File originalFile = new File(path);
                 System.out.println("Downloading: " + key + " from " + path + " to: " + targetFilePath);
-                if (targetFile.isDirectory()) {
+                if (originalFile.isDirectory()) {
                     Utilities.executeCommand("mkdir -p " + targetFilePath.toString());
                 } else {
                     fileProvisioning.provisionInputFile(path, targetFilePath, pathInfo);

--- a/dockstore-launcher/src/main/java/io/dockstore/common/WDLFileProvisioning.java
+++ b/dockstore-launcher/src/main/java/io/dockstore/common/WDLFileProvisioning.java
@@ -19,7 +19,6 @@ package io.dockstore.common;
 import com.amazonaws.util.json.JSONException;
 import com.amazonaws.util.json.JSONObject;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,8 +105,6 @@ public class WDLFileProvisioning {
                 FileProvisioning.PathInfo pathInfo = new FileProvisioning.PathInfo(path);
                 Map<String, Object> jsonEntry = new HashMap<>();
 
-                String filename = FilenameUtils.getName(path);
-
                 LOG.info("PATH TO DOWNLOAD FROM: {} FOR {}", path, key);
 
                 // Setup local paths
@@ -119,11 +116,12 @@ public class WDLFileProvisioning {
                     Utilities.executeCommand("mkdir -p " + downloadDirPath);
                 }
 
-                final Path targetFilePath = Paths.get(downloadDir.getAbsolutePath(), filename);
+                final Path targetFilePath = Paths.get(downloadDir.getAbsolutePath(), path);
 
                 File originalFile = new File(path);
                 System.out.println("Downloading: " + key + " from " + path + " to: " + targetFilePath);
                 if (originalFile.isDirectory()) {
+                    // If directory we will create a copy of it, but not of the content
                     Utilities.executeCommand("mkdir -p " + targetFilePath.toString());
                 } else {
                     fileProvisioning.provisionInputFile(path, targetFilePath, pathInfo);

--- a/dockstore-launcher/src/main/java/io/dockstore/common/WDLFileProvisioning.java
+++ b/dockstore-launcher/src/main/java/io/dockstore/common/WDLFileProvisioning.java
@@ -116,8 +116,8 @@ public class WDLFileProvisioning {
                     Utilities.executeCommand("mkdir -p " + downloadDirPath);
                 }
 
+                // Handle provisioning of file
                 final Path targetFilePath = Paths.get(downloadDir.getAbsolutePath(), path);
-
                 File originalFile = new File(path);
                 System.out.println("Downloading: " + key + " from " + path + " to: " + targetFilePath);
                 if (originalFile.isDirectory()) {
@@ -126,10 +126,10 @@ public class WDLFileProvisioning {
                 } else {
                     fileProvisioning.provisionInputFile(path, targetFilePath, pathInfo);
                 }
+
                 jsonEntry.put(key, targetFilePath);
                 LOG.info("DOWNLOADED FILE: LOCAL: {} URL: {} => {}", key, path, targetFilePath);
                 return jsonEntry;
-
         }
 
     /**


### PR DESCRIPTION
This fixes WDL file prov during launch so that it does not fail if an input file is a directory. Instead it just creates an associated directory in the directory where we put cromwell input (cromwell-input/hash/).

When copying files/dirs to the cromwell-input dir, we will also maintain the directory structure, as before we just put all of the input files into the same directory.

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
