### PR TITLE
Feature/java 9 experiment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,10 @@ env:
 script: ./scripts/run-tests.sh
 
 before_install:
+- wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip
+- unzip -qq apache-maven-3.3.9-bin.zip
+- export M2_HOME=$PWD/apache-maven-3.3.9
+- export PATH=$M2_HOME/bin:$PATH
 - mvn dependency:get -Dartifact=org.eluder.coveralls:coveralls-maven-plugin:4.2.0
 - openssl aes-256-cbc -K $encrypted_46c132010f04_key -iv $encrypted_46c132010f04_iv -in dockstore-integration-testing/src/test/resources/secrets.tar.enc -out dockstore-integration-testing/src/test/resources/secrets.tar -d
 - tar xvf dockstore-integration-testing/src/test/resources/secrets.tar

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,6 @@ env:
 script: ./scripts/run-tests.sh
 
 before_install:
-- wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip
-- unzip -qq apache-maven-3.3.9-bin.zip
-- export M2_HOME=$PWD/apache-maven-3.3.9
-- export PATH=$M2_HOME/bin:$PATH
 - mvn dependency:get -Dartifact=org.eluder.coveralls:coveralls-maven-plugin:4.2.0
 - openssl aes-256-cbc -K $encrypted_46c132010f04_key -iv $encrypted_46c132010f04_iv -in dockstore-integration-testing/src/test/resources/secrets.tar.enc -out dockstore-integration-testing/src/test/resources/secrets.tar -d
 - tar xvf dockstore-integration-testing/src/test/resources/secrets.tar

--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -171,6 +171,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-exec</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
     </dependencies>
 
 
@@ -251,6 +256,7 @@
 
                             <usedDependencies>
                                 <usedDependency>org.apache.httpcomponents:httpcore</usedDependency>
+                                <usedDependency>javax.annotation:javax.annotation-api</usedDependency>
                             </usedDependencies>
 
                         </configuration>

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -325,7 +325,7 @@ public class Client {
                     }
                 }
                 return false;
-            } catch (IOException e) {
+            } catch (IOException | NullPointerException e) {
             }
 
         } catch (MalformedURLException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -987,6 +987,22 @@
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
             </plugin>
+            <!-- identify and fail if we use problematic Java dependencies for Java 9 -->
+            <plugin>
+                <groupId>org.codefx.mvn</groupId>
+                <artifactId>jdeps-maven-plugin</artifactId>
+                <version>0.2</version>
+                <configuration>
+                    <defaultSeverity>FAIL</defaultSeverity>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jdkinternals</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
* cobertura seems to have a known conflict with Java 9
* added Maven plugin to prevent further dependencies on deprecated APIs in Java 9
* fixed issue causing failed builds locally

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
