### PR TITLE
Fix for when the user belongs to multiple organization

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/Helper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/Helper.java
@@ -495,12 +495,7 @@ public final class Helper {
 
             if (isOrg) {
                 List<String> namespaces = factory.getNamespaces();
-                for (String nm : namespaces) {
-                    if (nm.equals(namespace)) {
-                        return true;
-                    }
-                    return false;
-                }
+                return namespaces.stream().anyMatch(nm -> nm.equals(namespace));
             } else {
                 return (namespace.equals(quayUsername));
             }


### PR DESCRIPTION
Originally it only checked if the first organization of the user matches the tool's organization.  Changed it to check all organizations of the user.  Using stream instead of parallel stream because of less overhead.