### PR TITLE
Put schema salad version in schema salad version error

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cwlrunner/CWLToolWrapper.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cwlrunner/CWLToolWrapper.java
@@ -45,7 +45,7 @@ public class CWLToolWrapper implements CWLRunnerInterface {
         }
         final String expectedSchemaSaladVersion = "2.2.20170222151604";
         if (!schemaSaladVersion.equals(expectedSchemaSaladVersion)) {
-            ArgumentUtility.errorMessage("schema-salad version is " + cwlToolVersion + " , Dockstore is tested with " + expectedSchemaSaladVersion
+            ArgumentUtility.errorMessage("schema-salad version is " + schemaSaladVersion + " , Dockstore is tested with " + expectedSchemaSaladVersion
                     + "\nOverride and run with `--script`", Client.COMMAND_ERROR);
         }
     }


### PR DESCRIPTION
If using different schema salad version, dockstore reports error with cwltool version instead of schema salad version.  This fixes that.