### PR TITLE
Fix for launch with cwltools in tools/workflows

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -54,6 +54,7 @@ import java.util.TreeSet;
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findAll", query = "SELECT c FROM Workflow c"),
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findByPath", query = "SELECT c FROM Workflow c WHERE c.path = :path"),
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findPublishedByPath", query = "SELECT c FROM Workflow c WHERE c.path = :path AND c.isPublished = true"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findPublishedByWorkflowPath", query = "SELECT c FROM Workflow c WHERE c.path = :path AND c.workflowName = :name AND c.isPublished = true"),
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findByGitUrl", query = "SELECT c FROM Workflow c WHERE c.gitUrl = :gitUrl ORDER BY gitUrl"),
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findPublishedByOrganization", query = "SELECT c FROM Workflow c WHERE lower(c.organization) = lower(:organization) AND c.isPublished = true"),
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.searchPattern", query = "SELECT c FROM Workflow c WHERE ((c.defaultWorkflowPath LIKE :pattern) OR (c.description LIKE :pattern) OR (c.path LIKE :pattern)) AND c.isPublished = true") })

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
@@ -36,6 +36,11 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
     public Workflow findPublishedByPath(String path) {
         return uniqueResult(namedQuery("io.dockstore.webservice.core.Workflow.findPublishedByPath").setParameter("path", path));
     }
+    public Workflow findPublishedByWorkflowPath(String path, String name) {
+        return uniqueResult(namedQuery("io.dockstore.webservice.core.Workflow.findPublishedByWorkflowPath")
+                .setParameter("path", path)
+                .setParameter("name", name));
+    }
 
     public List<Workflow> findByGitUrl(String giturl) {
         return list(namedQuery("io.dockstore.webservice.core.Workflow.findByGitUrl").setParameter("gitUrl", giturl));

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
@@ -146,7 +146,11 @@ public class ToolsApiServiceImpl extends ToolsApiService {
         if (parsedID.isTool()) {
             entry = toolDAO.findPublishedByToolPath(parsedID.getPath(), parsedID.getToolName());
         } else {
-            entry = workflowDAO.findPublishedByPath(parsedID.getPath());
+            String workflowPath = parsedID.getPath();
+            if (!(parsedID.getToolName() == null)) {
+                workflowPath += "/" + parsedID.getToolName();
+            }
+            entry = workflowDAO.findPublishedByWorkflowPath(workflowPath, parsedID.getToolName());
         }
         return entry;
     }
@@ -357,7 +361,6 @@ public class ToolsApiServiceImpl extends ToolsApiService {
             throw new RuntimeException(e);
         }
         Entry entry = getEntry(parsedID);
-
         // check whether this is registered
         if (!entry.getIsPublished()) {
             return Response.status(Response.Status.UNAUTHORIZED).build();

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
@@ -147,7 +147,7 @@ public class ToolsApiServiceImpl extends ToolsApiService {
             entry = toolDAO.findPublishedByToolPath(parsedID.getPath(), parsedID.getToolName());
         } else {
             String workflowPath = parsedID.getPath();
-            if (!(parsedID.getToolName() == null)) {
+            if (parsedID.getToolName() != null) {
                 workflowPath += "/" + parsedID.getToolName();
             }
             entry = workflowDAO.findPublishedByWorkflowPath(workflowPath, parsedID.getToolName());
@@ -178,6 +178,8 @@ public class ToolsApiServiceImpl extends ToolsApiService {
 
         return getFileByToolVersionID(id, versionId, fileType, relativePath, value.getAcceptableMediaTypes().contains(MediaType.TEXT_PLAIN_TYPE) || StringUtils.containsIgnoreCase(type, "plain"));
     }
+
+
 
     @Override
     public Response toolsIdVersionsVersionIdTypeTestsGet(String type, String id, String versionId, SecurityContext securityContext, ContainerRequestContext value)


### PR DESCRIPTION
This partially fixes issue #844 .  The tool issue requires a fix on the UI, the workflow issue requires a fix on the webservice.  This pull request requires the quay swagger to be fixed or else this will not build properly.  This fixes the workflow issue by:

- Adding a workflow query that uses the workflow name to search for a query with the workflow path + workflow name.
- Modifies the ga4gh endpoint to find the workflow using this new query.
