### PR TITLE
Avoid using shaded jar in our dependency tree

### DIFF
--- a/dockstore-client/bin/dockstore
+++ b/dockstore-client/bin/dockstore
@@ -154,12 +154,12 @@ if [ "$1" = "self-install" ]; then
     mkdir -p "$(dirname "$DOCKSTORE_JAR")"
     
     if [ $SNAPSHOT = "YES" ]; then
-        DOCKSTORE_URL="file:///$HOME/.m2/repository/io/dockstore/dockstore-client/$DOCKSTORE_VERSION/dockstore-client-$DOCKSTORE_VERSION.jar"
-    elif [ -r "/$HOME/.m2/repository/io/dockstore/dockstore-client/$DOCKSTORE_VERSION/dockstore-client-$DOCKSTORE_VERSION.jar" ]; then
+        DOCKSTORE_URL="file:///$HOME/.m2/repository/io/dockstore/dockstore-client/$DOCKSTORE_VERSION/dockstore-client-$DOCKSTORE_VERSION-shaded.jar"
+    elif [ -r "/$HOME/.m2/repository/io/dockstore/dockstore-client/$DOCKSTORE_VERSION/dockstore-client-$DOCKSTORE_VERSION-shaded.jar" ]; then
     # for testing, if you have a local release version, just use it
-        DOCKSTORE_URL="file:///$HOME/.m2/repository/io/dockstore/dockstore-client/$DOCKSTORE_VERSION/dockstore-client-$DOCKSTORE_VERSION.jar"
+        DOCKSTORE_URL="file:///$HOME/.m2/repository/io/dockstore/dockstore-client/$DOCKSTORE_VERSION/dockstore-client-$DOCKSTORE_VERSION-shaded.jar"
     else
-       DOCKSTORE_URL="https://seqwaremaven.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-client/$DOCKSTORE_VERSION/dockstore-client-$DOCKSTORE_VERSION.jar"
+       DOCKSTORE_URL="https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/dockstore-client/$DOCKSTORE_VERSION/dockstore-client-$DOCKSTORE_VERSION-shaded.jar"
     fi
 
     echo "$DOCKSTORE_URL"

--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -185,6 +185,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <shadedClassifierName>shaded</shadedClassifierName>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
                         <filter>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -40,6 +40,11 @@
             <version>1.2-alpha.3-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>io.dockstore</groupId>
+            <artifactId>dockstore-common</artifactId>
+            <version>1.2-alpha.3-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-jersey2-jaxrs</artifactId>
             <version>${swagger-annotations-version}</version>
@@ -491,6 +496,30 @@
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.cwl</groupId>
+            <artifactId>cwlavro-tools</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.cwl</groupId>
+            <artifactId>cwlavro-generated</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.broadinstitute</groupId>
+            <artifactId>wdl4s_2.11</artifactId>
+        </dependency>
     </dependencies>
 
 
@@ -608,7 +637,6 @@
                                 <usedDependency>javax.ws.rs:jsr311-api</usedDependency>
                                 <usedDependency>io.swagger:swagger-jersey2-jaxrs</usedDependency>
                                 <usedDependency>io.dropwizard:dropwizard-views-freemarker</usedDependency>
-                                <usedDependency>org.apache.commons:commons-lang3</usedDependency>
                             </usedDependencies>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -605,14 +605,24 @@
                 <version>1.9.2</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-exec</artifactId>
+                <version>1.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro</artifactId>
+                <version>1.8.1</version>
+            </dependency>
+            <dependency>
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
                 <version>20090211</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-exec</artifactId>
-                <version>1.3</version>
+                <groupId>org.broadinstitute</groupId>
+                <artifactId>wdl4s_2.11</artifactId>
+                <version>0.6</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Minor fix to avoid some redundant warning messages from maven shade
