### PR TITLE
Use default version when tag is null

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
@@ -990,6 +990,9 @@ public class ToolClient extends AbstractEntryClient {
         SourceFile file = new SourceFile();
         // simply getting published descriptors does not require permissions
         DockstoreTool container = containersApi.getPublishedContainerByToolPath(path);
+        if (tag == null && container.getDefaultVersion() != null) {
+            tag = container.getDefaultVersion();
+        }
 
         if (container != null) {
             try {


### PR DESCRIPTION
This fixes issue #878 by falling back to default version when tag is not specified.  If both are undefined, it will use 'latest'.  If 'latest' also does not exist, then the current error will be shown.