### PR TITLE
Concurrency secondary files fix

### DIFF
--- a/dockstore-launcher/src/main/java/io/github/collaboratory/SecondaryFilesUtility.java
+++ b/dockstore-launcher/src/main/java/io/github/collaboratory/SecondaryFilesUtility.java
@@ -238,7 +238,7 @@ class SecondaryFilesUtility {
         List<String> inputFileIds = this.getInputFileIds(workflow);
         inputFileIds.forEach(inputFileId -> getDescriptorsWithFileInput(workflow, inputFileId, descriptorsWithFiles));
         List<InputParameter> inputs = workflow.getInputs();
-        inputs.stream().forEach(input -> {
+        inputs.parallelStream().forEach(input -> {
             String workflowId = input.getId().toString();
             descriptorsWithFiles.stream().forEach(file -> {
                 if (file.containsKey(workflowId)) {

--- a/dockstore-launcher/src/main/java/io/github/collaboratory/SecondaryFilesUtility.java
+++ b/dockstore-launcher/src/main/java/io/github/collaboratory/SecondaryFilesUtility.java
@@ -238,9 +238,9 @@ class SecondaryFilesUtility {
         List<String> inputFileIds = this.getInputFileIds(workflow);
         inputFileIds.forEach(inputFileId -> getDescriptorsWithFileInput(workflow, inputFileId, descriptorsWithFiles));
         List<InputParameter> inputs = workflow.getInputs();
-        inputs.parallelStream().forEach(input -> {
+        inputs.stream().forEach(input -> {
             String workflowId = input.getId().toString();
-            descriptorsWithFiles.parallelStream().forEach(file -> {
+            descriptorsWithFiles.stream().forEach(file -> {
                 if (file.containsKey(workflowId)) {
                     ArrayList<String> arrayListToolSecondaryFiles = (ArrayList<String>)file.get(workflowId);
                     setInputFile(input, arrayListToolSecondaryFiles, workflowId);

--- a/dockstore-launcher/src/test/java/io/github/collaboratory/SecondaryFilesUtilityTest.java
+++ b/dockstore-launcher/src/test/java/io/github/collaboratory/SecondaryFilesUtilityTest.java
@@ -5,7 +5,7 @@ import java.util.stream.IntStream;
 import com.google.gson.Gson;
 import io.cwl.avro.CWL;
 import io.cwl.avro.Workflow;
-import io.dropwizard.testing.ResourceHelpers;
+import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 
 /**
@@ -14,7 +14,8 @@ import org.junit.Test;
  */
 public class SecondaryFilesUtilityTest {
 
-    private static final String imageDescriptorPath = ResourceHelpers.resourceFilePath("gdc/cwl/workflows/dnaseq/transform.cwl");
+    private static final String imageDescriptorPath = FileUtils
+            .getFile("src", "test", "resources", "gdc/cwl/workflows/dnaseq/transform.cwl").getAbsolutePath();
     private static final CWL cwlUtil = new CWL();
     private static final String imageDescriptorContent = cwlUtil.parseCWL(imageDescriptorPath).getLeft();
     private static final Gson gson = CWL.getTypeSafeCWLToolDocument();

--- a/dockstore-launcher/src/test/java/io/github/collaboratory/SecondaryFilesUtilityTest.java
+++ b/dockstore-launcher/src/test/java/io/github/collaboratory/SecondaryFilesUtilityTest.java
@@ -1,0 +1,32 @@
+package io.github.collaboratory;
+
+import java.util.stream.IntStream;
+
+import com.google.gson.Gson;
+import io.cwl.avro.CWL;
+import io.cwl.avro.Workflow;
+import io.dropwizard.testing.ResourceHelpers;
+import org.junit.Test;
+
+/**
+ * @author gluu
+ * @since 18/09/17
+ */
+public class SecondaryFilesUtilityTest {
+
+    private static final String imageDescriptorPath = ResourceHelpers.resourceFilePath("gdc/cwl/workflows/dnaseq/transform.cwl");
+    private static final CWL cwlUtil = new CWL();
+    private static final String imageDescriptorContent = cwlUtil.parseCWL(imageDescriptorPath).getLeft();
+    private static final Gson gson = CWL.getTypeSafeCWLToolDocument();
+    private static final Object cwlObject = gson.fromJson(imageDescriptorContent, Workflow.class);
+
+    @Test
+    public void modifyWorkflowToIncludeToolSecondaryFiles() throws Exception {
+        IntStream.range(0, 5).forEach(i -> modifyWorkflow());
+    }
+
+    private void modifyWorkflow() {
+        SecondaryFilesUtility secondaryFilesUtility = new SecondaryFilesUtility(cwlUtil, gson);
+        secondaryFilesUtility.modifyWorkflowToIncludeToolSecondaryFiles((Workflow)cwlObject);
+    }
+}

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/align_workflow.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/align_workflow.cwl
@@ -1,0 +1,238 @@
+#!/usr/bin/env cwl-runner
+
+- id: bamtoreadgroup_cmd
+  class: CommandLineTool
+  requirements:
+    - class: ShellCommandRequirement
+  inputs:
+    - id: "#bam_path"
+      type: File
+      inputBinding:
+        position: 2
+  outputs:
+    - id: "#output_readgroup"
+      type:
+        type: array
+        items: File
+      outputBinding:
+        glob: "*.readgroup"
+        outputEval:
+          engine: node-engine.cwl
+          script: |
+            {
+            self.sort(function(a,b) { return a.path > b.path });
+            return self;
+            }
+  arguments:
+    - valueFrom: ".readgroup"
+      position: 1
+      shellQuote: false
+    - valueFrom: "|"
+      position: 3
+      shellQuote: false
+    - valueFrom: "xargs"
+      position: 4
+      shellQuote: false
+    - valueFrom: "touch"
+      position: 5
+      shellQuote: false
+  baseCommand: grep
+
+
+
+- id: bamtofastq_cmd
+  class: CommandLineTool
+  requirements:
+    - class: ShellCommandRequirement
+  inputs:
+    - id: "#bam_path"
+      type: File
+      inputBinding:
+        position: 2
+  outputs:
+    - id: "#output_fastq1"
+      type:
+        type: array
+        items: File
+      outputBinding:
+        glob: "*_1.fq"
+        outputEval:
+          engine: node-engine.cwl
+          script: |
+            {
+            self.sort(function(a,b) { return a.path > b.path });
+            return self;
+            }
+    - id: "#output_fastq2"
+      type:
+        type: array
+        items: File
+      outputBinding:
+        glob: "*_2.fq"
+        outputEval:
+          engine: node-engine.cwl
+          script: |
+            {
+            self.sort(function(a,b) { return a.path > b.path });
+            return self;
+            }
+  arguments:
+    - valueFrom: ".fq"
+      position: 1
+      shellQuote: false
+    - valueFrom: "|"
+      position: 3
+      shellQuote: false
+    - valueFrom: "xargs"
+      position: 4
+      shellQuote: false
+    - valueFrom: "touch"
+      position: 5
+      shellQuote: false
+  baseCommand: grep
+
+
+- id: align_cmd
+  class: CommandLineTool
+  requirements:
+    - class: ShellCommandRequirement
+    - class: InlineJavascriptRequirement
+    - import: node-engine.cwl
+    - import: envvar-global.cwl
+  inputs:
+    - id: "#fastq1_path"
+      type: File
+    - id: "#fastq2_path"
+      type: File
+    - id: "#readgroup_path"
+      type: File
+  outputs:
+    - id: "#output_bam"
+      type: File
+      outputBinding:
+        glob:
+          engine: node-engine.cwl
+          script: |
+            {
+            return inputs.readgroup_path.path.split('/').slice(-1)[0].slice(0,-10)+"_realign.bam";
+            }
+  arguments:
+    - valueFrom:
+        engine: node-engine.cwl
+        script: |
+          {
+          return '"' + inputs.fastq1_path.path.split('/').slice(-1)[0] + '"';
+          }
+      position: 1
+      shellQuote: false
+    - valueFrom: ">"
+      position: 2
+      shellQuote: false
+    - valueFrom:
+        engine: node-engine.cwl
+        script: |
+          {
+          return inputs.readgroup_path.path.split('/').slice(-1)[0].slice(0,-10)+"_realign.bam";
+          }
+      position: 3
+      shellQuote: false
+    - valueFrom: "&&"
+      position: 4
+      shellQuote: false
+    - valueFrom: echo
+      position: 5
+      shellQuote: false
+    - valueFrom:
+        engine: node-engine.cwl
+        script: |
+          {
+          return '"' + inputs.fastq2_path.path.split('/').slice(-1)[0] + '"';
+          }
+      position: 6
+      shellQuote: false
+    - valueFrom: ">>"
+      position: 7
+      shellQuote: false
+    - valueFrom:
+        engine: node-engine.cwl
+        script: |
+          {
+          return inputs.readgroup_path.path.split('/').slice(-1)[0].slice(0,-10)+"_realign.bam";
+          }
+      position: 8
+      shellQuote: false
+    - valueFrom: "&&"
+      position: 9
+      shellQuote: false
+    - valueFrom: echo
+      position: 10
+      shellQuote: false
+    - valueFrom:
+        engine: node-engine.cwl
+        script: |
+          {
+          return '"' + inputs.readgroup_path.path.split('/').slice(-1)[0] + '"';
+          }
+      position: 11
+      shellQuote: false
+    - valueFrom: ">>"
+      position: 12
+      shellQuote: false
+    - valueFrom:
+        engine: node-engine.cwl
+        script: |
+          {
+          return inputs.readgroup_path.path.split('/').slice(-1)[0].slice(0,-10)+"_realign.bam";
+          }
+      position: 13
+      shellQuote: false
+  baseCommand: echo
+
+
+
+- id: main
+  class: Workflow
+  requirements:
+    - class: ScatterFeatureRequirement
+    - class: StepInputExpressionRequirement
+    - class: InlineJavascriptRequirement
+    - import: node-engine.cwl
+    - import: envvar-global.cwl
+  inputs:
+    - id: "#bam_path"
+      type: File
+  outputs:
+    - id: "align_output_bam"
+      type:
+        type: array
+        items: File
+      source: "#align.output_bam"
+  steps:
+    - id: "#bamtoreadgroup"
+      run: "#bamtoreadgroup_cmd"
+      inputs:
+        - id: "#bamtoreadgroup.bam_path"
+          source: "#bam_path"
+      outputs:
+        - id: "#bamtoreadgroup.output_readgroup"
+    - id: "#bamtofastq"
+      run: "#bamtofastq_cmd"
+      inputs:
+        - id: "#bamtofastq.bam_path"
+          source: "#bam_path"
+      outputs:
+        - id: "#bamtofastq.output_fastq1"
+        - id: "#bamtofastq.output_fastq2"          
+    - id: "#align"
+      run: "#align_cmd"
+      scatter: ["#align.fastq1_path", "#align.fastq2_path", "#align.readgroup_path"]
+      scatterMethod: "dotproduct"
+      inputs:
+        - id: "#align.fastq1_path"
+          source: "#bamtofastq.output_fastq1"
+        - id: "#align.fastq2_path"
+          source: "#bamtofastq.output_fastq2"
+        - id: "#align.readgroup_path"
+          source: "#bamtoreadgroup.output_readgroup"
+      outputs:
+        - id: "#align.output_bam"

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/array_secondary_2.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/array_secondary_2.cwl
@@ -1,0 +1,46 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: "cwl:draft-2"
+
+requirements:
+  - import: node-engine.cwl
+  - import: envvar-global.cwl
+
+class: CommandLineTool
+
+inputs:
+  - id: "#bam_path"
+    type:
+      type: array
+      items: File
+      inputBinding:
+        secondaryFiles:
+          - engine: node-engine.cwl
+            script: |
+              {
+              return {"path": $self.path.slice(0,-4)+".bai", "class": "File"};
+              }
+
+outputs:
+  - id: "#afile"
+    type: File
+    outputBinding:
+      glob: "test.txt"
+
+#return $inputs.bam_path.path.split('/').slice(-1)[0] need to build an array, not a file
+
+# arguments:
+#   - valueFrom:
+#       engine: node-engine.cwl
+#       script: |
+#         {
+#         var bam_list = "";
+#         for (var i = 0; i < inputs.bam_path.length; i ++) {
+#           bam_list += " echo " + inputs.bam_path[i].path.split('/').slice(-1)[0] + " >> bam.list &&"
+#         }
+#         return bam_list.slice(0,-2)
+#         }
+#     position: 1
+#     shellQuote: false
+
+baseCommand: [touch, test.txt]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/array_secondary_3.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/array_secondary_3.cwl
@@ -1,0 +1,38 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: "cwl:draft-3"
+
+requirements:
+  - class: ShellCommandRequirement
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: bam_path
+    type:
+      type: array
+      items: File
+      secondaryFiles: |
+        ${
+        return {"path": self.path.slice(0,-4)+".bai", "class": "File"};
+        }
+
+outputs:
+  - id: bam_list
+    type: File
+    outputBinding:
+      glob: "bam.list"
+
+arguments:
+  - valueFrom: ${
+        var bam_list = "";
+        for (var i = 0; i < inputs.bam_path.length; i ++) {
+          bam_list += " echo " + inputs.bam_path[i].path.split('/').slice(-1)[0] + " >> bam.list &&"
+        }
+        return bam_list.slice(0,-2)
+        }
+    position: 1
+    shellQuote: false
+
+baseCommand: []

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/array_secondary_3_short.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/array_secondary_3_short.cwl
@@ -1,0 +1,38 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: "cwl:draft-3"
+
+requirements:
+  - class: ShellCommandRequirement
+  - class: InlineJavascriptRequirement
+  - class: DockerRequirement
+    dockerPull: alpine
+
+class: CommandLineTool
+
+inputs:
+  - id: bam_path
+    type:
+      type: array
+      items: File
+      secondaryFiles:
+        - ^.bai
+
+outputs:
+  - id: bai_list
+    type: File
+    outputBinding:
+      glob: "bai.list"
+
+arguments:
+  - valueFrom: ${
+        var bai_list = "";
+        for (var i = 0; i < inputs.bam_path.length; i ++) {
+          bai_list += " cat " + inputs.bam_path[i].path.slice(0,-4)+".bai" + " >> bai.list && "
+        }
+        return bai_list.slice(0,-3)
+        }
+    position: 1
+    shellQuote: false
+
+baseCommand: []

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/aws_s3_get_bai_signpost.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/aws_s3_get_bai_signpost.cwl
@@ -1,0 +1,126 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+class: CommandLineTool
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/awscli:1
+  - class: EnvVarRequirement
+    envDef:
+      - envName: "AWS_CONFIG_FILE"
+        envValue: $(inputs.aws_config.path)
+      - envName: "AWS_SHARED_CREDENTIALS_FILE"
+        envValue: $(inputs.aws_shared_credentials.path)
+  - class: InlineJavascriptRequirement
+
+inputs:
+  - id: aws_config
+    type: File
+
+  - id: aws_shared_credentials
+    type: File
+
+  - id: endpoint_json
+    type: File
+    inputBinding:
+      loadContents: true
+      valueFrom: null
+
+  - id: signpost_json
+    type: File
+    inputBinding:
+      loadContents: true
+      valueFrom: null
+
+outputs:
+  - id: output
+    type: File
+    outputBinding:
+      glob: |
+        ${
+        var signpost_json = JSON.parse(inputs.signpost_json.contents);
+        var signpost_url = String(signpost_json.urls.slice(0));
+        var file_name = signpost_url.split('/').slice(-1)[0].slice(0,-4) + ".bai";
+        return file_name
+        }
+
+arguments:
+  - valueFrom: |
+      ${
+      function include(arr,obj) {
+        return (arr.indexOf(obj) != -1)
+      }
+
+      var signpost_json = JSON.parse(inputs.signpost_json.contents);
+      var signpost_url = String(signpost_json.urls.slice(0));
+      var signpost_path = signpost_url.slice(5);
+      var signpost_array = signpost_path.split('/');
+      var signpost_root = signpost_array[0];
+
+      if (include(signpost_root,"ceph")) {
+        var profile = "ceph";
+      } else if (include(signpost_root,"cleversafe")) {
+        var profile = "cleversafe";
+      } else {
+        var profile = signpost_root.split('.')[0];
+      }
+
+      var endpoint_json = JSON.parse(inputs.endpoint_json.contents);
+      var endpoint_url = String(endpoint_json[profile]);
+      return endpoint_url
+      }
+    prefix: --endpoint-url
+    position: 0
+
+  - valueFrom: |
+      ${
+      function include(arr,obj) {
+        return (arr.indexOf(obj) != -1)
+      }
+
+      var signpost_json = JSON.parse(inputs.signpost_json.contents);
+      var signpost_url = String(signpost_json.urls.slice(0));
+      var signpost_path = signpost_url.slice(5);
+      var signpost_array = signpost_path.split('/');
+      var signpost_root = signpost_array[0];
+
+      if (include(signpost_root,"ceph")) {
+        return "ceph"
+      } else if (include(signpost_root,"cleversafe")) {
+        return "cleversafe"
+      } else {
+        var profile = signpost_root.split('.')[0];
+        return profile
+      }
+      }
+    prefix: --profile
+    position: 1
+
+  - valueFrom: |
+      ${
+      function include(arr,obj) {
+        return (arr.indexOf(obj) != -1)
+      }
+      var signpost_json = JSON.parse(inputs.signpost_json.contents);
+
+      var obj_path = [];
+      for (var i = 0; i < signpost_json.urls.length; i++) {
+        if (include(signpost_json.urls[i],"cleversafe")) {
+          obj_path.push(signpost_json.urls[i]);
+          break;
+          }
+      }
+      if (obj_path.length == 0) {
+        obj_path.push(signpost_json.urls[0]);
+      }
+      var signpost_path = obj_path[0].substring(5).split('/').slice(1).join('/');
+      var s3_url = "s3://" + signpost_path.slice(0,-4) + ".bai";
+      return s3_url
+      }
+    position: 98
+
+  - valueFrom: .
+    position: 99
+
+baseCommand: [aws, s3, cp]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/aws_s3_get_signpost.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/aws_s3_get_signpost.cwl
@@ -1,0 +1,126 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+class: CommandLineTool
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/awscli:1
+  - class: EnvVarRequirement
+    envDef:
+      - envName: "AWS_CONFIG_FILE"
+        envValue: $(inputs.aws_config.path)
+      - envName: "AWS_SHARED_CREDENTIALS_FILE"
+        envValue: $(inputs.aws_shared_credentials.path)
+  - class: InlineJavascriptRequirement
+
+inputs:
+  - id: aws_config
+    type: File
+
+  - id: aws_shared_credentials
+    type: File
+
+  - id: endpoint_json
+    type: File
+    inputBinding:
+      loadContents: true
+      valueFrom: null
+
+  - id: signpost_json
+    type: File
+    inputBinding:
+      loadContents: true
+      valueFrom: null
+
+outputs:
+  - id: output
+    type: File
+    outputBinding:
+      glob: |
+        ${
+        var signpost_json = JSON.parse(inputs.signpost_json.contents);
+        var signpost_url = String(signpost_json.urls.slice(0));
+        var file_name = signpost_url.split('/').slice(-1)[0];
+        return file_name
+        }
+
+arguments:
+  - valueFrom: |
+      ${
+      function include(arr,obj) {
+        return (arr.indexOf(obj) != -1)
+      }
+
+      var signpost_json = JSON.parse(inputs.signpost_json.contents);
+      var signpost_url = String(signpost_json.urls.slice(0));
+      var signpost_path = signpost_url.slice(5);
+      var signpost_array = signpost_path.split('/');
+      var signpost_root = signpost_array[0];
+
+      if (include(signpost_root,"ceph")) {
+        var profile = "ceph";
+      } else if (include(signpost_root,"cleversafe")) {
+        var profile = "cleversafe";
+      } else {
+        var profile = signpost_root.split('.')[0];
+      }
+
+      var endpoint_json = JSON.parse(inputs.endpoint_json.contents);
+      var endpoint_url = String(endpoint_json[profile]);
+      return endpoint_url
+      }
+    prefix: --endpoint-url
+    position: 0
+
+  - valueFrom: |
+      ${
+      function include(arr,obj) {
+        return (arr.indexOf(obj) != -1)
+      }
+
+      var signpost_json = JSON.parse(inputs.signpost_json.contents);
+      var signpost_url = String(signpost_json.urls.slice(0));
+      var signpost_path = signpost_url.slice(5);
+      var signpost_array = signpost_path.split('/');
+      var signpost_root = signpost_array[0];
+
+      if (include(signpost_root,"ceph")) {
+        return "ceph"
+      } else if (include(signpost_root,"cleversafe")) {
+        return "cleversafe"
+      } else {
+        var profile = signpost_root.split('.')[0];
+        return profile
+      }
+      }
+    prefix: --profile
+    position: 1
+
+  - valueFrom: |
+      ${
+      function include(arr,obj) {
+        return (arr.indexOf(obj) != -1)
+      }
+      var signpost_json = JSON.parse(inputs.signpost_json.contents);
+
+      var obj_path = [];
+      for (var i = 0; i < signpost_json.urls.length; i++) {
+        if (include(signpost_json.urls[i],"cleversafe")) {
+          obj_path.push(signpost_json.urls[i]);
+          break;
+          }
+      }
+      if (obj_path.length == 0) {
+        obj_path.push(signpost_json.urls[0]);
+      }
+      var signpost_path = obj_path[0].substring(5).split('/').slice(1).join('/');
+      var s3_url = "s3://" + signpost_path;
+      return s3_url
+      }
+    position: 98
+
+  - valueFrom: .
+    position: 99
+
+baseCommand: [aws, s3, cp]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/aws_s3_get_todir.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/aws_s3_get_todir.cwl
@@ -1,0 +1,72 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+class: CommandLineTool
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/awscli:1
+  - class: EnvVarRequirement
+    envDef:
+      - envName: "AWS_CONFIG_FILE"
+        envValue: $(inputs.aws_config_file.path)
+      - envName: "AWS_SHARED_CREDENTIALS_FILE"
+        envValue: $(inputs.aws_shared_credentials_file.path)
+  - class: InlineJavascriptRequirement
+  - class: ShellCommandRequirement
+
+inputs:
+  - id: aws_config_file
+    type: File
+
+  - id: aws_shared_credentials_file
+    type: File
+  
+  - id: endpoint_url
+    type: string
+    inputBinding:
+      prefix: --endpoint-url
+      position: 10
+
+  - id: input_dir
+    type: Directory
+    
+  - id: s3cfg_section
+    type: string
+    inputBinding:
+      prefix: --profile
+      position: 10
+    
+  - id: s3uri
+    type: string
+    inputBinding:
+      position: 98
+
+outputs:
+  - id: output
+    type: File
+    outputBinding:
+      glob: $(inputs.s3uri.split('/').slice(-1)[0])
+
+  - id: bin_time
+    type: File
+    outputBinding:
+      glob: "bin.time"
+
+arguments:
+  - valueFrom: "bin.time"
+    position: 0
+
+  - valueFrom: aws
+    position: 1
+
+  - valueFrom: s3
+    position: 2
+
+  - valueFrom: cp
+    position: 3
+
+  - valueFrom: $(inputs.input_dir)
+    position: 99
+
+baseCommand: [/usr/bin/time, -v, -o]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/aws_s3_ls.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/aws_s3_ls.cwl
@@ -1,0 +1,59 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: "cwl:draft-3"
+
+class: CommandLineTool
+requirements:
+  - class: ShellCommandRequirement
+  - class: InlineJavascriptRequirement
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/awscli:1
+
+inputs:
+  - id: endpoint-url
+    type: ["null", string]
+    inputBinding:
+      prefix: --endpoint-url
+      position: 10
+      
+  - id: output
+    type: string
+
+  - id: profile
+    type: ["null", string]
+    inputBinding:
+      prefix: --profile
+      position: 10
+    
+  - id: recursive
+    type: ["null", boolean]
+    inputBinding:
+      prefix: --recursive
+      position: 10
+
+  - id: S3Uri
+    type: string
+    inputBinding:
+      position: 99
+
+outputs:
+  - id: "#list"
+    type: File
+    outputBinding:
+      glob: $(inputs.output)
+
+stdout: $(inputs.output)
+
+arguments:
+  - valueFrom: "bin.time"
+    position: 0
+
+  - valueFrom: aws
+    position: 1
+
+  - valueFrom: s3
+    position: 2
+
+  - valueFrom: ls
+    position: 3
+
+baseCommand: [/usr/bin/time, -v, -o]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/aws_s3_put.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/aws_s3_put.cwl
@@ -1,0 +1,62 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+class: CommandLineTool
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/awscli:1
+  - class: EnvVarRequirement
+    envDef:
+      - envName: "AWS_CONFIG_FILE"
+        envValue: $(inputs.aws_config.path)
+      - envName: "AWS_SHARED_CREDENTIALS_FILE"
+        envValue: $(inputs.aws_shared_credentials.path)
+  - class: InlineJavascriptRequirement
+  - class: ShellCommandRequirement
+
+inputs:
+  - id: aws_config
+    type: File
+
+  - id: aws_shared_credentials
+    type: File
+  
+  - id: endpoint_json
+    type: File
+    inputBinding:
+      loadContents: true
+      valueFrom: null
+
+  - id: input
+    type: File
+
+  - id: s3cfg_section
+    type: string
+    
+  - id: s3uri
+    type: string
+
+outputs:
+  - id: output
+    type: File
+    outputBinding:
+      glob: "output"
+
+arguments:
+  - valueFrom: |
+      ${
+      var endpoint_json = JSON.parse(inputs.endpoint_json.contents);
+      var endpoint_url = String(endpoint_json[inputs.s3cfg_section]);
+      var endpoint = endpoint_url.replace("http://","");
+      var dig_cmd = ["dig", "+short", endpoint, "|", "grep", "-E", "'[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'", "|", "shuf", "-n1"];
+      var shell_dig = "http://" + "`" + dig_cmd.join(' ') + "`";
+      var cmd = ["aws", "s3", "cp", "--profile", inputs.s3cfg_section, "--endpoint-url", shell_dig, inputs.input.path, inputs.s3uri];
+      var shell_cmd = cmd.join(' ');
+      return shell_cmd
+      }
+    position: 0
+
+stdout: "output"
+    
+baseCommand: [bash, -c]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/bam_add_eof.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/bam_add_eof.cwl
@@ -1,0 +1,47 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: "cwl:draft-3"
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/bam_add_eof
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: bam_path
+    type: File
+    inputBinding:
+      prefix: --bam_path
+
+  - id: picard_validation_path
+    type: File
+    inputBinding:
+      prefix: --picard_validation_path
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+outputs:
+  - id: output_bam
+    type: File
+    description: "The BAM file with EOF"
+    outputBinding:
+      glob: $(inputs.bam_path.path.split('/').slice(-1)[0])
+
+  - id: log
+    type: File
+    description: "python log file"
+    outputBinding:
+      glob: $(inputs.uuid + "_bam_add_eof.log")
+
+  - id: output_sqlite
+    type: File
+    description: "sqlite file"
+    outputBinding:
+      glob: $(inputs.uuid + ".db")
+
+baseCommand: ["/home/ubuntu/.virtualenvs/p3/bin/python","/home/ubuntu/.virtualenvs/p3/lib/python3.5/site-packages/bam_add_eof/main.py"]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/bam_readgroup_to_json.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/bam_readgroup_to_json.cwl
@@ -1,0 +1,41 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/bam_readgroup_to_json:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: INPUT
+    type: File
+    format: "edam:format_2572"
+    inputBinding:
+      prefix: --bam_path
+
+  - id: MODE
+    type: string
+    default: strict
+    inputBinding:
+      prefix: --mode
+
+outputs:
+  - id: OUTPUT
+    format: "edam:format_3464"
+    type:
+      type: array
+      items: File
+    outputBinding:
+      glob: "*.json"
+      outputEval: |
+        ${ return self.sort(function(a,b) { return a.location > b.location ? 1 : (a.location < b.location ? -1 : 0) }) }
+
+  - id: log
+    type: File
+    outputBinding:
+      glob: "output.log"
+
+baseCommand: [/usr/local/bin/bam_readgroup_to_json]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/bam_reheader.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/bam_reheader.cwl
@@ -1,0 +1,31 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/bam_reheader:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: bam_path
+    type: File
+    format: "edam:format_2572"
+    inputBinding:
+      prefix: --bam_path
+
+outputs:
+  - id: output_bam
+    type: File
+    format: "edam:format_2572"
+    outputBinding:
+      glob: $(inputs.bam_path.basename)
+
+  - id: log
+    type: File
+    outputBinding:
+      glob: $(inputs.bam_path.basename + ".log")
+
+baseCommand: [/usr/local/bin/bam_reheader]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/bamutils_splitbam.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/bamutils_splitbam.cwl
@@ -1,0 +1,45 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: "cwl:draft-3"
+
+description: |
+  Usage:  cwl-runner <this-file-path> --bam_path <bam-path> --uuid <uuid-string>
+  Options:
+    --bam_path       Generate readgroup BAMs from BAM file
+    --uuid           UUID for log file and sqlite db file
+
+requirements:
+  - $import: envvar-global.cwl
+  - class: InlineJavascriptRequirement
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/bamutil_tool
+
+class: CommandLineTool
+
+inputs:
+  - id: "#input_bam"
+    type: File
+    inputBinding:
+      prefix: --bam_path
+
+  - id: "#uuid"
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+outputs:
+  - id: "#output_bam"
+    type:
+      type: array
+      items: File
+    description: "The readgroup BAM{s}"
+    outputBinding:
+      glob: split.*.bam
+
+  - id: "#log"
+    type: File
+    description: "python log file"
+    outputBinding:
+      glob: $(inputs.uuid + "_splitbam.log")
+
+baseCommand: ["/home/ubuntu/.virtualenvs/p3/bin/python","/home/ubuntu/.virtualenvs/p3/lib/python3.4/site-packages/bamutil_tool/main.py", "--tool_name", "splitbam"]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/biobambam2_bamtofastq.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/biobambam2_bamtofastq.cwl
@@ -1,0 +1,169 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/biobambam:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: collate
+    type: int
+    default: 1
+    inputBinding:
+      prefix: collate=
+      separate: false
+
+  - id: exclude
+    type: string
+    default: QCFAIL,SECONDARY,SUPPLEMENTARY
+    inputBinding:
+      prefix: exclude=
+      separate: false
+
+  - id: filename
+    format: "edam:format_2572"
+    type: File
+    inputBinding:
+      prefix: filename=
+      separate: false
+
+  - id: gz
+    type: int
+    default: 1
+    inputBinding:
+      prefix: gz=
+      separate: false
+
+  - id: inputformat
+    type: string
+    default: "bam"
+    inputBinding:
+      prefix: inputformat=
+      separate: false
+
+  - id: level
+    type: int
+    default: 5
+    inputBinding:
+      prefix: level=
+      separate: false
+
+  - id: outputdir
+    type: string
+    default: .
+    inputBinding:
+      prefix: outputdir=
+      separate: false
+
+  - id: outputperreadgroup
+    type: int
+    default: 1
+    inputBinding:
+      prefix: outputperreadgroup=
+      separate: false
+
+  - id: outputperreadgroupsuffixF
+    type: string
+    default: _1.fq.gz
+    inputBinding:
+      prefix: outputperreadgroupsuffixF=
+      separate: false
+
+  - id: outputperreadgroupsuffixF2
+    type: string
+    default: _2.fq.gz
+    inputBinding:
+      prefix: outputperreadgroupsuffixF2=
+      separate: false
+
+  - id: outputperreadgroupsuffixO
+    type: string
+    default: _o1.fq.gz
+    inputBinding:
+      prefix: outputperreadgroupsuffixO=
+      separate: false
+
+  - id: outputperreadgroupsuffixO2
+    type: string
+    default: _o2.fq.gz
+    inputBinding:
+      prefix: outputperreadgroupsuffixO2=
+      separate: false
+
+  - id: outputperreadgroupsuffixS
+    type: string
+    default: _s.fq.gz
+    inputBinding:
+      prefix: outputperreadgroupsuffixS=
+      separate: false
+
+  - id: tryoq
+    type: int
+    default: 1
+    inputBinding:
+      prefix: tryoq=
+      separate: false
+
+  - id: T
+    type: string
+    default: tempfq
+    inputBinding:
+      prefix: T=
+      separate: false
+
+outputs:
+  - id: output_fastq1
+    format: "edam:format_2182"
+    type:
+      type: array
+      items: File
+    outputBinding:
+      glob: "*_1.fq.gz"
+      outputEval: |
+        ${ return self.sort(function(a,b) { return a.location > b.location ? 1 : (a.location < b.location ? -1 : 0) }) }
+
+  - id: output_fastq2
+    format: "edam:format_2182"
+    type:
+      type: array
+      items: File
+    outputBinding:
+      glob: "*_2.fq.gz"
+      outputEval: |
+        ${ return self.sort(function(a,b) { return a.location > b.location ? 1 : (a.location < b.location ? -1 : 0) }) }
+
+  - id: output_fastq_o1
+    format: "edam:format_2182"
+    type:
+      type: array
+      items: File
+    outputBinding:
+      glob: "*_o1.fq.gz"
+      outputEval: |
+        ${ return self.sort(function(a,b) { return a.location > b.location ? 1 : (a.location < b.location ? -1 : 0) }) }
+
+  - id: output_fastq_o2
+    format: "edam:format_2182"
+    type:
+      type: array
+      items: File
+    outputBinding:
+      glob: "*_o2.fq.gz"
+      outputEval: |
+        ${ return self.sort(function(a,b) { return a.location > b.location ? 1 : (a.location < b.location ? -1 : 0) }) }
+
+  - id: output_fastq_s
+    format: "edam:format_2182"
+    type:
+      type: array
+      items: File
+    outputBinding:
+      glob: "*_s.fq.gz"
+      outputEval: |
+        ${ return self.sort(function(a,b) { return a.location > b.location ? 1 : (a.location < b.location ? -1 : 0) }) }
+
+baseCommand: [/usr/local/bin/bamtofastq]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/bwa_pe.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/bwa_pe.cwl
@@ -1,0 +1,123 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/bwa:1
+  - class: InlineJavascriptRequirement
+  - class: ShellCommandRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: fastq1
+    type: File
+    format: "edam:format_2182"
+
+  - id: fastq2
+    type: File
+    format: "edam:format_2182"
+
+  - id: fasta
+    type: File
+    format: "edam:format_1929"
+    secondaryFiles:
+      - .amb
+      - .ann
+      - .bwt
+      - .pac
+      - .sa
+
+  - id: readgroup_json_path
+    type: File
+    format: "edam:format_3464"
+    inputBinding:
+      loadContents: true
+      valueFrom: null
+
+  - id: fastqc_json_path
+    type: File
+    format: "edam:format_3464"
+    inputBinding:
+      loadContents: true
+      valueFrom: null
+
+  - id: thread_count
+    type: int
+
+outputs:
+  - id: OUTPUT
+    type: File
+    format: "edam:format_2572"
+    outputBinding:
+      glob: $(inputs.readgroup_json_path.basename.slice(0,-4) + "bam")
+
+arguments:
+  - valueFrom: |
+      ${
+        function to_rg() {
+          var readgroup_str = "@RG";
+          var readgroup_json = JSON.parse(inputs.readgroup_json_path.contents);
+          var keys = Object.keys(readgroup_json).sort();
+          for (var i = 0; i < keys.length; i++) {
+            var key = keys[i];
+            var value = readgroup_json[key];
+            readgroup_str = readgroup_str + "\\t" + key + ":" + value;
+          }
+          return readgroup_str
+        }
+
+        function bwa_aln_33(rg_str, outbam) {
+          var cmd = [
+          "bwa", "aln", "-t", inputs.thread_count, inputs.fasta.path, inputs.fastq1.path, ">", "aln.sai1", "&&",
+          "bwa", "aln", "-t", inputs.thread_count, inputs.fasta.path, inputs.fastq2.path, ">", "aln.sai2", "&&",
+          "bwa", "sampe", "-r", "\"" + rg_str + "\"", inputs.fasta.path, "aln.sai1", "aln.sai2", inputs.fastq1.path, inputs.fastq2.path, "|",
+          "samtools", "view", "-Shb", "-o", outbam, "-"
+          ];
+          return cmd.join(' ')
+        }
+
+        function bwa_aln_64(rg_str, outbam) {
+          var cmd = [
+          "bwa", "aln", "-I","-t", inputs.thread_count, inputs.fasta.path, inputs.fastq1.path, ">", "aln.sai1", "&&",
+          "bwa", "aln", "-I", "-t", inputs.thread_count, inputs.fasta.path, inputs.fastq2.path, ">", "aln.sai2", "&&",
+          "bwa", "sampe", "-r", "\"" + rg_str + "\"", inputs.fasta.path, "aln.sai1", "aln.sai2", inputs.fastq1.path, inputs.fastq2.path, "|",
+          "samtools", "view", "-Shb", "-o", outbam, "-"
+          ];
+          return cmd.join(' ')
+        }
+
+        function bwa_mem(rg_str, outbam) {
+          var cmd = [
+          "bwa", "mem", "-t", inputs.thread_count, "-T", "0", "-R", "\"" + rg_str + "\"",
+          inputs.fasta.path, inputs.fastq1.path, inputs.fastq2.path, "|",
+          "samtools", "view", "-Shb", "-o", outbam, "-"
+          ];
+          return cmd.join(' ')
+        }
+
+        var MEM_ALN_CUTOFF = 70;
+        var fastqc_json = JSON.parse(inputs.fastqc_json_path.contents);
+        var readlength = fastqc_json[inputs.fastq1.basename]["Sequence length"];
+        var encoding = fastqc_json[inputs.fastq1.basename]["Encoding"];
+        var rg_str = to_rg();
+
+        var outbam = inputs.readgroup_json_path.basename.slice(0,-4) + "bam";
+        
+        if (encoding == "Illumina 1.3" || encoding == "Illumina 1.5") {
+          return bwa_aln_64(rg_str, outbam)
+        } else if (encoding == "Sanger / Illumina 1.9") {
+          if (readlength < MEM_ALN_CUTOFF) {
+            return bwa_aln_33(rg_str, outbam)
+          }
+          else {
+            return bwa_mem(rg_str, outbam)
+          }
+        } else {
+          return
+        }
+
+      }
+
+baseCommand: [bash, -c]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/bwa_se.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/bwa_se.cwl
@@ -1,0 +1,115 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/bwa:1
+  - class: ShellCommandRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: fastq
+    type: File
+    format: "edam:format_2182"
+
+  - id: fasta
+    type: File
+    format: "edam:format_1929"
+    secondaryFiles:
+      - .amb
+      - .ann
+      - .bwt
+      - .pac
+      - .sa
+
+  - id: readgroup_json_path
+    type: File
+    inputBinding:
+      loadContents: true
+      valueFrom: null
+
+  - id: fastqc_json_path
+    type: File
+    inputBinding:
+      loadContents: true
+      valueFrom: null
+
+  - id: thread_count
+    type: int
+
+outputs:
+  - id: OUTPUT
+    type: File
+    format: "edam:format_2572"
+    outputBinding:
+      glob: $(inputs.readgroup_json_path.basename.slice(0,-4) + "bam")
+
+arguments:
+  - valueFrom: |
+      ${
+        function to_rg() {
+          var readgroup_str = "@RG";
+          var readgroup_json = JSON.parse(inputs.readgroup_json_path.contents);
+          var keys = Object.keys(readgroup_json).sort();
+          for (var i = 0; i < keys.length; i++) {
+            var key = keys[i];
+            var value = readgroup_json[key];
+            readgroup_str = readgroup_str + "\\t" + key + ":" + value;
+          }
+          return readgroup_str
+        }
+
+        function bwa_aln_33(rg_str, outbam) {
+          var cmd = [
+          "bwa", "aln", "-t", inputs.thread_count, inputs.fasta.path, inputs.fastq.path, ">", "aln.sai", "&&",
+          "bwa", "samse", "-r", "\"" + rg_str + "\"", inputs.fasta.path, "aln.sai", inputs.fastq.path, "|",
+          "samtools", "view", "-Shb", "-o", outbam, "-"
+          ];
+          return cmd.join(' ')
+        }
+
+        function bwa_aln_64(rg_str, outbam) {
+          var cmd = [
+          "bwa", "aln", "-I","-t", inputs.thread_count, inputs.fasta.path, inputs.fastq.path, ">", "aln.sai", "&&",
+          "bwa", "samse", "-r", "\"" + rg_str + "\"", inputs.fasta.path, "aln.sai", inputs.fastq.path, "|",
+          "samtools", "view", "-Shb", "-o", outbam, "-"
+          ];
+          return cmd.join(' ')
+        }
+
+        function bwa_mem(rg_str, outbam) {
+          var cmd = [
+          "bwa", "mem", "-t", inputs.thread_count, "-T", "0", "-R", "\"" + rg_str + "\"",
+          inputs.fasta.path, inputs.fastq.path, "|",
+          "samtools", "view", "-Shb", "-o", outbam, "-"
+          ];
+          return cmd.join(' ')
+        }
+
+        var MEM_ALN_CUTOFF = 70;
+        var fastqc_json = JSON.parse(inputs.fastqc_json_path.contents);
+        var readlength = fastqc_json[inputs.fastq.basename]["Sequence length"];
+        var encoding = fastqc_json[inputs.fastq.basename]["Encoding"];
+        var rg_str = to_rg();
+
+        var outbam = inputs.readgroup_json_path.basename.slice(0,-4) + "bam";
+
+        if (encoding == "Illumina 1.3" || encoding == "Illumina 1.5") {
+          return bwa_aln_64(rg_str, outbam)
+        } else if (encoding == "Sanger / Illumina 1.9") {
+          if (readlength < MEM_ALN_CUTOFF) {
+            return bwa_aln_33(rg_str, outbam)
+          }
+          else {
+            return bwa_mem(rg_str, outbam)
+          }
+        } else {
+          return
+        }
+
+      }
+
+baseCommand: [bash, -c]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/cgquery_xml_to_bamlibrary_capture_json.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/cgquery_xml_to_bamlibrary_capture_json.cwl
@@ -1,0 +1,42 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/cgquery_xml_to_bamlibrary_capture_json
+  - class: InlineJavascriptRequirement
+  - class: ShellCommandRequirement
+
+class: CommandLineTool
+
+inputs:
+  []
+
+outputs:
+  - id: bam_libraryname_capturekey
+    type: File
+    outputBinding:
+      glob: "bam_libraryname_capturekey.json"
+
+  - id: tcga_multi_list
+    type: File
+    outputBinding:
+      glob: "phs000178_wxs_illumina_live_all_states_multi_capture_per_library"
+
+  - id: tcga_missing_list
+    type: File
+    outputBinding:
+      glob: "phs000178_wxs_illumina_live_all_states_no_capture_per_library"
+
+  - id: target_multi_list
+    type: File
+    outputBinding:
+      glob: "phs000218_phs0004_phs000515_wxs_illumina_live_all_states_multi_capture_per_library"
+
+  - id: target_missing_list
+    type: File
+    outputBinding:
+      glob: "phs000218_phs0004_phs000515_wxs_illumina_live_all_states_no_capture_per_library"
+
+baseCommand: ["tar", "xvf", "/cgquery_xml.tar.xz", "&&", "/usr/local/bin/cgquery_xml_to_bamlibrary_capture_json", "-t", "cgquery_xml/phs000178_wxs_illumina_live_all_states.xml", "-g", "cgquery_xml/phs000218_phs0004_phs000515_wxs_illumina_live_all_states.xml"]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/copy_files_to_dir.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/copy_files_to_dir.cwl
@@ -1,0 +1,58 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: ubuntu:xenial-20160923.1
+  - class: InlineJavascriptRequirement
+  - class: ShellCommandRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: fasta
+    type: File
+
+  - id: fasta_amb
+    type: File
+
+  - id: fasta_ann
+    type: File
+
+  - id: fasta_bwt
+    type: File
+
+  - id: fasta_fai
+    type: File
+
+  - id: fasta_pac
+    type: File
+
+  - id: fasta_sa
+    type: File
+
+outputs:
+  - id: output
+    type: File
+    outputBinding:
+      glob: $(inputs.fasta.basename)
+    secondaryFiles:
+      - .amb
+      - .ann
+      - .bwt
+      - .fai
+      - .pac
+      - .sa
+
+arguments:
+  - valueFrom: |
+      ${
+         var cmd = "cp " + inputs.fasta.path + " " +  inputs.fasta_amb.path + " " + inputs.fasta_ann.path + " "
+                         + inputs.fasta_bwt.path + " " + inputs.fasta_fai.path + " " + inputs.fasta_pac.path + " "
+                         + inputs.fasta_sa.path + " .";
+         return cmd
+      }
+    shellQuote: false
+
+baseCommand: []

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/curl.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/curl.cwl
@@ -1,0 +1,29 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/curl:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: output
+    type: string
+    inputBinding:
+      prefix: --output
+
+  - id: url
+    type: string
+    inputBinding:
+      prefix: --url
+
+outputs:
+  - id: output_file
+    type: File
+    outputBinding:
+      glob: $(inputs.output)
+      
+baseCommand: [curl]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/curl_pdc.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/curl_pdc.cwl
@@ -1,0 +1,37 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/curl:1
+  - class: EnvVarRequirement
+    envDef:
+      - envName: ftp_proxy
+        envValue: $(inputs.env_ftp_proxy)
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: env_ftp_proxy
+    type: string
+    default: http://cloud-proxy:3128
+
+  - id: output
+    type: string
+    inputBinding:
+      prefix: --output
+
+  - id: url
+    type: string
+    inputBinding:
+      prefix: --url
+
+outputs:
+  - id: output_file
+    type: File
+    outputBinding:
+      glob: $(inputs.output)
+      
+baseCommand: [curl]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/curl_simple.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/curl_simple.cwl
@@ -1,0 +1,26 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+class: CommandLineTool
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/curl:1
+  - class: InlineJavascriptRequirement
+
+inputs:
+  - id: url
+    type: string
+    inputBinding:
+      position: 1
+
+stdout: output
+
+outputs:
+  - id: output
+    type: File
+    outputBinding:
+      glob: output
+
+baseCommand: [curl]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/decider_bwa_expression.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/decider_bwa_expression.cwl
@@ -1,0 +1,91 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: InlineJavascriptRequirement
+
+class: ExpressionTool
+
+inputs:
+  - id: fastq_path
+    format: "edam:format_2182"
+    type:
+      type: array
+      items: File
+
+  - id: readgroup_path
+    format: "edam:format_3464"
+    type:
+      type: array
+      items: File
+
+outputs:
+  - id: output_readgroup_paths
+    format: "edam:format_3464"
+    type:
+      type: array
+      items: File
+
+expression: |
+   ${
+      function include(arr,obj) {
+        return (arr.indexOf(obj) != -1)
+      }
+
+      function endsWith(str, suffix) {
+        return str.indexOf(suffix, str.length - suffix.length) !== -1;
+      }
+
+      function local_basename(path) {
+        var basename = path.split(/[\\/]/).pop();
+        return basename
+      }
+
+      function local_dirname(path) {
+        return path.replace(/\\/g,'/').replace(/\/[^\/]*$/, '');
+      }
+
+      function get_slice_number(fastq_name) {
+        if (endsWith(fastq_name, '_1.fq.gz')) {
+          return -8
+        }
+        else if (endsWith(fastq_name, '_s.fq.gz')) {
+          return -8
+        }
+        else if (endsWith(fastq_name, '_o1.fq.gz')) {
+          return -9
+        }
+        else if (endsWith(fastq_name, '_o2.fq.gz')) {
+          return -9
+        }
+        else {
+          exit()
+        }
+      }
+      
+      // get predicted readgroup basenames from fastq
+      var readgroup_basename_array = [];
+      for (var i = 0; i < inputs.fastq_path.length; i++) {
+        var fq_path = inputs.fastq_path[i];
+        var fq_name = local_basename(fq_path.location);
+
+        var slice_number = get_slice_number(fq_name);
+        
+        var readgroup_name = fq_name.slice(0,slice_number) + ".json";
+        readgroup_basename_array.push(readgroup_name);
+      }
+
+      // find which readgroup items are in predicted basenames
+      var readgroup_array = [];
+      for (var i = 0; i < inputs.readgroup_path.length; i++) {
+        var readgroup_path = inputs.readgroup_path[i];
+        var readgroup_basename = local_basename(readgroup_path.location);
+        if (include(readgroup_basename_array, readgroup_basename)) {
+          readgroup_array.push(readgroup_path);
+        }
+      }
+
+      var readgroup_sorted = readgroup_array.sort(function(a,b) { return a.location > b.location ? 1 : (a.location < b.location ? -1 : 0) })
+      return {'output_readgroup_paths': readgroup_sorted}
+    }

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/decider_merge_readgroup_parts_expression.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/decider_merge_readgroup_parts_expression.cwl
@@ -1,0 +1,108 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: InlineJavascriptRequirement
+
+class: ExpressionTool
+
+inputs:
+  - id: readgroup_parts_1
+    format: "edam:format_2572"
+    type:
+      type: array
+      items: File
+
+  - id: readgroup_parts_2
+    format: "edam:format_2572"
+    type:
+      type: array
+      items: File
+
+outputs:
+  - id: to_merge
+    format: "edam:format_2572"
+    type:
+      items: array
+      type: array
+      items: File
+
+  - id: not_merge
+    format: "edam:format_2572"
+    type:
+      type: array
+      items: File
+
+
+expression: |
+   ${
+      function endsWith(str, suffix) {
+        return str.indexOf(suffix, str.length - suffix.length) !== -1;
+      }
+
+      function include(arr,obj) {
+        return (arr.indexOf(obj) != -1)
+      }
+
+      function getIntersection(a, b) {
+        var matches = [];
+        for ( var i = 0; i < a.length; i++ ) {
+          if (include(b,a[i])) matches.push(a[i]);
+        }
+        return matches
+      }
+
+      // a - b
+      function getDifference(a, b) {
+        var absence = [];
+        for (var i = 0; i < a.length; i++) {
+          if (!include(b,a[i])) absence.push(a[i]);
+        }
+        return absence
+      }
+
+      var basename_parts_1 = [];
+      for (var i = 0; i < inputs.readgroup_parts_1.length; i++) {
+        basename_parts_1.push(inputs.readgroup_parts_1[i].basename);
+      }
+      var basename_parts_2 = [];
+      for (var i = 0; i < inputs.readgroup_parts_2.length; i++) {
+        basename_parts_2.push(inputs.readgroup_parts_2[i].basename);
+      }
+
+      var to_merge_basename_parts = getIntersection(basename_parts_1, basename_parts_2);
+      var not_merge_basename_parts1 = getDifference(basename_parts_1, to_merge_basename_parts);
+      var not_merge_basename_parts2 = getDifference(basename_parts_2, to_merge_basename_parts);
+
+      var array_of_array = [];
+      for (var i = 0; i < to_merge_basename_parts.length; i++) {
+        var basename_part = to_merge_basename_parts[i];
+        var merge_array = [];
+        for (var j = 0; j < inputs.readgroup_parts_1.length; j++) {
+          if (basename_part == inputs.readgroup_parts_1[j].basename) {
+            merge_array.push(inputs.readgroup_parts_1[j]);
+          }
+        }
+        for (var j = 0; j < inputs.readgroup_parts_2.length; j++) {
+          if (basename_part == inputs.readgroup_parts_2[j].basename) {
+            merge_array.push(inputs.readgroup_parts_2[j]);
+          }
+        }
+        array_of_array.push(merge_array);
+      }
+
+      var not_merge = [];
+      for (var i = 0; i < not_merge_basename_parts1.length; i++) {
+        for (var j = 0; j < inputs.readgroup_parts_1.length; j++) {
+          if (not_merge_basename_parts1[i] == inputs.readgroup_parts_1[j].basename) not_merge.push(inputs.readgroup_parts_1[j]);
+        }
+      }
+      for (var i = 0; i < not_merge_basename_parts2.length; i++) {
+        for (var j = 0; j < inputs.readgroup_parts_2.length; j++) {
+          if (not_merge_basename_parts2[i] == inputs.readgroup_parts_2[j].basename) not_merge.push(inputs.readgroup_parts_2[j]);
+        }
+      }
+
+      return {'to_merge': array_of_array, 'not_merge': not_merge}
+    }

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/dnaseq_validation.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/dnaseq_validation.cwl
@@ -1,0 +1,34 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/dnaseq_validation
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: input_sqlite_metrics
+    type: File
+    inputBinding:
+      prefix: --input_sqlite_metrics
+
+  - id: input_json_expected_metrics
+    type: File
+    inputBinding:
+      prefix: --input_json_expected_metrics
+
+outputs:
+  - id: log
+    type: File
+    outputBinding:
+      glob: $("log.txt")
+
+  - id: results
+    type: File
+    outputBinding:
+      glob: $("results.json")
+
+baseCommand: [/usr/local/bin/dnaseq_validation]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/emit_file_string.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/emit_file_string.cwl
@@ -1,0 +1,25 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: InlineJavascriptRequirement
+
+class: ExpressionTool
+
+inputs:
+  - id: input
+    type: File
+    inputBinding:
+      loadContents: true
+      valueFrom: null
+
+outputs:
+  - id: output
+    type: string
+
+expression: |
+  ${
+    var output = inputs.input.contents;
+    return {'output': output}
+  }

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/envvar-global.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/envvar-global.cwl
@@ -1,0 +1,4 @@
+class: EnvVarRequirement
+envDef:
+  - envName: "PATH"
+    envValue: "/usr/local/bin/:/usr/bin:/bin"

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/fastq_remove_duplicate_qname.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/fastq_remove_duplicate_qname.cwl
@@ -1,0 +1,41 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/fastq_remove_duplicate_qname:1
+  - class: InlineJavascriptRequirement
+  - class: ShellCommandRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: INPUT
+    type: File
+    format: "edam:format_2182"
+
+outputs:
+  - id: OUTPUT
+    type: File
+    format: "edam:format_2182"
+    outputBinding:
+      glob: $(inputs.INPUT.basename)
+
+  - id: METRICS
+    type: File
+    outputBinding:
+      glob: "fastq_dup_rm.log"
+
+arguments:
+  - valueFrom: |
+      ${
+        var cmd = [
+        "zcat", inputs.INPUT.path, "|",
+        "/usr/local/bin/fastq_remove_duplicate_qname", "-", "|",
+        "gzip", "-", ">", inputs.INPUT.basename
+        ];
+        return cmd.join(' ')
+      }
+
+baseCommand: [bash, -c]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/fastqc.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/fastqc.cwl
@@ -1,0 +1,131 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/fastqc:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: adapters
+    type: ["null", File]
+    inputBinding:
+      prefix: --adapters
+
+  - id: casava
+    type: boolean
+    default: false
+    inputBinding:
+      prefix: --casava
+
+  - id: contaminants
+    type: ["null", File]
+    inputBinding:
+      prefix: --contaminants
+
+  - id: dir
+    type: string
+    default: .
+    inputBinding:
+      prefix: --dir
+
+  - id: extract
+    type: boolean
+    default: false
+    inputBinding:
+      prefix: --extract
+
+  - id: format
+    type: string
+    default: fastq
+    inputBinding:
+      prefix: --format
+
+  - id: INPUT
+    type: File
+    format: "edam:format_2182"
+    inputBinding:
+      position: 99
+
+  - id: kmers
+    type: ["null", File]
+    inputBinding:
+      prefix: --kmers
+
+  - id: limits
+    type: ["null", File]
+    inputBinding:
+      prefix: --limits
+
+  - id: nano
+    type: boolean
+    default: false
+    inputBinding:
+      prefix: --nano
+
+  - id: noextract
+    type: boolean
+    default: true
+    inputBinding:
+      prefix: --noextract
+
+  - id: nofilter
+    type: boolean
+    default: false
+    inputBinding:
+      prefix: --nofilter
+
+  - id: nogroup
+    type: boolean
+    default: false
+    inputBinding:
+      prefix: --nogroup
+
+  - id: outdir
+    type: string
+    default: .
+    inputBinding:
+      prefix: --outdir
+
+  - id: quiet
+    type: boolean
+    default: false
+    inputBinding:
+      prefix: --quiet
+
+  - id: threads
+    type: int
+    default: 1
+    inputBinding:
+      prefix: --threads
+
+outputs:
+  - id: OUTPUT
+    type: File
+    outputBinding:
+      glob: |
+        ${
+          function endsWith(str, suffix) {
+            return str.indexOf(suffix, str.length - suffix.length) !== -1;
+          }
+
+          var filename = inputs.INPUT.nameroot;
+
+          if ( endsWith(filename, '.fq') ) {
+            var nameroot = filename.slice(0,-3);
+          }
+          else if ( endsWith(nameroot, '.fastq') ) {
+            var nameroot = filename.slice(0,-6);
+          }
+          else {
+            var nameroot = filename;
+          }
+
+          var output = nameroot +"_fastqc.zip";
+          return output
+        }
+          
+baseCommand: [/usr/local/FastQC/fastqc]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/fastqc_basicstatistics_json.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/fastqc_basicstatistics_json.cwl
@@ -1,0 +1,24 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/fastqc_to_json:1
+
+class: CommandLineTool
+
+inputs:
+  - id: sqlite_path
+    type: File
+    inputBinding:
+      prefix: --sqlite_path
+
+outputs:
+  - id: OUTPUT
+    type: File
+    outputBinding:
+      glob: "fastqc.json"
+
+baseCommand: [/usr/local/bin/fastqc_to_json]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/fastqc_db.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/fastqc_db.cwl
@@ -1,0 +1,35 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/fastqc_db:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: INPUT
+    type: File
+    inputBinding:
+      prefix: --INPUT
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+outputs:
+  - id: LOG
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid + ".log")
+
+  - id: OUTPUT
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".db")
+
+          
+baseCommand: [/usr/local/bin/fastqc_db]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/gatk_baserecalibrator.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/gatk_baserecalibrator.cwl
@@ -1,0 +1,165 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/cocleaning-tool:3.7
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: binary_tag_name
+    type: ["null", string]
+    inputBinding:
+      prefix: --binary_tag_name
+
+  - id: bqsrBAQGapOpenPenalty
+    type: double
+    default: 40
+    inputBinding:
+      prefix: --bqsrBAQGapOpenPenalty
+
+  - id: covariate
+    type: ["null", string]
+    inputBinding:
+      prefix: --covariate
+
+  - id: deletions_default_quality
+    type: int
+    default: 45
+    inputBinding:
+      prefix: --deletions_default_quality
+
+  - id: indels_context_size
+    type: int
+    default: 3
+    inputBinding:
+      prefix: --indels_context_size
+
+  - id: input_file
+    #format: "edam:format_2572"
+    type: File
+    inputBinding:
+      prefix: --input_file
+    secondaryFiles:
+      - ^.bai
+
+  - id: insertions_default_quality
+    type: int
+    default: 45
+    inputBinding:
+      prefix: --insertions_default_quality
+
+  - id: knownSites
+    #format: "edam:format_3016"
+    type: File
+    inputBinding:
+      prefix: --knownSites
+    secondaryFiles:
+      - .tbi
+
+  - id: list
+    type: boolean
+    default: false
+    inputBinding:
+      prefix: --list
+
+  - id: log_to_file
+    type: string
+    inputBinding:
+      prefix: --log_to_file
+
+  - id: --logging_level
+    default: INFO
+    type: string
+    inputBinding:
+      prefix: --logging_level
+
+  - id: low_quality_tail
+    type: int
+    default: 2
+    inputBinding:
+      prefix: --low_quality_tail
+
+  - id: lowMemoryMode
+    type: boolean
+    default: false
+    inputBinding:
+      prefix: --lowMemoryMode
+
+  - id: maximum_cycle_value
+    type: int
+    default: 500
+    inputBinding:
+      prefix: --maximum_cycle_value
+
+  - id: mismatches_context_size
+    type: int
+    default: 2
+    inputBinding:
+      prefix: --mismatches_context_size
+
+  - id: mismatches_default_quality
+    type: int
+    default: -1
+    inputBinding:
+      prefix: --mismatches_default_quality
+
+  - id: no_standard_covs
+    type: boolean
+    default: false
+    inputBinding:
+      prefix: --no_standard_covs
+
+  - id: num_cpu_threads_per_data_thread
+    type: int
+    default: 1
+    inputBinding:
+      prefix: --num_cpu_threads_per_data_thread
+
+  - id: --quantizing_levels
+    type: int
+    default: 16
+    inputBinding:
+      prefix: --quantizing_levels
+
+  - id: run_without_dbsnp_potentially_ruining_quality
+    type: boolean
+    default: false
+    inputBinding:
+      prefix: --run_without_dbsnp_potentially_ruining_quality
+
+  - id: sort_by_all_columns
+    type: boolean
+    default: false
+    inputBinding:
+      prefix: --sort_by_all_columns
+
+  - id: reference_sequence
+    #format: "edam:format_1929"
+    type: File
+    inputBinding:
+      prefix: --reference_sequence
+    secondaryFiles:
+      - .fai
+      - ^.dict
+
+outputs:
+  - id: output_grp
+    type: File
+    outputBinding:
+      glob: $(inputs.input_file.nameroot + "_bqsr.grp")
+
+  - id: output_log
+    type: File
+    outputBinding:
+      glob: $(inputs.log_to_file)
+
+arguments:
+  - valueFrom: $(inputs.input_file.nameroot + "_bqsr.grp")
+    prefix: --out
+    separate: true
+
+baseCommand: [java, -jar, /usr/local/bin/GenomeAnalysisTK.jar, -T, BaseRecalibrator]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/gatk_contest.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/gatk_contest.cwl
@@ -1,0 +1,78 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/cocleaning-tool:3.7
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: base_report
+    type: ["null", string]
+    inputBinding:
+      prefix: --base_report
+
+  - id: beta_threshold
+    type: double
+    default: 0.95
+    inputBinding:
+      prefix: --beta_threshold
+
+  - id: genotype_mode
+    type: string
+    default: HARD_THRESHOLD
+    inputBinding:
+      prefix: --genotype_mode
+
+  - id: genotypes
+    type: ["null", File]
+    #format: "edam:format_3016"
+    inputBinding:
+      prefix: --genotypes
+
+  - id: INPUT
+    type: File
+    #format: "edam:format_2572"
+    inputBinding:
+      prefix: -I
+    secondaryFiles:
+      - ^.bai
+
+  - id: lane_level_contamination
+    type: string
+    default: META
+    inputBinding:
+      prefix: --lane_level_contamination
+
+  - id: out
+    type: string
+    inputBinding:
+      prefix: --out
+
+  - id: popfile
+    type: File
+    #format: "edam:format_3016"
+    inputBinding:
+      prefix: --popfile
+    secondaryFiles:
+      - .tbi
+
+  - id: REFERENCE_SEQUENCE
+    type: File
+    #format: "edam:format_1929"
+    inputBinding:
+      prefix: -R
+    secondaryFiles:
+      - .fai
+      - ^.dict
+
+outputs:
+  - id: OUTPUT
+    type: File
+    outputBinding:
+      glob: $(inputs.out)
+
+baseCommand: [java, -jar, /usr/local/bin/GenomeAnalysisTK.jar, -T, ContEst]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/gatk_indelrealigner.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/gatk_indelrealigner.cwl
@@ -1,0 +1,140 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: draft-3
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/cocleaning-tool:3.7
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: consensusDeterminationModel
+    type: string
+    default: USE_READS
+    inputBinding:
+      prefix: --consensusDeterminationModel
+
+  - id: entropyThreshold
+    type: double
+    default: 0.15
+    inputBinding:
+      prefix: --entropyThreshold
+
+  - id: input_file
+    #format: "edam:format_2572"
+    type:
+      type: array
+      items: File
+      inputBinding:
+        prefix: --input_file
+      secondaryFiles:
+        - ^.bai
+
+  - id: knownAlleles
+    #format: "edam:format_3016"
+    type: File
+    inputBinding:
+      prefix: --knownAlleles
+    secondaryFiles:
+      - .tbi
+
+  - id: log_to_file
+    type: string
+    inputBinding:
+      prefix: --log_to_file
+
+  - id: --logging_level
+    default: INFO
+    type: string
+    inputBinding:
+      prefix: --logging_level
+
+  - id: LODThresholdForCleaning
+    type: double
+    default: 5.0
+    inputBinding:
+      prefix: --LODThresholdForCleaning
+
+  - id: maxConsensuses
+    type: int
+    default: 30
+    inputBinding:
+      prefix: --maxConsensuses
+
+  - id: maxIsizeForMovement
+    type: int
+    default: 3000
+    inputBinding:
+      prefix: --maxIsizeForMovement
+
+  - id: maxPositionalMoveAllowed
+    type: int
+    default: 200
+    inputBinding:
+      prefix: --maxPositionalMoveAllowed
+
+  - id: maxReadsForConsensuses
+    type: int
+    default: 120
+    inputBinding:
+      prefix: --maxReadsForConsensuses
+
+  - id: maxReadsForRealignment
+    type: int
+    default: 20000
+    inputBinding:
+      prefix: --maxReadsForRealignment
+
+  - id: maxReadsInMemory
+    type: int
+    default: 150000
+    inputBinding:
+      prefix: --maxReadsInMemory
+
+  - id: noOriginalAlignmentTags
+    type: boolean
+    default: true
+    inputBinding:
+      prefix: --noOriginalAlignmentTags
+
+  - id: nWayOut
+    type: string
+    default: ".bam"
+    inputBinding:
+      prefix: --nWayOut
+
+  - id: reference_sequence
+    #format: "edam:format_1929"
+    type: File
+    inputBinding:
+      prefix: --reference_sequence
+    secondaryFiles:
+      - ^.dict
+      - .fai
+
+  - id: targetIntervals
+    type: File
+    inputBinding:
+      prefix: --targetIntervals
+
+outputs:
+  - id: output_bam
+    #format: "edam:format_2572"
+    type:
+      type: array
+      items: File
+    outputBinding:
+      glob: "*.bam"
+      outputEval: |
+        ${ return self.sort(function(a,b) { return a.location > b.location ? 1 : (a.location < b.location ? -1 : 0) }) }
+    secondaryFiles:
+      - ^.bai
+
+  - id: output_log
+    type: File
+    outputBinding:
+      glob: $(inputs.log_to_file)
+
+baseCommand: [java, -jar, /usr/local/bin/GenomeAnalysisTK.jar, -T, IndelRealigner]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/gatk_printreads.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/gatk_printreads.cwl
@@ -1,0 +1,103 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/cocleaning-tool:3.7
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: BQSR
+    type: ["null", File]
+    inputBinding:
+      prefix: --BQSR
+
+  - id: input_file
+    #format: "edam:format_2572"
+    type: File
+    inputBinding:
+      prefix: --input_file
+    secondaryFiles:
+      - ^.bai
+
+  - id: log_to_file
+    type: string
+    inputBinding:
+      prefix: --log_to_file
+
+  - id: --logging_level
+    default: INFO
+    type: string
+    inputBinding:
+      prefix: --logging_level
+
+  - id: num_cpu_threads_per_data_thread
+    type: int
+    default: 1
+    inputBinding:
+      prefix: --num_cpu_threads_per_data_thread
+
+  - id: number
+    type: int
+    default: -1
+    inputBinding:
+      prefix: --number
+    
+  - id: platform
+    type: ["null", string]
+    inputBinding:
+      prefix: --platform
+
+  - id: readGroup
+    type: ["null", string]
+    inputBinding:
+      prefix: --readGroup
+
+  - id: reference_sequence
+    #format: "edam:format_1929"
+    type: File
+    inputBinding:
+      prefix: --reference_sequence
+    secondaryFiles:
+      - .fai
+      - ^.dict
+
+  - id: sample_file
+    type: ["null", string]
+    inputBinding:
+      prefix: --sample_file
+
+  - id: sample_name
+    type: ["null", string]
+    inputBinding:
+      prefix: --sample_name
+
+  - id: simplify
+    type: boolean
+    default: false
+    inputBinding:
+      prefix: --simplify
+
+outputs:
+  - id: output_bam
+    #format: "edam:format_2572"
+    type: File
+    outputBinding:
+      glob: $(inputs.input_file.basename)
+    secondaryFiles:
+      - ^.bai
+
+  - id: output_log
+    type: File
+    outputBinding:
+      glob: $(inputs.log_to_file)
+
+arguments:
+  - valueFrom: $(inputs.input_file.basename)
+    prefix: --out
+    separate: true
+
+baseCommand: [java, -jar, /usr/local/bin/GenomeAnalysisTK.jar, -T, PrintReads]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/gatk_realignertargetcreator.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/gatk_realignertargetcreator.cwl
@@ -1,0 +1,97 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: draft-3
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/cocleaning-tool:3.7
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: input_file
+    #format: "edam:format_2572"
+    type:
+      type: array
+      items: File
+      inputBinding:
+        prefix: --input_file
+      secondaryFiles:
+        - ^.bai
+
+  - id: known
+    #format: "edam:format_3016"
+    type: File
+    inputBinding:
+      prefix: --known
+    secondaryFiles:
+      - .tbi
+
+  - id: log_to_file
+    type: string
+    inputBinding:
+      prefix: --log_to_file
+
+  - id: --logging_level
+    default: INFO
+    type: string
+    inputBinding:
+      prefix: --logging_level
+
+  - id: maxIntervalSize
+    type: int
+    default: 500
+    inputBinding:
+      prefix: --maxIntervalSize
+
+  - id: minReadsAtLocus
+    type: int
+    default: 4
+    inputBinding:
+      prefix: --minReadsAtLocus
+
+  - id: mismatchFraction
+    type: double
+    default: 0.0
+    inputBinding:
+      prefix: --mismatchFraction
+
+  - id: out
+    type: string
+    inputBinding:
+      prefix: --out
+
+  - id: num_threads
+    type: int
+    default: 1
+    inputBinding:
+      prefix: --num_threads
+
+  - id: windowSize
+    type: int
+    default: 10
+    inputBinding:
+      prefix: --windowSize
+
+  - id: reference_sequence
+    #format: "edam:format_1929"
+    type: File
+    inputBinding:
+      prefix: --reference_sequence
+    secondaryFiles:
+      - ^.dict
+      - .fai
+
+outputs:
+  - id: output_intervals
+    type: File
+    outputBinding:
+      glob: $(inputs.out)
+
+  - id: output_log
+    type: File
+    outputBinding:
+      glob: $(inputs.log_to_file)
+
+baseCommand: [java, -jar, /usr/local/bin/GenomeAnalysisTK.jar, -T, RealignerTargetCreator]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/gdc_bed_liftover.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/gdc_bed_liftover.cwl
@@ -1,0 +1,34 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/gdc_bed_liftover
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  []
+
+outputs:
+  - id: BAIT_INTERVAL_LIST
+    type:
+      type: array
+      items: File
+    outputBinding:
+      glob: "*.baitIntervals.hg38.list.xz"
+      outputEval: |
+        ${ return self.sort(function(a,b) { return a.location > b.location ? 1 : (a.location < b.location ? -1 : 0) }) }
+
+  - id: TARGET_INTERVAL_LIST
+    type:
+      type: array
+      items: File
+    outputBinding:
+      glob: "*.targetIntervals.hg38.list.xz"
+      outputEval: |
+        ${ return self.sort(function(a,b) { return a.location > b.location ? 1 : (a.location < b.location ? -1 : 0) }) }
+
+baseCommand: [/usr/local/bin/main.sh]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/generate_load_token.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/generate_load_token.cwl
@@ -1,0 +1,38 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+class: CommandLineTool
+requirements:
+  - class: DockerRequirement
+    dockerPull: ubuntu:xenial-20161010
+
+inputs:
+  - id: load1
+    type: ["null", File]
+
+  - id: load2
+    type: ["null", File]
+
+  - id: load3
+    type: ["null", File]
+
+  - id: load4
+    type: ["null", File]
+
+  - id: load5
+    type: ["null", File]
+
+  - id: load6
+    type: ["null", File]
+
+  - id: load7
+    type: ["null", File]
+
+outputs:
+  - id: token
+    type: File
+    outputBinding:
+      glob: "token"
+    
+baseCommand: [touch, token]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/generate_s3load_path.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/generate_s3load_path.cwl
@@ -1,0 +1,28 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: InlineJavascriptRequirement
+
+class: ExpressionTool
+
+inputs:
+  - id: load_bucket
+    type: string
+
+  - id: filename
+    type: string
+
+  - id: uuid
+    type: string
+
+outputs:
+  - id: output
+    type: string
+
+expression: |
+  ${
+    var output = inputs.load_bucket + "/" + inputs.uuid + "/" + inputs.filename;
+    return {'output': output}
+  }

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_bait_target.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_bait_target.cwl
@@ -1,0 +1,37 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/gdc_bam_library_exomekit
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: exome_kit
+    type: File
+    inputBinding:
+      loadContents: true
+      valueFrom: null
+
+outputs:
+  - id: bait
+    type: File
+    outputBinding:
+      glob: "*bait*"
+
+  - id: target
+    type: File
+    outputBinding:
+      glob: "*target*"
+
+arguments:
+  - valueFrom: |
+      ${
+      var cmd="exec(\"import lzma; import json; import subprocess\\nwith open('/usr/local/share/bait_target_key_interval.json') as data_file: data = json.load(data_file)\\nbait = data['bait']['" + inputs.exome_kit.contents.slice(0,-1) + "']\\ncmd=['unxz', '-c', '/usr/local/share/intervals/' + bait + '.xz', '>', bait]\\nshell_cmd=' '.join(cmd)\\nsubprocess.check_output(shell_cmd,shell=True)\\ntarget = data['target']['" + inputs.exome_kit.contents.slice(0,-1) + "']\\ncmd=['unxz', '-c', '/usr/local/share/intervals/' + target + '.xz', '>', target]\\nshell_cmd=' '.join(cmd)\\nsubprocess.check_output(shell_cmd,shell=True)\")";
+      return cmd
+      }
+
+baseCommand: [python3, -c]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_bam_exome_kit.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_bam_exome_kit.cwl
@@ -1,0 +1,39 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/gdc_bam_library_exomekit
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: bam
+    type: string
+
+  - id: library
+    type: File
+    inputBinding:
+      loadContents: true
+      valueFrom: null
+
+outputs:
+  - id: exome_kit
+    type:
+      type: array
+      item: File
+    outputBinding:
+      glob: $(inputs.library.basename + ".kit")
+
+stdout: $(inputs.library.basename + ".kit")
+
+arguments:
+  - valueFrom: |
+      ${
+      var cmd = "exec(\"import json\\nwith open('/usr/local/share/bam_libraryname_capturekey.json') as data_file: data = json.load(data_file)\\nprint(data['" + inputs.bam + "']['" + inputs.library.contents.slice(0,-1) + "'])\")";
+      return cmd
+      }
+
+baseCommand: [python3, -c]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_bam_library.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_bam_library.cwl
@@ -1,0 +1,71 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: ubuntu:xenial-20160809
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: readgroups
+    type: File
+    inputBinding:
+      loadContents: true
+      valueFrom: null
+
+outputs:
+  - id: library
+    type: File
+    outputBinding:
+      glob: $(inputs.readgroups.basename + ".library")
+
+arguments:
+  - valueFrom: |
+      ${
+        function contains(array_in, item) {
+          for (var i = 0; i < array_in.length; i++) {
+            if(array_in[i] == item) return true;
+          }
+          return false
+        }
+      
+        function get_unique_array(array_in) {
+          var arr = []
+          for (var i = 0; i < array_in.length; i++) {
+            if (!contains(arr, array_in[i])) {
+              arr.push(array_in[i]);
+            }
+          }
+          return arr
+        }
+      
+        var lines = inputs.readgroups.contents.split('\n');
+        var library_name_array = [];
+        for (var i = 0; i < lines.length; i++) {
+          var items = lines[i].replace("@RG\t", "");
+          var items_array = items.split("\t");
+          for (var j = 0; j < items_array.length; j++) {
+            var item = items_array[j];
+            var key = item.split(":")[0];
+            var value = item.split(":")[1];
+            if (key == "LB") {
+              library_name_array.push(value);
+            }
+          }
+        }
+
+        var uniq_arr = get_unique_array(library_name_array);
+        if (uniq_arr.length == 1) {
+          return uniq_arr[0]
+        }
+        else {
+          exit
+        }
+      }
+
+stdout: $(inputs.readgroups.basename + ".library")
+
+baseCommand: [echo]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_bam_readgroups.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_bam_readgroups.cwl
@@ -1,0 +1,32 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/samtools:1
+  - class: InlineJavascriptRequirement
+  - class: ShellCommandRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: bam
+    format: "edam:format_2572"
+    type: File
+    inputBinding:
+      position: 0
+
+outputs:
+  - id: readgroups
+    type: File
+    outputBinding:
+      glob: $(inputs.bam.basename + ".readgroups")
+
+stdout: $(inputs.bam.basename + ".readgroups")
+
+arguments:
+  - valueFrom: $(["/usr/local/bin/samtools", "view", "-H", inputs.bam.path, "|", "grep", '^@RG'].join(' '))
+    shellQuote: true
+
+baseCommand: [bash, -c]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_file_from_array.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_file_from_array.cwl
@@ -1,0 +1,42 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: InlineJavascriptRequirement
+
+class: ExpressionTool
+
+inputs:
+  - id: filearray
+    type:
+      type: array
+      items: File
+
+  - id: filename
+    type: string
+
+outputs:
+  - id: output
+    type: File
+
+expression: |
+   ${
+      function include(arr,obj) {
+        return (arr.indexOf(obj) != -1)
+      }
+
+      function local_basename(path) {
+        var basename = path.split(/[\\/]/).pop();
+        return basename
+      }
+
+      // get filepath using filename
+      for (var i = 0; i < inputs.filearray.length; i++) {
+        var this_file = inputs.filearray[i];
+        var this_basename = local_basename(this_file.location);
+        if (include(inputs.filename, this_basename)) {
+          return {'output' : this_file }
+        }
+      }
+    }

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_host_ipaddress.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_host_ipaddress.cwl
@@ -1,0 +1,18 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+class: CommandLineTool
+
+inputs:
+  []
+
+outputs:
+  - id: output
+    type: File
+    outputBinding:
+      glob: output
+
+stdout: output
+
+baseCommand: [bash, -c, "printf %s $(ip addr list eth0 | grep 'inet ' | cut -d' ' -f6 | cut -d/ -f1)"]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_host_mac.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_host_mac.cwl
@@ -1,0 +1,18 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+class: CommandLineTool
+
+inputs:
+  []
+
+outputs:
+  - id: output
+    type: File
+    outputBinding:
+      glob: output
+
+stdout: output
+
+baseCommand: [bash, -c, "printf %s $(ip addr list eth0 | grep 'link/ether' | cut -d' ' -f6 | cut -d/ -f1)"]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_hostname.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_hostname.cwl
@@ -1,0 +1,18 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+class: CommandLineTool
+
+inputs:
+  []
+
+outputs:
+  - id: output
+    type: File
+    outputBinding:
+      glob: output
+
+stdout: output
+
+baseCommand: [bash, -c, printf %s $(hostname)]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_signpost_json.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_signpost_json.cwl
@@ -1,0 +1,42 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+class: CommandLineTool
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/curl:1
+  - class: InlineJavascriptRequirement
+
+inputs:
+  - id: signpost_id
+    type: string
+
+  - id: base_url
+    type: string
+
+stdout: output.json
+
+outputs:
+  - id: output
+    type: File
+    outputBinding:
+      glob: output.json
+
+arguments:
+  - valueFrom: |
+      ${
+         function endsWith(str, suffix) {
+           return str.indexOf(suffix, str.length - suffix.length) !== -1;
+         }
+         if ( endsWith(inputs.base_url, '/') ) {
+           return inputs.base_url + inputs.signpost_id;
+         }
+         else {
+           return inputs.base_url + '/' + inputs.signpost_id;
+         }
+      }
+    position: 0
+
+baseCommand: [curl]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_uuid.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/get_uuid.cwl
@@ -1,0 +1,22 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: python:3.6.0-slim
+
+class: CommandLineTool
+
+inputs:
+  []
+
+outputs:
+  - id: uuid
+    type: File
+    outputBinding:
+      glob: uuid
+
+stdout: uuid
+
+baseCommand: [bash, -c, python3 -c 'import uuid; import sys; sys.stdout.write(str(uuid.uuid4()));']

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/integrity_to_sqlite.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/integrity_to_sqlite.cwl
@@ -1,0 +1,49 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/integrity_to_sqlite:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: input_state
+    type: string
+    inputBinding:
+      prefix: "--input_state"
+
+  - id: ls_l_path
+    type: File
+    inputBinding:
+      prefix: "--ls_l_path"
+
+  - id: md5sum_path
+    type: File
+    inputBinding:
+      prefix: "--md5sum_path"
+
+  - id: sha256sum_path
+    type: File
+    inputBinding:
+      prefix: "--sha256sum_path"
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: "--uuid"
+
+outputs:
+  - id: LOG
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid + ".log")
+
+  - id: OUTPUT
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid + ".db")
+
+baseCommand: [/usr/local/bin/integrity_to_sqlite]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/ls_l.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/ls_l.cwl
@@ -1,0 +1,26 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: ubuntu:xenial-20161010
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: INPUT
+    type: File
+    inputBinding:
+      position: 0
+
+outputs:
+  - id: OUTPUT
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".ls")
+
+stdout: $(inputs.INPUT.nameroot + ".ls")
+      
+baseCommand: [ls, -l]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/md5sum.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/md5sum.cwl
@@ -1,0 +1,26 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: ubuntu:xenial-20161010
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: INPUT
+    type: File
+    inputBinding:
+      position: 0
+
+outputs:
+  - id: OUTPUT
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".md5")
+
+stdout: $(inputs.INPUT.nameroot + ".md5")
+      
+baseCommand: [md5sum]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/merge_sqlite.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/merge_sqlite.cwl
@@ -1,0 +1,38 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/merge_sqlite:3
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: source_sqlite
+    format: "edam:format_3621"
+    type:
+      type: array
+      items: File
+      inputBinding:
+        prefix: "--source_sqlite"
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: "--uuid"
+
+outputs:
+  - id: destination_sqlite
+    format: "edam:format_3621"
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid + ".db")
+
+  - id: log
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid + ".log")
+
+baseCommand: [/usr/local/bin/merge_sqlite]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_buildbamindex.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_buildbamindex.cwl
@@ -1,0 +1,45 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/picard:1
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: $(inputs.INPUT.basename)
+        entry: $(inputs.INPUT)
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: INPUT
+    type: File
+    format: "edam:format_2572"
+    inputBinding:
+      prefix: INPUT=
+      separate: false
+
+  - id: VALIDATION_STRINGENCY
+    type: string
+    default: STRICT
+    inputBinding:
+      prefix: VALIDATION_STRINGENCY=
+      separate: false
+
+outputs:
+  - id: OUTPUT
+    type: File
+    format: "edam:format_2572"
+    outputBinding:
+      glob: $(inputs.INPUT.basename)
+    secondaryFiles:
+      - ^.bai
+
+arguments:
+  - valueFrom: $(inputs.INPUT.nameroot + ".bai")
+    prefix: OUTPUT=
+    separate: false
+
+baseCommand: [java, -jar, /usr/local/bin/picard.jar, BuildBamIndex]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_calculatehsmetrics.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_calculatehsmetrics.cwl
@@ -1,0 +1,68 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: "cwl:draft-3"
+
+description: |
+  Usage:  cwl-runner <this-file-path> ...
+  Options:
+    --input_bam      Generate metrics from BAM file
+    --reference      Genome for metrics
+    --uuid           UUID for log file and sqlite db file
+
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/picard_tool
+
+class: CommandLineTool
+
+inputs:
+  - id: bam_path
+    type: File
+    inputBinding:
+      prefix: --bam_path
+
+  - id: readgroup_json_path
+    type: File
+    inputBinding:
+      prefix: --readgroup_json_path
+
+  - id: bam_library_kit_json_path
+    type: File
+    inputBinding:
+      prefix: --bam_library_kit_json_path
+
+  - id: orig_bam_name
+    type: string
+    inputBinding:
+      prefix: --outbam_name
+
+  - id: reference_fasta_path
+    type: File
+    inputBinding:
+      prefix: --reference_fasta_path
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: --uuid
+      
+outputs:
+  - id: log
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid + "_picard_CalculateHsMetrics_gdc.log")
+
+  - id: hs_metrics
+    type: File
+    outputBinding:
+      glob: $("picard_calculatehsmetrics_"+ inputs.bam_path.path.split('/').slice(-1)[0].slice(0,-4))
+
+  - id: output_sqlite
+    type: File
+    description: "sqlite file"
+    outputBinding:
+      glob: $(inputs.uuid + ".db")
+
+
+baseCommand: ["/home/ubuntu/.virtualenvs/p3/bin/python", "/home/ubuntu/.virtualenvs/p3/lib/python3.4/site-packages/picard_tool/main.py", "--tool_name", "CalculateHsMetrics_gdc"]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collectalignmentsummarymetrics.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collectalignmentsummarymetrics.cwl
@@ -1,0 +1,59 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/picard
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: INPUT
+    type: File
+    format: "edam:format_2572"
+    inputBinding:
+      prefix: INPUT=
+      separate: false
+
+  - id: METRIC_ACCUMULATION_LEVEL
+    type: string
+    default: ALL_READS
+    inputBinding:
+      prefix: METRIC_ACCUMULATION_LEVEL=
+      separate: false
+
+  - id: REFERENCE_SEQUENCE
+    type: ["null", File]
+    format: "edam:format_1929"
+    inputBinding:
+      prefix: REFERENCE_SEQUENCE=
+      separate: false
+
+  - id: TMP_DIR
+    type: string
+    default: .
+    inputBinding:
+      prefix: TMP_DIR=
+      separate: false
+
+  - id: VALIDATION_STRINGENCY=
+    type: string
+    default: STRICT
+    inputBinding:
+      prefix: VALIDATION_STRINGENCY=
+      separate: false
+
+outputs:
+  - id: OUTPUT
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.basename + ".metrics")
+
+arguments:
+  - valueFrom: $(inputs.INPUT.basename + ".metrics")
+    prefix: OUTPUT=
+    separate: false
+
+baseCommand: [java, -jar, /usr/local/bin/picard.jar, CollectAlignmentSummaryMetrics]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collectalignmentsummarymetrics_to_sqlite.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collectalignmentsummarymetrics_to_sqlite.cwl
@@ -1,0 +1,49 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/picard_metrics_sqlite:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: bam
+    type: string
+    inputBinding:
+      prefix: --bam
+
+  - id: fasta
+    type: ["null", string]
+    inputBinding:
+      prefix: --fasta
+
+  - id: input_state
+    type: string
+    inputBinding:
+      prefix: --input_state
+
+  - id: metric_path
+    type: File
+    inputBinding:
+      prefix: --metric_path
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+outputs:
+  - id: log
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid+"_picard_CollectAlignmentSummaryMetrics.log")
+
+  - id: sqlite
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid + ".db")
+
+baseCommand: [/usr/local/bin/picard_metrics_sqlite, --metric_name, CollectAlignmentSummaryMetrics]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collecthsmetrics.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collecthsmetrics.cwl
@@ -1,0 +1,132 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/picard:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: BAIT_INTERVALS
+    type: File
+    inputBinding:
+      prefix: BAIT_INTERVALS=
+      separate: false
+
+  - id: BAIT_SET_NAME
+    type: ["null", string]
+    inputBinding:
+      prefix: BAIT_SET_NAME=
+      separate: false
+
+  - id: CLIP_OVERLAPPING_READS
+    type: string
+    default: "true"
+    inputBinding:
+      prefix: CLIP_OVERLAPPING_READS=
+      separate: false
+
+  - id: COVERAGE_CAP
+    type: int
+    default: 200
+    inputBinding:
+      prefix: COVERAGE_CAP=
+      separate: false
+
+  - id: INPUT
+    type: File
+    format: "edam:format_2572"
+    inputBinding:
+      prefix: INPUT=
+      separate: false
+
+  - id: METRIC_ACCUMULATION_LEVEL
+    type: string
+    default: ALL_READS
+    inputBinding:
+      prefix: METRIC_ACCUMULATION_LEVEL=
+      separate: false
+
+  - id: MINIMUM_BASE_QUALITY
+    type: int
+    default: 20
+    inputBinding:
+      prefix: MINIMUM_BASE_QUALITY=
+      separate: false
+
+  - id: MINIMUM_MAPPING_QUALITY
+    type: int
+    default: 20
+    inputBinding:
+      prefix: MINIMUM_MAPPING_QUALITY=
+      separate: false
+
+  - id: NEAR_DISTANCE
+    type: int
+    default: 250
+    inputBinding:
+      prefix: NEAR_DISTANCE=
+      separate: false
+
+  - id: OUTPUT
+    type: string
+    inputBinding:
+      prefix: OUTPUT=
+      separate: false
+
+  - id: PER_BASE_COVERAGE
+    type: ["null", File]
+    inputBinding:
+      prefix: PER_BASE_COVERAGE=
+      separate: false
+
+  - id: PER_TARGET_COVERAGE
+    type: ["null", File]
+    inputBinding:
+      prefix: PER_TARGET_COVERAGE=
+      separate: false
+
+  - id: REFERENCE_SEQUENCE
+    type: File
+    format: "edam:format_1929"
+    inputBinding:
+      prefix: REFERENCE_SEQUENCE=
+      separate: false
+    secondaryFiles:
+      - .fai
+
+  - id: SAMPLE_SIZE
+    type: int
+    default: 10000
+    inputBinding:
+      prefix: SAMPLE_SIZE=
+      separate: false
+
+  - id: TARGET_INTERVALS
+    type: File
+    inputBinding:
+      prefix: TARGET_INTERVALS=
+      separate: false
+
+  - id: VALIDATION_STRINGENCY
+    default: STRICT
+    type: string
+    inputBinding:
+      prefix: VALIDATION_STRINGENCY=
+      separate: false
+
+outputs:
+  - id: METRIC_OUTPUT
+    type: File
+    outputBinding:
+      glob: $(inputs.OUTPUT)
+
+# arguments:
+#   - valueFrom: $(inputs.INPUT.nameroot + ".metrics")
+#     prefix: "OUTPUT="
+#     separate: false
+
+baseCommand: [java, -jar, /usr/local/bin/picard.jar, CollectHsMetrics]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collecthsmetrics_to_sqlite.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collecthsmetrics_to_sqlite.cwl
@@ -1,0 +1,63 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/picard_metrics_sqlite:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: bam
+    type: string
+    inputBinding:
+      prefix: --bam
+
+  - id: bam_library
+    type: File
+    inputBinding:
+      loadContents: true
+      prefix: --bam_library
+      valueFrom: $(self.contents.slice(0,-1))
+
+  - id: exome_kit
+    type: File
+    inputBinding:
+      loadContents: true
+      prefix: --exome_kit
+      valueFrom: $(self.contents.slice(0,-1))
+
+  - id: fasta
+    type: string
+    inputBinding:
+      prefix: --fasta
+
+  - id: input_state
+    type: string
+    inputBinding:
+      prefix: --input_state
+
+  - id: metric_path
+    type: File
+    inputBinding:
+      prefix: --metric_path
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+outputs:
+  - id: log
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid+"_picard_CollectHsMetrics.log")
+
+  - id: sqlite
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid + ".db")
+
+baseCommand: [/usr/local/bin/picard_metrics_sqlite, --metric_name, CollectHsMetrics]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collectmultiplemetrics.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collectmultiplemetrics.cwl
@@ -1,0 +1,155 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/picard:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: DB_SNP
+    type: File
+    format: "edam:format_3016"
+    inputBinding:
+      prefix: DB_SNP=
+      separate: false
+
+  - id: INPUT
+    type: File
+    format: "edam:format_2572"
+    inputBinding:
+      prefix: INPUT=
+      separate: false
+
+  - id: METRIC_ACCUMULATION_LEVEL=
+    type: string
+    default: ALL_READS
+    inputBinding:
+      prefix: METRIC_ACCUMULATION_LEVEL=
+      separate: false
+
+  - id: REFERENCE_SEQUENCE
+    type: File
+    format: "edam:format_1929"
+    inputBinding:
+      prefix: REFERENCE_SEQUENCE=
+      separate: false
+
+  - id: TMP_DIR
+    type: string
+    default: .
+    inputBinding:
+      prefix: TMP_DIR=
+      separate: false
+
+  - id: VALIDATION_STRINGENCY
+    default: STRICT
+    type: string
+    inputBinding:
+      prefix: VALIDATION_STRINGENCY=
+      separate: false
+
+outputs:
+  - id: alignment_summary_metrics
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".alignment_summary_metrics")
+
+  - id: bait_bias_detail_metrics
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".bait_bias_detail_metrics")
+
+  - id: bait_bias_summary_metrics
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".bait_bias_summary_metrics")
+
+  - id: base_distribution_by_cycle_metrics
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".base_distribution_by_cycle_metrics")
+
+  - id: base_distribution_by_cycle_pdf
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".base_distribution_by_cycle.pdf")
+
+  - id: gc_bias_detail_metrics
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".gc_bias.detail_metrics")
+
+  - id: gc_bias_pdf
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".gc_bias.pdf")
+
+  - id: gc_bias_summary_metrics
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".gc_bias.summary_metrics")
+
+  - id: insert_size_histogram_pdf
+    type: ["null", File]
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".insert_size_histogram.pdf")
+
+  - id: insert_size_metrics
+    type: ["null", File]
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".insert_size_metrics")
+
+  - id: pre_adapter_detail_metrics
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".pre_adapter_detail_metrics")
+
+  - id: pre_adapter_summary_metrics
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".pre_adapter_summary_metrics")
+
+  - id: quality_by_cycle_metrics
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".quality_by_cycle_metrics")
+
+  - id: quality_by_cycle_pdf
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".quality_by_cycle.pdf")
+
+  - id: quality_distribution_metrics
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".quality_distribution_metrics")
+
+  - id: quality_distribution_pdf
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".quality_distribution.pdf")
+
+  - id: quality_yield_metrics
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".quality_yield_metrics")
+
+arguments:
+  - valueFrom: "PROGRAM=CollectAlignmentSummaryMetrics"
+  - valueFrom: "PROGRAM=CollectBaseDistributionByCycle"
+  - valueFrom: "PROGRAM=CollectGcBiasMetrics"
+  - valueFrom: "PROGRAM=CollectInsertSizeMetrics"
+  - valueFrom: "PROGRAM=CollectQualityYieldMetrics"
+  - valueFrom: "PROGRAM=CollectSequencingArtifactMetrics"
+  - valueFrom: "PROGRAM=MeanQualityByCycle"
+  - valueFrom: "PROGRAM=QualityScoreDistribution"
+
+  - valueFrom: $(inputs.INPUT.nameroot)
+    prefix: OUTPUT=
+    separate: false
+
+baseCommand: [java, -jar, /usr/local/bin/picard.jar, CollectMultipleMetrics]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collectmultiplemetrics_to_sqlite.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collectmultiplemetrics_to_sqlite.cwl
@@ -1,0 +1,109 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/picard_metrics_sqlite:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: bam
+    type: string
+    inputBinding:
+      prefix: --bam
+
+  - id: fasta
+    type: string
+    inputBinding:
+      prefix: --fasta
+
+  - id: input_state
+    type: string
+    inputBinding:
+      prefix: --input_state
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+  - id: vcf
+    type: string
+    inputBinding:
+      prefix: --vcf
+
+  - id: alignment_summary_metrics
+    type: File
+    inputBinding:
+      prefix: --alignment_summary_metrics
+
+  - id: bait_bias_detail_metrics
+    type: File
+    inputBinding:
+      prefix: --bait_bias_detail_metrics
+
+  - id: bait_bias_summary_metrics
+    type: File
+    inputBinding:
+      prefix: --bait_bias_summary_metrics
+
+  - id: base_distribution_by_cycle_metrics
+    type: File
+    inputBinding:
+      prefix: --base_distribution_by_cycle_metrics
+
+  - id: gc_bias_detail_metrics
+    type: File
+    inputBinding:
+      prefix: --gc_bias_detail_metrics
+
+  - id: gc_bias_summary_metrics
+    type: File
+    inputBinding:
+      prefix: --gc_bias_summary_metrics
+
+  - id: insert_size_metrics
+    type: ["null", File]
+    inputBinding:
+      prefix: --insert_size_metrics
+
+  - id: pre_adapter_detail_metrics
+    type: File
+    inputBinding:
+      prefix: --pre_adapter_detail_metrics
+
+  - id: pre_adapter_summary_metrics
+    type: File
+    inputBinding:
+      prefix: --pre_adapter_summary_metrics
+
+  - id: quality_by_cycle_metrics
+    type: File
+    inputBinding:
+      prefix: --quality_by_cycle_metrics
+
+  - id: quality_distribution_metrics
+    type: File
+    inputBinding:
+      prefix: --quality_distribution_metrics
+
+  - id: quality_yield_metrics
+    type: File
+    inputBinding:
+      prefix: --quality_yield_metrics
+
+outputs:
+  - id: log
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid+"_picard_CollectMultipleMetrics.log")
+
+  - id: sqlite
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid + ".db")
+
+baseCommand: [/usr/local/bin/picard_metrics_sqlite, --metric_name, CollectMultipleMetrics]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collectoxogmetrics.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collectoxogmetrics.cwl
@@ -1,0 +1,66 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/picard:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: DB_SNP
+    type: File
+    format: "edam:format_3016"
+    inputBinding:
+      prefix: DB_SNP=
+      separate: false
+
+  - id: INPUT
+    type: File
+    format: "edam:format_2572"
+    inputBinding:
+      prefix: INPUT=
+      separate: false
+
+  - id: REFERENCE_SEQUENCE
+    type: File
+    format: "edam:format_1929"
+    inputBinding:
+      prefix: REFERENCE_SEQUENCE=
+      separate: false
+
+  - id: TMP_DIR
+    type: string
+    default: .
+    inputBinding:
+      prefix: TMP_DIR=
+      separate: false
+
+  - id: USE_OQ
+    type: string
+    default: "true"
+    inputBinding:
+      prefix: USE_OQ=
+      separate: false
+
+  - id: VALIDATION_STRINGENCY
+    default: STRICT
+    type: string
+    inputBinding:
+      prefix: VALIDATION_STRINGENCY=
+      separate: false
+
+outputs:
+  - id: OUTPUT
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.basename + ".metrics")
+
+arguments:
+  - valueFrom: $(inputs.INPUT.basename + ".metrics")
+    prefix: OUTPUT=
+    separate: false
+
+baseCommand: [java, -jar, /usr/local/bin/picard.jar, CollectOxoGMetrics]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collectoxogmetrics_to_sqlite.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collectoxogmetrics_to_sqlite.cwl
@@ -1,0 +1,54 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/picard_metrics_sqlite:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: bam
+    type: string
+    inputBinding:
+      prefix: --bam
+
+  - id: fasta
+    type: string
+    inputBinding:
+      prefix: --fasta
+
+  - id: input_state
+    type: string
+    inputBinding:
+      prefix: --input_state
+
+  - id: metric_path
+    type: File
+    inputBinding:
+      prefix: --metric_path
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+  - id: vcf
+    type: string
+    inputBinding:
+      prefix: --vcf
+
+outputs:
+  - id: log
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid+"_picard_CollectOxoGMetrics.log")
+
+  - id: sqlite
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid + ".db")
+          
+baseCommand: [/usr/local/bin/picard_metrics_sqlite, --metric_name, CollectOxoGMetrics]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collectwgsmetrics.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collectwgsmetrics.cwl
@@ -1,0 +1,45 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/picard:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: INPUT
+    type: File
+    format: "edam:format_2572"
+    inputBinding:
+      prefix: INPUT=
+      separate: false
+
+  - id: REFERENCE_SEQUENCE
+    type: File
+    format: "edam:format_1929"
+    inputBinding:
+      prefix: REFERENCE_SEQUENCE=
+      separate: false
+
+  - id: VALIDATION_STRINGENCY
+    default: STRICT
+    type: string
+    inputBinding:
+      prefix: VALIDATION_STRINGENCY=
+      separate: false
+
+outputs:
+  - id: OUTPUT
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".metrics")
+
+arguments:
+  - valueFrom: $(inputs.INPUT.nameroot + ".metrics")
+    prefix: OUTPUT=
+    separate: false
+
+baseCommand: [java, -jar, /usr/local/bin/picard.jar, CollectWgsMetrics]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collectwgsmetrics_to_sqlite.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_collectwgsmetrics_to_sqlite.cwl
@@ -1,0 +1,49 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/picard_metrics_sqlite:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: bam
+    type: string
+    inputBinding:
+      prefix: --bam
+
+  - id: fasta
+    type: string
+    inputBinding:
+      prefix: --fasta
+
+  - id: input_state
+    type: string
+    inputBinding:
+      prefix: --input_state
+
+  - id: metric_path
+    type: File
+    inputBinding:
+      prefix: --metric_path
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+outputs:
+  - id: log
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid+"_picard_CollectWgsMetrics.log")
+
+  - id: sqlite
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid + ".db")
+
+baseCommand: [/usr/local/bin/picard_metrics_sqlite, --metric_name, CollectWgsMetrics]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_markduplicates.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_markduplicates.cwl
@@ -1,0 +1,64 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/picard:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: CREATE_INDEX
+    type: string
+    default: "true"
+    inputBinding:
+      prefix: CREATE_INDEX=
+      separate: false
+
+  - id: INPUT
+    type: File
+    format: "edam:format_2572"
+    inputBinding:
+      prefix: INPUT=
+      separate: false
+
+  - id: TMP_DIR
+    default: .
+    type: string
+    inputBinding:
+      prefix: TMP_DIR=
+      separate: false
+
+  - id: VALIDATION_STRINGENCY
+    default: STRICT
+    type: string
+    inputBinding:
+      prefix: VALIDATION_STRINGENCY=
+      separate: false
+
+outputs:
+  - id: OUTPUT
+    type: File
+    format: "edam:format_2572"
+    outputBinding:
+      glob: $(inputs.INPUT.basename)
+    secondaryFiles:
+      - ^.bai
+
+  - id: METRICS
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.basename + ".metrics")
+
+arguments:
+  - valueFrom: $(inputs.INPUT.basename)
+    prefix: OUTPUT=
+    separate: false
+
+  - valueFrom: $(inputs.INPUT.basename + ".metrics")
+    prefix: METRICS_FILE=
+    separate: false
+
+baseCommand: [java, -jar, /usr/local/bin/picard.jar, MarkDuplicates]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_markduplicates_to_sqlite.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_markduplicates_to_sqlite.cwl
@@ -1,0 +1,44 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/picard_metrics_sqlite:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: bam
+    type: string
+    inputBinding:
+      prefix: --bam
+
+  - id: input_state
+    type: string
+    inputBinding:
+      prefix: --input_state
+
+  - id: metric_path
+    type: File
+    inputBinding:
+      prefix: --metric_path
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+outputs:
+  - id: log
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid+"_picard_MarkDuplicates.log")
+
+  - id: sqlite
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid + ".db")
+
+baseCommand: [/usr/local/bin/picard_metrics_sqlite, --metric_name, MarkDuplicates]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_mergesamfiles.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_mergesamfiles.cwl
@@ -1,0 +1,108 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/picard:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: ASSUME_SORTED
+    type: boolean
+    default: false
+    inputBinding:
+      prefix: ASSUME_SORTED=
+      separate: false
+
+  - id: CREATE_INDEX
+    type: string
+    default: "true"
+    inputBinding:
+      prefix: CREATE_INDEX=
+      separate: false
+
+  - id: INPUT
+    format: "edam:format_2572"
+    type:
+      type: array
+      items: File
+
+  - id: INTERVALS
+    type: ["null", File]
+    inputBinding:
+      prefix: INTERVALS=
+      separate: false
+
+  - id: MERGE_SEQUENCE_DICTIONARIES
+    type: string
+    default: "false"
+    inputBinding:
+      prefix: MERGE_SEQUENCE_DICTIONARIES=
+      separate: false
+
+  - id: OUTPUT
+    type: string
+    inputBinding:
+      prefix: OUTPUT=
+      separate: false
+
+  - id: SORT_ORDER
+    type: string
+    default: coordinate
+    inputBinding:
+      prefix: SORT_ORDER=
+      separate: false
+
+  - id: TMP_DIR
+    type: string
+    default: .
+    inputBinding:
+      prefix: TMP_DIR=
+      separate: false
+
+  - id: USE_THREADING
+    type: string
+    default: "true"
+    inputBinding:
+      prefix: USE_THREADING=
+      separate: false
+
+  - id: VALIDATION_STRINGENCY
+    type: string
+    default: STRICT
+    inputBinding:
+      prefix: VALIDATION_STRINGENCY=
+      separate: false
+
+outputs:
+  - id: MERGED_OUTPUT
+    type: File
+    outputBinding:
+      glob: $(inputs.OUTPUT)
+
+arguments:
+  - valueFrom: |
+      ${
+        if (inputs.INPUT.length == 0) {
+          var cmd = ['/usr/bin/touch', inputs.OUTPUT];
+          return cmd
+        }
+        else {
+          var cmd = ["java", "-jar", "/usr/local/bin/picard.jar", "MergeSamFiles"];
+          var use_input = [];
+          for (var i = 0; i < inputs.INPUT.length; i++) {
+            var filesize = inputs.INPUT[i].size;
+            if (filesize > 0) {
+              use_input.push("INPUT=" + inputs.INPUT[i].path);
+            }
+          }
+
+          var run_cmd = cmd.concat(use_input);
+          return run_cmd
+        }
+
+      }
+baseCommand: []

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_sortsam.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_sortsam.cwl
@@ -1,0 +1,61 @@
+ #!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/picard:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: CREATE_INDEX
+    type: string
+    default: "true"
+    inputBinding:
+      prefix: CREATE_INDEX=
+      separate: false
+
+  - id: INPUT
+    type: File
+    format: "edam:format_2572"
+    inputBinding:
+      prefix: INPUT=
+      separate: false
+
+  - id: OUTPUT
+    type: string
+    inputBinding:
+      prefix: OUTPUT=
+      separate: false
+
+  - id: SORT_ORDER
+    type: string
+    default: "coordinate"
+    inputBinding:
+      prefix: SORT_ORDER=
+      separate: false
+
+  - id: TMP_DIR
+    type: string
+    default: .
+    inputBinding:
+      prefix: TMP_DIR=
+      separate: false
+
+  - id: VALIDATION_STRINGENCY
+    type: string
+    default: "STRICT"
+    inputBinding:
+      prefix: VALIDATION_STRINGENCY=
+      separate: false
+
+outputs:
+  - id: SORTED_OUTPUT
+    type: File
+    format: "edam:format_2572"
+    outputBinding:
+      glob: $(inputs.OUTPUT)
+          
+baseCommand: [java, -jar, /usr/local/bin/picard.jar, SortSam]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_validatesamfile.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_validatesamfile.cwl
@@ -1,0 +1,61 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/picard:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: INPUT
+    type: File
+    format: "edam:format_2572"
+    inputBinding:
+      prefix: INPUT=
+      separate: false
+
+  - id: MAX_OUTPUT
+    type: int
+    default: 2147483647
+    inputBinding:
+      prefix: MAX_OUTPUT=
+      separate: false
+
+  - id: MODE
+    type: string
+    default: VERBOSE
+    inputBinding:
+      prefix: MODE=
+      separate: false
+
+  - id: TMP_DIR
+    type: string
+    default: .
+    inputBinding:
+      prefix: TMP_DIR=
+      separate: false
+
+  - id: VALIDATION_STRINGENCY
+    default: STRICT
+    type: string
+    inputBinding:
+      prefix: VALIDATION_STRINGENCY=
+      separate: false
+
+outputs:
+  - id: OUTPUT
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.basename + ".metrics")
+
+arguments:
+  - valueFrom: $(inputs.INPUT.basename + ".metrics")
+    prefix: OUTPUT=
+    separate: false
+      
+successCodes: [0, 1]
+
+baseCommand: [java, -jar, /usr/local/bin/picard.jar, ValidateSamFile]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_validatesamfile_to_sqlite.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/picard_validatesamfile_to_sqlite.cwl
@@ -1,0 +1,45 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/picard_metrics_sqlite:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: bam
+    type: string
+    inputBinding:
+      prefix: --bam
+
+  - id: input_state
+    type: string
+    inputBinding:
+      prefix: --input_state
+
+  - id: metric_path
+    type: File
+    inputBinding:
+      prefix: --metric_path
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+outputs:
+  - id: log
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid+"_picard_ValidateSamFile.log")
+
+  - id: sqlite
+    type: File
+    format: "edam:format_3621"
+    outputBinding:
+      glob: $(inputs.uuid + ".db")
+
+baseCommand: [/usr/local/bin/picard_metrics_sqlite, --metric_name, ValidateSamFile]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/queue_bqsr_status.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/queue_bqsr_status.cwl
@@ -1,0 +1,119 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/queue_bqsr_status:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: bam_signpost_id
+    type: string
+    inputBinding:
+      prefix: --bam_signpost_id
+
+  - id: bam_uuid
+    type: ["null", string]
+    inputBinding:
+      prefix: --bam_uuid
+
+  - id: hostname
+    type: string
+    inputBinding:
+      prefix: --hostname
+
+  - id: host_ipaddress
+    type: string
+    inputBinding:
+      prefix: --host_ipaddress
+
+  - id: host_mac
+    type: string
+    inputBinding:
+      prefix: --host_mac
+
+  - id: job_creation_uuid
+    type: string
+    inputBinding:
+      prefix: --job_creation_uuid
+
+  - id: job_path
+    type: string
+    inputBinding:
+      prefix: --job_path
+
+  - id: known_snp_signpost_id
+    type: string
+    inputBinding:
+      prefix: --known_snp_signpost_id
+
+  - id: num_threads
+    type: int
+    inputBinding:
+      prefix: --num_threads
+
+  - id: reference_fa_signpost_id
+    type: string
+    inputBinding:
+      prefix: --reference_fa_signpost_id
+
+  - id: runner_cwl_path
+    type: string
+    inputBinding:
+      prefix: --runner_cwl_path
+
+  - id: runner_repo_hash
+    type: string
+    inputBinding:
+      prefix: --runner_repo_hash
+
+  - id: run_uuid
+    type: string
+    inputBinding:
+      prefix: --run_uuid
+
+  - id: s3_bam_url
+    type: ["null", string]
+    inputBinding:
+      prefix: --s3_bam_url
+
+  - id: slurm_resource_core_count
+    type: int
+    inputBinding:
+      prefix: --slurm_resource_core_count
+
+  - id: slurm_resource_disk_gibibytes
+    type: int
+    inputBinding:
+      prefix: --slurm_resource_disk_gibibytes
+
+  - id: slurm_resource_mem_mebibytes
+    type: int
+    inputBinding:
+      prefix: --slurm_resource_mem_mebibytes
+
+  - id: status
+    type: string
+    inputBinding:
+      prefix: --status
+
+  - id: table_name
+    type: string
+    inputBinding:
+      prefix: --table_name
+
+outputs:
+  - id: log
+    type: File
+    outputBinding:
+      glob: $(inputs.run_uuid+".log")
+
+  - id: sqlite
+    type: File
+    outputBinding:
+      glob: $(inputs.run_uuid+".db")
+
+baseCommand: [/usr/local/bin/queue_bqsr_status]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/queue_coclean_status.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/queue_coclean_status.cwl
@@ -1,0 +1,114 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/queue_coclean_status
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: bam_normal_signpost_id
+    type: string
+    inputBinding:
+      prefix: --bam_normal_signpost_id
+
+  - id: bam_tumor_signpost_id
+    type: string
+    inputBinding:
+      prefix: --bam_tumor_signpost_id
+
+  - id: bam_normal_uuid
+    type: ["null", string]
+    inputBinding:
+      prefix: --bam_normal_uuid
+
+  - id: bam_tumor_uuid
+    type: ["null", string]
+    inputBinding:
+      prefix: --bam_tumor_uuid
+
+  - id: hostname
+    type: string
+    inputBinding:
+      prefix: --hostname
+
+  - id: host_ipaddress
+    type: string
+    inputBinding:
+      prefix: --host_ipaddress
+
+  - id: host_mac
+    type: string
+    inputBinding:
+      prefix: --host_mac
+
+  - id: known_indel_signpost_id
+    type: string
+    inputBinding:
+      prefix: --known_indel_signpost_id
+
+  - id: known_snp_signpost_id
+    type: string
+    inputBinding:
+      prefix: --known_snp_signpost_id
+
+  - id: num_threads
+    type: int
+    inputBinding:
+      prefix: --num_threads
+
+  - id: reference_fa_signpost_id
+    type: string
+    inputBinding:
+      prefix: --reference_fa_signpost_id
+
+  - id: repo
+    type: string
+    inputBinding:
+      prefix: --repo
+
+  - id: repo_hash
+    type: string
+    inputBinding:
+      prefix: --repo_hash
+
+  - id: run_uuid
+    type: string
+    inputBinding:
+      prefix: --run_uuid
+
+  - id: s3_bam_normal_url
+    type: ["null", string]
+    inputBinding:
+      prefix: --s3_bam_normal_url
+
+  - id: s3_bam_tumor_url
+    type: ["null", string]
+    inputBinding:
+      prefix: --s3_bam_tumor_url
+
+  - id: status
+    type: string
+    inputBinding:
+      prefix: --status
+
+  - id: table_name
+    type: string
+    inputBinding:
+      prefix: --table_name
+
+outputs:
+  - id: log
+    type: File
+    outputBinding:
+      glob: $(inputs.run_uuid+".log")
+
+  - id: sqlite
+    type: File
+    outputBinding:
+      glob: $(inputs.run_uuid+".db")
+
+baseCommand: [/usr/local/bin/queue_coclean_status]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/queue_status.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/queue_status.cwl
@@ -1,0 +1,59 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/queue_status:4
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: input_signpost_id
+    type: string
+    inputBinding:
+      prefix: --input_signpost_id
+
+  - id: repo
+    type: string
+    inputBinding:
+      prefix: --repo
+
+  - id: repo_hash
+    type: string
+    inputBinding:
+      prefix: --repo_hash
+
+  - id: s3_url
+    type: ["null", string]
+    inputBinding:
+      prefix: --s3_url
+
+  - id: status
+    type: string
+    inputBinding:
+      prefix: --status
+
+  - id: table_name
+    type: string
+    inputBinding:
+      prefix: --table_name
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+outputs:
+  - id: log
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid+".log")
+
+  - id: sqlite
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid+".db")
+
+baseCommand: [/usr/local/bin/queue_status]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/readgroup_json_db.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/readgroup_json_db.cwl
@@ -1,0 +1,36 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/readgroup_json_db:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: json_path
+    type: File
+    format: "edam:format_3464"
+    inputBinding:
+      prefix: --json_path
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+outputs:
+  - id: log
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid +".log")
+
+  - id: output_sqlite
+    type: File
+    format: "edam:format_3621"
+    outputBinding:
+      glob: $(inputs.uuid + ".db")         
+          
+baseCommand: [/usr/local/bin/readgroup_json_db]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/remove_duplicate_fastq_matepair.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/remove_duplicate_fastq_matepair.cwl
@@ -1,0 +1,41 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: "cwl:draft-3"
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/remove_duplicate_fastq_matepair
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: fastq_path
+    type: File
+    inputBinding:
+      prefix: --fastq_path
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+outputs:
+  - id: output_fastq
+    type: File
+    outputBinding:
+      glob: $(inputs.fastq_path.path.split('/').slice(-1)[0])
+
+  - id: log
+    type: File
+    description: "python log file"
+    outputBinding:
+      glob: $(inputs.uuid + "_remove_duplicate_fastq_matepair_main.log")
+
+  - id: output_sqlite
+    type: File
+    description: "sqlite file"
+    outputBinding:
+      glob: $(inputs.uuid + ".db")
+
+baseCommand: ["/home/ubuntu/.virtualenvs/p3/bin/python","/home/ubuntu/.virtualenvs/p3/lib/python3.5/site-packages/remove_duplicate_fastq_matepair/main.py"]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/remove_qcfail.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/remove_qcfail.cwl
@@ -1,0 +1,83 @@
+#!/usr/bin/env cwl-runner
+
+# example
+# cwl-runner --outdir /mnt/SCRATCH/47b42e81-2500-4ebc-a0c2-acd3187cc2f0/realn/md/ --verbose remove_qcfail.cwl.yaml --first_bam /mnt/SCRATCH/47b42e81-2500-4ebc-a0c2-acd3187cc2f0/C440.TCGA-IN-8462-01A-11D-2340-08.1.bam --second_bam /mnt/SCRATCH/47b42e81-2500-4ebc-a0c2-acd3187cc2f0/realn/md/C440.TCGA-IN-8462-01A-11D-2340-08.1.bam --uuid test
+
+description: |
+  Usage:  cwl-runner --outdir <second_bam_path-dir> <this-file-path> --first_bam_path <bam-path> --second_bam_path <bam-path> --uuid <uuid-string>
+  Options:
+    --first_input_bam       BAM containing qcfail reads with bitmask flag
+    --second_input_bam      BAM containing qcfail reads without bitmask flag
+    --uuid            UUID for log file and sqlite db file
+
+requirements:
+  - import: node-engine.cwl
+  - import: envvar-global.cwl
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/remove_qcfailed_mapped
+
+class: CommandLineTool
+
+inputs:
+  - id: "#first_input_bam"
+    type: File
+    inputBinding:
+      prefix: --first_bam
+      secondaryFiles:
+        - engine: node-engine.cwl
+          script: |
+            {
+              return {"path": $job['first_input_bam'].path.slice(0,-4)+".bai", "class": "File"};
+            }
+
+  - id: "#second_input_bam"
+    type: File
+    inputBinding:
+      prefix: --second_bam
+      secondaryFiles:
+        - engine: node-engine.cwl
+          script: |
+            {
+              return {"path": $job['second_input_bam'].path.slice(0,-4)+".bai", "class": "File"};
+            }
+
+  - id: "#uuid"
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+outputs:
+  - id: "#output_bam"
+    type: File
+    description: "The second bam file without qcfail reads"
+    outputBinding:
+      glob:
+        engine: node-engine.cwl
+        script: |
+          {
+            return "remove_qcfail/"+$job['second_input_bam'].path.split('/').slice(-1)[0];
+          }
+
+  - id: "#output_sqlite"
+    type: File
+    description: "sqlite file"
+    outputBinding:
+      glob:
+        engine: node-engine.cwl
+        script: |
+          {
+          return $job['uuid']+".db"
+          }
+
+  - id: "#log"
+    type: File
+    description: "python log file"
+    outputBinding:
+      glob:
+        engine: node-engine.cwl
+        script: |
+          {
+          return $job['uuid']+"_remove_qcfail.log"
+          }
+
+baseCommand: ["/home/ubuntu/.virtualenvs/p3/bin/python","/home/ubuntu/.virtualenvs/p3/lib/python3.4/site-packages/remove_qcfailed_mapped/main.py"]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/root_bam_coclean.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/root_bam_coclean.cwl
@@ -1,0 +1,33 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: $(inputs.bam.basename)
+        entry: $(inputs.bam)
+      - entryname: $(inputs.bam_index.basename)
+        entry: $(inputs.bam_index)
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: bam
+    type: File
+    format: "edam:format_2572"
+
+  - id: bam_index
+    type: File
+
+outputs:
+  - id: output
+    type: File
+    format: "edam:format_2572"
+    outputBinding:
+      glob: $(inputs.bam.basename)
+    secondaryFiles:
+      - ^.bai
+
+baseCommand: "true"

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/root_fasta_coclean.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/root_fasta_coclean.cwl
@@ -1,0 +1,39 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: $(inputs.fasta.basename)
+        entry: $(inputs.fasta)
+      - entryname: $(inputs.fasta_dict.basename)
+        entry: $(inputs.fasta_dict)
+      - entryname: $(inputs.fasta_index.basename)
+        entry: $(inputs.fasta_index)
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: fasta
+    type: File
+    format: "edam:format_1929"
+
+  - id: fasta_dict
+    type: File
+
+  - id: fasta_index
+    type: File
+
+outputs:
+  - id: output
+    type: File
+    format: "edam:format_1929"
+    outputBinding:
+      glob: $(inputs.fasta.basename)
+    secondaryFiles:
+      - ^.dict
+      - .fai
+
+baseCommand: "true"

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/root_fasta_dnaseq.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/root_fasta_dnaseq.cwl
@@ -1,0 +1,57 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: $(inputs.fasta.basename)
+        entry: $(inputs.fasta)
+      - entryname: $(inputs.fasta_amb.basename)
+        entry: $(inputs.fasta_amb)
+      - entryname: $(inputs.fasta_ann.basename)
+        entry: $(inputs.fasta_ann)
+      - entryname: $(inputs.fasta_bwt.basename)
+        entry: $(inputs.fasta_bwt)
+      - entryname: $(inputs.fasta_pac.basename)
+        entry: $(inputs.fasta_pac)
+      - entryname: $(inputs.fasta_sa.basename)
+        entry: $(inputs.fasta_sa)
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: fasta
+    type: File
+    format: "edam:format_1929"
+
+  - id: fasta_amb
+    type: File
+
+  - id: fasta_ann
+    type: File
+
+  - id: fasta_bwt
+    type: File
+
+  - id: fasta_pac
+    type: File
+
+  - id: fasta_sa
+    type: File
+
+outputs:
+  - id: output
+    type: File
+    format: "edam:format_1929"
+    outputBinding:
+      glob: $(inputs.fasta.basename)
+    secondaryFiles:
+      - .amb
+      - .ann
+      - .bwt
+      - .pac
+      - .sa
+
+baseCommand: "true"

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/root_reference_fasta.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/root_reference_fasta.cwl
@@ -1,0 +1,55 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: cwl:draft-3
+
+class: CommandLineTool
+
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: CreateFileRequirement
+    fileDef:
+      - filename: $(inputs.fasta_path.basename)
+        fileContent: $(inputs.fasta_path)
+      - filename: $(inputs.fasta_amb_path.basename)
+        fileContent: $(inputs.fasta_amb_path)
+      - filename: $(inputs.fasta_ann_path.basename)
+        fileContent: $(inputs.fasta_ann_path)
+      - filename: $(inputs.fasta_bwt_path.basename)
+        fileContent: $(inputs.fasta_bwt_path)
+      - filename: $(inputs.fasta_fai_path.basename)
+        fileContent: $(inputs.fasta_fai_path)
+      - filename: $(inputs.fasta_pac_path.basename)
+        fileContent: $(inputs.fasta_pac_path)
+      - filename: $(inputs.fasta_sa_path.basename)
+        fileContent: $(inputs.fasta_sa_path)
+
+inputs:
+  - id: fasta_path
+    type: File
+  - id: fasta_amb_path
+    type: File
+  - id: fasta_ann_path
+    type: File
+  - id: fasta_bwt_path
+    type: File
+  - id: fasta_fai_path
+    type: File
+  - id: fasta_pac_path
+    type: File
+  - id: fasta_sa_path
+    type: File
+
+outputs:
+  - id: output
+    type: File
+    outputBinding:
+      glob: $(inputs.fasta_path.basename)
+    secondaryFiles:
+      - .amb
+      - .ann
+      - .bwt
+      - .fai
+      - .pac
+      - .sa
+
+baseCommand: []

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/root_vcf_coclean.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/root_vcf_coclean.cwl
@@ -1,0 +1,33 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: $(inputs.vcf.basename)
+        entry: $(inputs.vcf)
+      - entryname: $(inputs.vcf_index.basename)
+        entry: $(inputs.vcf_index)
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: vcf
+    type: File
+    format: "edam:format_3016"
+
+  - id: vcf_index
+    type: File
+
+outputs:
+  - id: output
+    type: File
+    format: "edam:format_3016"
+    outputBinding:
+      glob: $(inputs.vcf.basename)
+    secondaryFiles:
+      - .tbi
+
+baseCommand: "true"

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/samtools_bamtobam.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/samtools_bamtobam.cwl
@@ -1,0 +1,28 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/samtools:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: INPUT
+    format: "edam:format_2572"
+    type: File
+    inputBinding:
+      position: 0
+
+outputs:
+  - id: OUTPUT
+    format: "edam:format_2572"
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.basename)
+
+stdout: $(inputs.INPUT.basename)
+
+baseCommand: [/usr/local/bin/samtools, view, -Shb]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/samtools_flagstat.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/samtools_flagstat.cwl
@@ -1,0 +1,27 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/samtools:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: INPUT
+    type: File
+    format: "edam:format_2572"
+    inputBinding:
+      position: 0
+
+outputs:
+  - id: OUTPUT
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".flagstat")
+
+stdout: $(inputs.INPUT.nameroot + ".flagstat")
+
+baseCommand: [/usr/local/bin/samtools, flagstat]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/samtools_flagstat_to_sqlite.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/samtools_flagstat_to_sqlite.cwl
@@ -1,0 +1,44 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/samtools_metrics_sqlite:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: bam
+    type: string
+    inputBinding:
+      prefix: --bam
+
+  - id: input_state
+    type: string
+    inputBinding:
+      prefix: --input_state
+
+  - id: metric_path
+    type: File
+    inputBinding:
+      prefix: --metric_path
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+outputs:
+  - id: log
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid+"_samtools_flagstat.log")
+
+  - id: sqlite
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid + ".db")
+
+baseCommand: [/usr/local/bin/samtools_metrics_sqlite, --metric_name, flagstat]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/samtools_idxstats.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/samtools_idxstats.cwl
@@ -1,0 +1,29 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/samtools:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: INPUT
+    type: File
+    format: "edam:format_2572"
+    inputBinding:
+      position: 0
+    secondaryFiles:
+      - ^.bai
+
+outputs:
+  - id: OUTPUT
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".idxstats")
+
+stdout: $(inputs.INPUT.nameroot + ".idxstats")
+
+baseCommand: [/usr/local/bin/samtools, idxstats]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/samtools_idxstats_to_sqlite.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/samtools_idxstats_to_sqlite.cwl
@@ -1,0 +1,44 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/samtools_metrics_sqlite:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: bam
+    type: string
+    inputBinding:
+      prefix: --bam
+
+  - id: input_state
+    type: string
+    inputBinding:
+      prefix: --input_state
+
+  - id: metric_path
+    type: File
+    inputBinding:
+      prefix: --metric_path
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+outputs:
+  - id: log
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid+"_samtools_idxstats.log")
+
+  - id: sqlite
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid + ".db")
+
+baseCommand: [/usr/local/bin/samtools_metrics_sqlite, --metric_name, idxstats]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/samtools_stats.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/samtools_stats.cwl
@@ -1,0 +1,27 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/samtools:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: INPUT
+    type: File
+    format: "edam:format_2572"
+    inputBinding:
+      position: 0
+
+outputs:
+  - id: OUTPUT
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".stats")
+
+stdout: $(inputs.INPUT.nameroot + ".stats")
+
+baseCommand: [/usr/local/bin/samtools, stats]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/samtools_stats_to_sqlite.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/samtools_stats_to_sqlite.cwl
@@ -1,0 +1,44 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/samtools_metrics_sqlite:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: bam
+    type: string
+    inputBinding:
+      prefix: --bam
+
+  - id: input_state
+    type: string
+    inputBinding:
+      prefix: --input_state
+
+  - id: metric_path
+    type: File
+    inputBinding:
+      prefix: --metric_path
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+outputs:
+  - id: log
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid+"_samtools_stats.log")
+
+  - id: sqlite
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid + ".db")
+
+baseCommand: [/usr/local/bin/samtools_metrics_sqlite, --metric_name, stats]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/sha256sum.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/sha256sum.cwl
@@ -1,0 +1,26 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: ubuntu:xenial-20161010
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: INPUT
+    type: File
+    inputBinding:
+      position: 0
+
+outputs:
+  - id: OUTPUT
+    type: File
+    outputBinding:
+      glob: $(inputs.INPUT.nameroot + ".sha256")
+
+stdout: $(inputs.INPUT.nameroot + ".sha256")
+      
+baseCommand: [sha256sum]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/sort_bqsr_grp.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/sort_bqsr_grp.cwl
@@ -1,0 +1,42 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: ubuntu:xenial-20160923.1
+  - class: InlineJavascriptRequirement
+  - class: ShellCommandRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: input_grp
+    type:
+      type: array
+      items: File
+
+outputs:
+  - id: output_grp
+    type:
+      type: array
+      items: File
+    outputBinding:
+      outputEval: |
+      glob: "*_bqsr.grp"
+      outputEval: |
+        ${ return self.sort(function(a,b) { return a.location > b.location ? 1 : (a.location < b.location ? -1 : 0) }) }
+
+arguments:
+  - valueFrom: |
+      ${
+         var cmd = "cp ";
+         for (var i = 0; i < inputs.input_grp.length; i++) {
+          cmd += inputs.input_grp[i].path + " ";
+         }
+         cmd += "."
+         return cmd
+      }
+    shellQuote: false
+
+baseCommand: []

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/sort_scatter_expression.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/sort_scatter_expression.cwl
@@ -1,0 +1,26 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: InlineJavascriptRequirement
+
+class: ExpressionTool
+
+inputs:
+  - id: INPUT
+    type:
+      type: array
+      items: File
+
+outputs:
+  - id: OUTPUT
+    type:
+      type: array
+      items: File
+
+expression: |
+  ${
+    var output = inputs.INPUT.sort(function(a,b) { return a.basename > b.basename ? 1 : (a.basename < b.basename ? -1 : 0) });
+    return {'OUTPUT': output}
+  }

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/sqlite_to_postgres.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/sqlite_to_postgres.cwl
@@ -1,0 +1,52 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: "cwl:draft-3"
+
+description: |
+  Usage:  cwl-runner <this-file-path> --source_sqlite <source-sqlite-path> --uuid <uuid-string>
+  Options:
+    --source_sqlite  source sqlite to insert in postgres
+    --uuid           UUID for log file and sqlite db file
+
+requirements:
+  - $import: envvar-global.cwl
+  - class: InlineJavascriptRequirement
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/sqlite_to_postgres
+
+class: CommandLineTool
+
+inputs:
+  - id: "#source_sqlite_path"
+    type: File
+    inputBinding:
+      prefix: --source_sqlite_path
+
+  - id: "#uuid"
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+  - id: "#postgres_creds_s3url"
+    type: string
+    inputBinding:
+      prefix: --postgres_creds_s3url
+
+  - id: "#ini_section"
+    type: string
+    inputBinding:
+      prefix: --ini_section
+
+  - id: "#s3cfg_path"
+    type: File
+    inputBinding:
+      prefix: --s3cfg_path
+
+outputs:
+  - id: "#log"
+    type: File
+    description: "python log file"
+    outputBinding:
+      glob: $(inputs.uuid + "_sqlite_to_postgres.log")
+          
+baseCommand: ["/home/ubuntu/.virtualenvs/p3/bin/python","/home/ubuntu/.virtualenvs/p3/lib/python3.4/site-packages/sqlite_to_postgres/main.py"]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/sqlite_to_postgres_hirate.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/sqlite_to_postgres_hirate.cwl
@@ -1,0 +1,39 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/sqlite_to_postgres:1
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: ini_section
+    type: string
+    inputBinding:
+      prefix: --ini_section
+
+  - id: postgres_creds_path
+    type: File
+    inputBinding:
+      prefix: --postgres_creds_path
+
+  - id: source_sqlite_path
+    type: File
+    inputBinding:
+      prefix: --source_sqlite_path
+
+  - id: uuid
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+outputs:
+  - id: log
+    type: File
+    outputBinding:
+      glob: $(inputs.uuid + ".log")
+          
+baseCommand: [sqlite_to_postgres]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/sra_hs_lookup.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/sra_hs_lookup.cwl
@@ -1,0 +1,62 @@
+#!/usr/bin/env cwl-runner
+
+description: |
+  Usage:  cwl-runner <this-file-path> --bam_path <bam-path> --uuid <uuid-string>
+  Options:
+    --bam_path       Determine interval paths needed for picard CalculateHsMetrics
+    --uuid           UUID for log file and sqlite db file
+
+requirements:
+  - import: node-engine.cwl
+  - import: envvar-global.cwl
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/sra_hs_lookup
+
+class: CommandLineTool
+
+inputs:
+  - id: "#input_bam"
+    type: File
+    inputBinding:
+      prefix: --bam_path
+
+  - id: "#uuid"
+    type: string
+    inputBinding:
+      prefix: --uuid
+
+  - id: "#bam_library_key"
+    type: File
+    inputBinding:
+      prefix: --bam_library_key_json_path
+
+  - id: "#key_interval"
+    type: File
+    inputBinding:
+      prefix: --key_interval_json_path
+
+outputs:
+  - id: "#output_json"
+    type: File
+    description: "The json file"
+    outputBinding:
+      glob:
+        engine: node-engine.cwl
+        script: |
+          {
+            return $job['input_bam'].path.split('/').slice(-1)[0].slice(0,-4)+"_readgroup_interval.json";
+          }
+
+  - id: "#log"
+    type: File
+    description: "python log file"
+    outputBinding:
+      glob:
+        engine: node-engine.cwl
+        script: |
+          {
+          return $job['uuid']+"_sra_hs_lookup.log"
+          }
+
+          
+baseCommand: ["/home/ubuntu/.virtualenvs/p3/bin/python","/home/ubuntu/.virtualenvs/p3/lib/python3.4/site-packages/sra_hs_lookup/main.py"]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/table_string_sqlite_cell.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/table_string_sqlite_cell.cwl
@@ -1,0 +1,28 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/ncigdc/table_string_sqlite_cell:1
+
+class: CommandLineTool
+
+inputs:
+  - id: cell_value
+    type: string
+    inputBinding:
+      prefix: --cell_value
+
+  - id: table_name
+    type: string
+    inputBinding:
+      prefix: --table_name
+
+outputs:
+  - id: sqlite
+    type: File
+    outputBinding:
+      glob: "output.db"
+
+baseCommand: [/usr/local/bin/table_string_sqlite_cell]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/untar_fasta.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/untar_fasta.cwl
@@ -1,0 +1,24 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: ubuntu:xenial-20161010
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: input
+    type: File
+    inputBinding:
+      position: 0
+
+outputs:
+  - id: fasta
+    type: File
+    outputBinding:
+      glob: "*.fa"
+
+baseCommand: [tar, xf]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/tools/untar_fastabwa.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/tools/untar_fastabwa.cwl
@@ -1,0 +1,44 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: ubuntu:xenial-20161010
+  - class: InlineJavascriptRequirement
+
+class: CommandLineTool
+
+inputs:
+  - id: input
+    type: File
+    inputBinding:
+      position: 0
+
+outputs:
+  - id: fasta_amb
+    type: File
+    outputBinding:
+      glob: "*.amb"
+
+  - id: fasta_ann
+    type: File
+    outputBinding:
+      glob: "*.ann"
+
+  - id: fasta_bwt
+    type: File
+    outputBinding:
+      glob: "*.bwt"
+
+  - id: fasta_pac
+    type: File
+    outputBinding:
+      glob: "*.pac"
+
+  - id: fasta_sa
+    type: File
+    outputBinding:
+      glob: "*.sa"
+
+baseCommand: [tar, xf]

--- a/dockstore-launcher/src/test/resources/gdc/cwl/transform.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/transform.cwl
@@ -1,0 +1,799 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+class: Workflow
+
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: MultipleInputFeatureRequirement
+  - class: ScatterFeatureRequirement
+  - class: StepInputExpressionRequirement
+  - class: SubworkflowFeatureRequirement
+
+inputs:
+  - id: bam_path
+    type: File
+  - id: db_snp_path
+    type: File
+  - id: reference_fasta_path
+    type: File
+  - id: thread_count
+    type: int
+  - id: uuid
+    type: string
+
+outputs:
+  - id: picard_markduplicates_output
+    type: File
+    outputSource: picard_markduplicates/OUTPUT
+  - id: merge_all_sqlite_destination_sqlite
+    type: File
+    outputSource: merge_all_sqlite/destination_sqlite
+
+steps:
+  - id: samtools_bamtobam
+    run: ../../tools/samtools_bamtobam.cwl
+    in:
+      - id: INPUT
+        source: bam_path
+    out:
+      - id: OUTPUT
+
+  - id: picard_validatesamfile_original
+    run: ../../tools/picard_validatesamfile.cwl
+    in:
+      - id: INPUT
+        source: samtools_bamtobam/OUTPUT
+      - id: VALIDATION_STRINGENCY
+        valueFrom: "LENIENT"
+    out:
+      - id: OUTPUT
+
+  # need eof and dup QNAME detection
+  - id: picard_validatesamfile_original_to_sqlite
+    run: ../../tools/picard_validatesamfile_to_sqlite.cwl
+    in:
+      - id: bam
+        source: bam_path
+        valueFrom: $(self.basename)
+      - id: input_state
+        valueFrom: "original"
+      - id: metric_path
+        source: picard_validatesamfile_original/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: sqlite
+
+  - id: biobambam_bamtofastq
+    run: ../../tools/biobambam2_bamtofastq.cwl
+    in:
+      - id: filename
+        source: samtools_bamtobam/OUTPUT
+    out:
+      - id: output_fastq1
+      - id: output_fastq2
+      - id: output_fastq_o1
+      - id: output_fastq_o2
+      - id: output_fastq_s
+
+  - id: remove_duplicate_fastq1
+    run: ../../tools/fastq_remove_duplicate_qname.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: biobambam_bamtofastq/output_fastq1
+    out:
+      - id: OUTPUT
+
+  - id: remove_duplicate_fastq2
+    run: ../../tools/fastq_remove_duplicate_qname.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: biobambam_bamtofastq/output_fastq2
+    out:
+      - id: OUTPUT
+
+  - id: remove_duplicate_fastq_o1
+    run: ../../tools/fastq_remove_duplicate_qname.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: biobambam_bamtofastq/output_fastq_o1
+    out:
+      - id: OUTPUT
+
+  - id: remove_duplicate_fastq_o2
+    run: ../../tools/fastq_remove_duplicate_qname.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: biobambam_bamtofastq/output_fastq_o2
+    out:
+      - id: OUTPUT
+
+  - id: remove_duplicate_fastq_s
+    run: ../../tools/fastq_remove_duplicate_qname.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: biobambam_bamtofastq/output_fastq_s
+    out:
+      - id: OUTPUT
+
+  - id: sort_scattered_fastq1
+    run: ../../tools/sort_scatter_expression.cwl
+    in:
+      - id: INPUT
+        source: remove_duplicate_fastq1/OUTPUT
+    out:
+      - id: OUTPUT
+
+  - id: sort_scattered_fastq2
+    run: ../../tools/sort_scatter_expression.cwl
+    in:
+      - id: INPUT
+        source: remove_duplicate_fastq2/OUTPUT
+    out:
+      - id: OUTPUT
+
+  - id: sort_scattered_fastq_o1
+    run: ../../tools/sort_scatter_expression.cwl
+    in:
+      - id: INPUT
+        source: remove_duplicate_fastq_o1/OUTPUT
+    out:
+      - id: OUTPUT
+
+  - id: sort_scattered_fastq_o2
+    run: ../../tools/sort_scatter_expression.cwl
+    in:
+      - id: INPUT
+        source: remove_duplicate_fastq_o2/OUTPUT
+    out:
+      - id: OUTPUT
+
+  - id: sort_scattered_fastq_s
+    run: ../../tools/sort_scatter_expression.cwl
+    in:
+      - id: INPUT
+        source: remove_duplicate_fastq_s/OUTPUT
+    out:
+      - id: OUTPUT
+
+  - id: bam_readgroup_to_json
+    run: ../../tools/bam_readgroup_to_json.cwl
+    in:
+      - id: INPUT
+        source: samtools_bamtobam/OUTPUT
+      - id: MODE
+        valueFrom: "lenient"
+    out:
+      - id: OUTPUT
+
+  - id: readgroup_json_db
+    run: ../../tools/readgroup_json_db.cwl
+    scatter: json_path
+    in:
+      - id: json_path
+        source: bam_readgroup_to_json/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: log
+      - id: output_sqlite
+
+  - id: merge_readgroup_json_db
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: readgroup_json_db/output_sqlite
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log
+
+  - id: fastqc1
+    run: ../../tools/fastqc.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: sort_scattered_fastq1/OUTPUT
+      - id: threads
+        source: thread_count
+    out:
+      - id: OUTPUT
+
+  - id: fastqc2
+    run: ../../tools/fastqc.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: sort_scattered_fastq2/OUTPUT
+      - id: threads
+        source: thread_count
+    out:
+      - id: OUTPUT
+
+  - id: fastqc_s
+    run: ../../tools/fastqc.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: sort_scattered_fastq_s/OUTPUT
+      - id: threads
+        source: thread_count
+    out:
+      - id: OUTPUT
+
+  - id: fastqc_o1
+    run: ../../tools/fastqc.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: sort_scattered_fastq_o1/OUTPUT
+      - id: threads
+        source: thread_count
+    out:
+      - id: OUTPUT
+
+  - id: fastqc_o2
+    run: ../../tools/fastqc.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: sort_scattered_fastq_o2/OUTPUT
+      - id: threads
+        source: thread_count
+    out:
+      - id: OUTPUT
+
+  - id: fastqc_db1
+    run: ../../tools/fastqc_db.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: fastqc1/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: LOG
+      - id: OUTPUT
+
+  - id: fastqc_db2
+    run: ../../tools/fastqc_db.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: fastqc2/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: LOG
+      - id: OUTPUT
+
+  - id: fastqc_db_s
+    run: ../../tools/fastqc_db.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: fastqc_s/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: LOG
+      - id: OUTPUT
+
+  - id: fastqc_db_o1
+    run: ../../tools/fastqc_db.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: fastqc_o1/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: LOG
+      - id: OUTPUT
+
+  - id: fastqc_db_o2
+    run: ../../tools/fastqc_db.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: fastqc_o2/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: LOG
+      - id: OUTPUT
+
+  - id: merge_fastqc_db1_sqlite
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: fastqc_db1/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log
+
+  - id: merge_fastqc_db2_sqlite
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: fastqc_db2/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log
+
+  - id: merge_fastqc_db_s_sqlite
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: fastqc_db_s/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log
+
+  - id: merge_fastqc_db_o1_sqlite
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: fastqc_db_o1/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log
+
+  - id: merge_fastqc_db_o2_sqlite
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: fastqc_db_o2/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log
+
+  - id: fastqc_pe_basicstats_json
+    run: ../../tools/fastqc_basicstatistics_json.cwl
+    in:
+      - id: sqlite_path
+        source: merge_fastqc_db1_sqlite/destination_sqlite
+    out:
+      - id: OUTPUT
+
+  - id: fastqc_se_basicstats_json
+    run: ../../tools/fastqc_basicstatistics_json.cwl
+    in:
+      - id: sqlite_path
+        source: merge_fastqc_db_s_sqlite/destination_sqlite
+    out:
+      - id: OUTPUT
+
+  - id: fastqc_o1_basicstats_json
+    run: ../../tools/fastqc_basicstatistics_json.cwl
+    in:
+      - id: sqlite_path
+        source: merge_fastqc_db_o1_sqlite/destination_sqlite
+    out:
+      - id: OUTPUT
+
+  - id: fastqc_o2_basicstats_json
+    run: ../../tools/fastqc_basicstatistics_json.cwl
+    in:
+      - id: sqlite_path
+        source: merge_fastqc_db_o2_sqlite/destination_sqlite
+    out:
+      - id: OUTPUT
+
+  - id: decider_bwa_pe
+    run: ../../tools/decider_bwa_expression.cwl
+    in:
+      - id: fastq_path
+        source: sort_scattered_fastq1/OUTPUT
+      - id: readgroup_path
+        source: bam_readgroup_to_json/OUTPUT
+    out:
+      - id: output_readgroup_paths
+
+  - id: decider_bwa_se
+    run: ../../tools/decider_bwa_expression.cwl
+    in:
+      - id: fastq_path
+        source: sort_scattered_fastq_s/OUTPUT
+      - id: readgroup_path
+        source: bam_readgroup_to_json/OUTPUT
+    out:
+      - id: output_readgroup_paths
+
+  - id: decider_bwa_o1
+    run: ../../tools/decider_bwa_expression.cwl
+    in:
+      - id: fastq_path
+        source: sort_scattered_fastq_o1/OUTPUT
+      - id: readgroup_path
+        source: bam_readgroup_to_json/OUTPUT
+    out:
+      - id: output_readgroup_paths
+
+  - id: decider_bwa_o2
+    run: ../../tools/decider_bwa_expression.cwl
+    in:
+      - id: fastq_path
+        source: sort_scattered_fastq_o2/OUTPUT
+      - id: readgroup_path
+        source: bam_readgroup_to_json/OUTPUT
+    out:
+      - id: output_readgroup_paths
+
+  - id: bwa_pe
+    run: ../../tools/bwa_pe.cwl
+    scatter: [fastq1, fastq2, readgroup_json_path]
+    scatterMethod: "dotproduct"
+    in:
+      - id: fasta
+        source: reference_fasta_path
+      - id: fastq1
+        source: sort_scattered_fastq1/OUTPUT
+      - id: fastq2
+        source: sort_scattered_fastq2/OUTPUT
+      - id: readgroup_json_path
+        source: decider_bwa_pe/output_readgroup_paths
+      - id: fastqc_json_path
+        source: fastqc_pe_basicstats_json/OUTPUT
+      - id: thread_count
+        source: thread_count
+    out:
+      - id: OUTPUT
+
+  - id: bwa_se
+    run: ../../tools/bwa_se.cwl
+    scatter: [fastq, readgroup_json_path]
+    scatterMethod: "dotproduct"
+    in:
+      - id: fasta
+        source: reference_fasta_path
+      - id: fastq
+        source: sort_scattered_fastq_s/OUTPUT
+      - id: readgroup_json_path
+        source: decider_bwa_se/output_readgroup_paths
+      - id: fastqc_json_path
+        source: fastqc_se_basicstats_json/OUTPUT
+      - id: thread_count
+        source: thread_count
+    out:
+      - id: OUTPUT
+
+  - id: bwa_o1
+    run: ../../tools/bwa_se.cwl
+    scatter: [fastq, readgroup_json_path]
+    scatterMethod: "dotproduct"
+    in:
+      - id: fasta
+        source: reference_fasta_path
+      - id: fastq
+        source: sort_scattered_fastq_o1/OUTPUT
+      - id: readgroup_json_path
+        source: decider_bwa_o1/output_readgroup_paths
+      - id: fastqc_json_path
+        source: fastqc_o1_basicstats_json/OUTPUT
+      - id: thread_count
+        source: thread_count
+    out:
+      - id: OUTPUT
+
+  - id: bwa_o2
+    run: ../../tools/bwa_se.cwl
+    scatter: [fastq, readgroup_json_path]
+    scatterMethod: "dotproduct"
+    in:
+      - id: fasta
+        source: reference_fasta_path
+      - id: fastq
+        source: sort_scattered_fastq_o2/OUTPUT
+      - id: readgroup_json_path
+        source: decider_bwa_o2/output_readgroup_paths
+      - id: fastqc_json_path
+        source: fastqc_o2_basicstats_json/OUTPUT
+      - id: thread_count
+        source: thread_count
+    out:
+      - id: OUTPUT
+
+  - id: picard_sortsam_pe
+    run: ../../tools/picard_sortsam.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: bwa_pe/OUTPUT
+      - id: OUTPUT
+        valueFrom: $(inputs.INPUT.basename)
+    out:
+      - id: SORTED_OUTPUT
+
+  - id: picard_sortsam_se
+    run: ../../tools/picard_sortsam.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: bwa_se/OUTPUT
+      - id: OUTPUT
+        valueFrom: $(inputs.INPUT.basename)
+    out:
+      - id: SORTED_OUTPUT
+
+  - id: picard_sortsam_o1
+    run: ../../tools/picard_sortsam.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: bwa_o1/OUTPUT
+      - id: OUTPUT
+        valueFrom: $(inputs.INPUT.basename)
+    out:
+      - id: SORTED_OUTPUT
+
+  - id: picard_sortsam_o2
+    run: ../../tools/picard_sortsam.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: bwa_o2/OUTPUT
+      - id: OUTPUT
+        valueFrom: $(inputs.INPUT.basename)
+    out:
+      - id: SORTED_OUTPUT
+
+  - id: metrics_pe
+    run: metrics.cwl
+    scatter: bam
+    in:
+      - id: bam
+        source: picard_sortsam_pe/SORTED_OUTPUT
+      - id: db_snp_vcf
+        source: db_snp_path
+      - id: fasta
+        source: reference_fasta_path
+      - id: input_state
+        valueFrom: "sorted_readgroup"
+      - id: parent_bam
+        source: bam_path
+        valueFrom: $(self.basename)
+      - id: thread_count
+        source: thread_count
+      - id: uuid
+        source: uuid
+    out:
+      - id: merge_sqlite_destination_sqlite
+
+  - id: merge_metrics_pe
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: metrics_pe/merge_sqlite_destination_sqlite
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log
+
+  - id: metrics_se
+    run: metrics.cwl
+    scatter: bam
+    in:
+      - id: bam
+        source: picard_sortsam_se/SORTED_OUTPUT
+      - id: db_snp_vcf
+        source: db_snp_path
+      - id: fasta
+        source: reference_fasta_path
+      - id: input_state
+        valueFrom: "sorted_readgroup"
+      - id: parent_bam
+        source: bam_path
+        valueFrom: $(self.basename)
+      - id: thread_count
+        source: thread_count
+      - id: uuid
+        source: uuid
+    out:
+      - id: merge_sqlite_destination_sqlite
+
+  - id: merge_metrics_se
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: metrics_se/merge_sqlite_destination_sqlite
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log
+
+  - id: picard_mergesamfiles_pe
+    run: ../../tools/picard_mergesamfiles.cwl
+    in:
+      - id: INPUT
+        source: picard_sortsam_pe/SORTED_OUTPUT
+      - id: OUTPUT
+        source: bam_path
+        valueFrom: $(self.basename)
+    out:
+      - id: MERGED_OUTPUT
+
+  - id: picard_mergesamfiles_se
+    run: ../../tools/picard_mergesamfiles.cwl
+    in:
+      - id: INPUT
+        source: picard_sortsam_se/SORTED_OUTPUT
+      - id: OUTPUT
+        source: bam_path
+        valueFrom: $(self.basename)
+    out:
+      - id: MERGED_OUTPUT
+
+  - id: picard_mergesamfiles_o1
+    run: ../../tools/picard_mergesamfiles.cwl
+    in:
+      - id: INPUT
+        source: picard_sortsam_o1/SORTED_OUTPUT
+      - id: OUTPUT
+        source: bam_path
+        valueFrom: $(self.basename)
+    out:
+      - id: MERGED_OUTPUT
+
+  - id: picard_mergesamfiles_o2
+    run: ../../tools/picard_mergesamfiles.cwl
+    in:
+      - id: INPUT
+        source: picard_sortsam_o2/SORTED_OUTPUT
+      - id: OUTPUT
+        source: bam_path
+        valueFrom: $(self.basename)
+    out:
+      - id: MERGED_OUTPUT
+
+  - id: picard_mergesamfiles
+    run: ../../tools/picard_mergesamfiles.cwl
+    in:
+      - id: INPUT
+        source: [
+        picard_mergesamfiles_pe/MERGED_OUTPUT,
+        picard_mergesamfiles_se/MERGED_OUTPUT,
+        picard_mergesamfiles_o1/MERGED_OUTPUT,
+        picard_mergesamfiles_o2/MERGED_OUTPUT
+        ]
+      - id: OUTPUT
+        source: bam_path
+        valueFrom: $(self.basename.slice(0,-4) + "_gdc_realn.bam")
+    out:
+      - id: MERGED_OUTPUT
+
+  - id: bam_reheader
+    run: ../../tools/bam_reheader.cwl
+    in:
+      - id: bam_path
+        source: picard_mergesamfiles/MERGED_OUTPUT
+    out:
+      - id: output_bam
+
+  - id: picard_markduplicates
+    run: ../../tools/picard_markduplicates.cwl
+    in:
+      - id: INPUT
+        source: bam_reheader/output_bam
+    out:
+      - id: OUTPUT
+      - id: METRICS
+
+  - id: picard_markduplicates_to_sqlite
+    run: ../../tools/picard_markduplicates_to_sqlite.cwl
+    in:
+      - id: bam
+        source: picard_markduplicates/OUTPUT
+        valueFrom: $(self.basename)
+      - id: input_state
+        valueFrom: "markduplicates_readgroups"
+      - id: metric_path
+        source: picard_markduplicates/METRICS
+      - id: uuid
+        source: uuid
+    out:
+      - id: sqlite
+
+  - id: picard_validatesamfile_markduplicates
+    run: ../../tools/picard_validatesamfile.cwl
+    in:
+      - id: INPUT
+        source: picard_markduplicates/OUTPUT
+      - id: VALIDATION_STRINGENCY
+        valueFrom: "STRICT"
+    out:
+      - id: OUTPUT
+
+  #need eof and dup QNAME detection
+  - id: picard_validatesamfile_markdupl_to_sqlite
+    run: ../../tools/picard_validatesamfile_to_sqlite.cwl
+    in:
+      - id: bam
+        source: bam_path
+        valueFrom: $(self.basename)
+      - id: input_state
+        valueFrom: "markduplicates_readgroups"
+      - id: metric_path
+        source: picard_validatesamfile_markduplicates/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: sqlite
+
+  - id: metrics_markduplicates
+    run: mixed_library_metrics.cwl
+    in:
+      - id: bam
+        source: picard_markduplicates/OUTPUT
+      - id: db_snp_vcf
+        source: db_snp_path
+      - id: fasta
+        source: reference_fasta_path
+      - id: input_state
+        valueFrom: "markduplicates_readgroups"
+      - id: thread_count
+        source: thread_count
+      - id: uuid
+        source: uuid
+    out:
+      - id: merge_sqlite_destination_sqlite
+
+  - id: integrity
+    run: integrity.cwl
+    in:
+      - id: bai_path
+        source: picard_markduplicates/OUTPUT
+        valueFrom: $(self.secondaryFiles[0])
+      - id: bam_path
+        source: picard_markduplicates/OUTPUT
+      - id: input_state
+        valueFrom: "markduplicates_readgroups"
+      - id: uuid
+        source: uuid
+    out:
+      - id: merge_sqlite_destination_sqlite
+
+  - id: merge_all_sqlite
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: [
+          picard_validatesamfile_original_to_sqlite/sqlite,
+          picard_validatesamfile_markdupl_to_sqlite/sqlite,
+          merge_readgroup_json_db/destination_sqlite,
+          merge_fastqc_db1_sqlite/destination_sqlite,
+          merge_fastqc_db2_sqlite/destination_sqlite,
+          merge_fastqc_db_s_sqlite/destination_sqlite,
+          merge_fastqc_db_o1_sqlite/destination_sqlite,
+          merge_fastqc_db_o2_sqlite/destination_sqlite,
+          merge_metrics_pe/destination_sqlite,
+          merge_metrics_se/destination_sqlite,
+          metrics_markduplicates/merge_sqlite_destination_sqlite,
+          picard_markduplicates_to_sqlite/sqlite,
+          integrity/merge_sqlite_destination_sqlite
+        ]
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log

--- a/dockstore-launcher/src/test/resources/gdc/cwl/workflows/dnaseq/integrity.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/workflows/dnaseq/integrity.cwl
@@ -1,0 +1,119 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+class: Workflow
+
+requirements:
+ - class: StepInputExpressionRequirement
+ - class: MultipleInputFeatureRequirement
+
+inputs:
+  - id: bai_path
+    type: File
+  - id: bam_path
+    type: File
+  - id: input_state
+    type: string
+  - id: uuid
+    type: string
+
+outputs:
+  - id: merge_sqlite_destination_sqlite
+    type: File
+    outputSource: merge_sqlite/destination_sqlite
+
+steps:
+  - id: bai_ls_l
+    run: ../../tools/ls_l.cwl
+    in:
+      - id: INPUT
+        source: bai_path
+    out:
+      - id: OUTPUT
+
+  - id: bai_md5sum
+    run: ../../tools/md5sum.cwl
+    in:
+      - id: INPUT
+        source: bai_path
+    out:
+      - id: OUTPUT
+
+  - id: bai_sha256
+    run: ../../tools/sha256sum.cwl
+    in:
+      - id: INPUT
+        source: bai_path
+    out:
+      - id: OUTPUT
+
+  - id: bam_ls_l
+    run: ../../tools/ls_l.cwl
+    in:
+      - id: INPUT
+        source: bam_path
+    out:
+      - id: OUTPUT
+
+  - id: bam_md5sum
+    run: ../../tools/md5sum.cwl
+    in:
+      - id: INPUT
+        source: bam_path
+    out:
+      - id: OUTPUT
+
+  - id: bam_sha256
+    run: ../../tools/sha256sum.cwl
+    in:
+      - id: INPUT
+        source: bam_path
+    out:
+      - id: OUTPUT
+
+  - id: bai_integrity_to_db
+    run: ../../tools/integrity_to_sqlite.cwl
+    in:
+      - id: input_state
+        source: input_state
+      - id: ls_l_path
+        source: bai_ls_l/OUTPUT
+      - id: md5sum_path
+        source: bai_md5sum/OUTPUT
+      - id: sha256sum_path
+        source: bai_sha256/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: OUTPUT
+
+  - id: bam_integrity_to_db
+    run: ../../tools/integrity_to_sqlite.cwl
+    in:
+      - id: input_state
+        source: input_state
+      - id: ls_l_path
+        source: bam_ls_l/OUTPUT
+      - id: md5sum_path
+        source: bam_md5sum/OUTPUT
+      - id: sha256sum_path
+        source: bam_sha256/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: OUTPUT
+
+  - id: merge_sqlite
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: [
+        bai_integrity_to_db/OUTPUT,
+        bam_integrity_to_db/OUTPUT
+        ]
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log

--- a/dockstore-launcher/src/test/resources/gdc/cwl/workflows/dnaseq/metrics.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/workflows/dnaseq/metrics.cwl
@@ -1,0 +1,323 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+class: Workflow
+
+requirements:
+  - class: InlineJavascriptRequirement
+
+inputs:
+  - id: bam
+    type: File
+  - id: db_snp_vcf
+    type: File
+  - id: fasta
+    type: File
+  - id: input_state
+    type: string
+  - id: parent_bam
+    type: string
+  - id: thread_count
+    type: int
+  - id: uuid
+    type: string
+
+outputs:
+  - id: merge_sqlite_destination_sqlite
+    type: File
+    outputSource: merge_sqlite/destination_sqlite
+
+steps:
+  # - id: get_bam_readgroups
+  #   run: ../../tools/get_bam_readgroups.cwl
+  #   in:
+  #     - id: bam
+  #       source: bam
+  #   out:
+  #     - id: readgroups
+
+  # - id: get_bam_library
+  #   run: ../../tools/get_bam_library.cwl
+  #   in:
+  #     - id: readgroups
+  #       source: get_bam_readgroups/readgroups
+  #   out:
+  #     - id: library
+
+  # - id: get_bam_exome_kit
+  #   run: ../../tools/get_bam_exome_kit.cwl
+  #   in:
+  #     - id: bam
+  #       source: parent_bam
+  #     - id: library
+  #       source: get_bam_library/library
+  #   out:
+  #     - id: exome_kit
+
+  # - id: get_bait_target
+  #   run: ../../tools/get_bait_target.cwl
+  #   in:
+  #     - id: exome_kit
+  #       source: get_bam_exome_kit/exome_kit
+  #   out:
+  #     - id: bait
+  #     - id: target
+
+  # - id: picard_collecthsmetrics
+  #   run: ../../tools/picard_collecthsmetrics.cwl
+  #   in:
+  #     - id: BAIT_INTERVALS
+  #       source: get_bait_target/bait
+  #     - id: INPUT
+  #       source: bam
+  #     - id: OUTPUT
+  #       source: bam
+  #       valueFrom: $(self.basename + ".metrics")
+  #     - id: REFERENCE_SEQUENCE
+  #       source: fasta
+  #     - id: TARGET_INTERVALS
+  #       source: get_bait_target/target
+  #   out:
+  #     - id: METRIC_OUTPUT
+
+  # - id: picard_collecthsmetrics_to_sqlite
+  #   run: ../../tools/picard_collecthsmetrics_to_sqlite.cwl
+  #   in:
+  #     - id: bam
+  #       source: bam
+  #       valueFrom: $(self.basename)
+  #     - id: bam_library
+  #       source: get_bam_library/library
+  #     - id: exome_kit
+  #       source: get_bam_exome_kit/exome_kit
+  #     - id: fasta
+  #       source: fasta
+  #       valueFrom: $(self.basename)
+  #     - id: input_state
+  #       source: input_state
+  #     - id: metric_path
+  #       source: picard_collecthsmetrics/METRIC_OUTPUT
+  #     - id: uuid
+  #       source: uuid
+  #   out:
+  #     - id: log
+  #     - id: sqlite
+
+  - id: picard_collectmultiplemetrics
+    run: ../../tools/picard_collectmultiplemetrics.cwl
+    in:
+      - id: DB_SNP
+        source: db_snp_vcf
+      - id: INPUT
+        source: bam
+      - id: REFERENCE_SEQUENCE
+        source: fasta
+    out:
+      - id: alignment_summary_metrics
+      - id: bait_bias_detail_metrics
+      - id: bait_bias_summary_metrics
+      - id: base_distribution_by_cycle_metrics
+      - id: gc_bias_detail_metrics
+      - id: gc_bias_summary_metrics
+      - id: insert_size_metrics
+      - id: pre_adapter_detail_metrics
+      - id: pre_adapter_summary_metrics
+      - id: quality_by_cycle_metrics
+      - id: quality_distribution_metrics
+      - id: quality_yield_metrics
+
+  - id: picard_collectmultiplemetrics_to_sqlite
+    run: ../../tools/picard_collectmultiplemetrics_to_sqlite.cwl
+    in:
+      - id: bam
+        source: bam
+        valueFrom: $(self.basename)
+      - id: fasta
+        source: fasta
+        valueFrom: $(self.basename)
+      - id: input_state
+        source: input_state
+      - id: uuid
+        source: uuid
+      - id: vcf
+        source: db_snp_vcf
+        valueFrom: $(self.basename)
+      - id: alignment_summary_metrics
+        source: picard_collectmultiplemetrics/alignment_summary_metrics
+      - id: bait_bias_detail_metrics
+        source: picard_collectmultiplemetrics/bait_bias_detail_metrics
+      - id: bait_bias_summary_metrics
+        source: picard_collectmultiplemetrics/bait_bias_summary_metrics
+      - id: base_distribution_by_cycle_metrics
+        source: picard_collectmultiplemetrics/base_distribution_by_cycle_metrics
+      - id: gc_bias_detail_metrics
+        source: picard_collectmultiplemetrics/gc_bias_detail_metrics
+      - id: gc_bias_summary_metrics
+        source: picard_collectmultiplemetrics/gc_bias_summary_metrics
+      - id: insert_size_metrics
+        source: picard_collectmultiplemetrics/insert_size_metrics
+      - id: pre_adapter_detail_metrics
+        source: picard_collectmultiplemetrics/pre_adapter_detail_metrics
+      - id: pre_adapter_summary_metrics
+        source: picard_collectmultiplemetrics/pre_adapter_summary_metrics
+      - id: quality_by_cycle_metrics
+        source: picard_collectmultiplemetrics/quality_by_cycle_metrics
+      - id: quality_distribution_metrics
+        source: picard_collectmultiplemetrics/quality_distribution_metrics
+      - id: quality_yield_metrics
+        source: picard_collectmultiplemetrics/quality_yield_metrics
+    out:
+      - id: log
+      - id: sqlite
+
+  - id: picard_collectoxogmetrics
+    run: ../../tools/picard_collectoxogmetrics.cwl
+    in:
+      - id: DB_SNP
+        source: db_snp_vcf
+      - id: INPUT
+        source: bam
+      - id: REFERENCE_SEQUENCE
+        source: fasta
+    out:
+      - id: OUTPUT
+
+  - id: picard_collectoxogmetrics_to_sqlite
+    run: ../../tools/picard_collectoxogmetrics_to_sqlite.cwl
+    in:
+      - id: bam
+        source: bam
+        valueFrom: $(self.basename)
+      - id: fasta
+        source: fasta
+        valueFrom: $(self.basename)
+      - id: input_state
+        source: input_state
+      - id: metric_path
+        source: picard_collectoxogmetrics/OUTPUT
+      - id: uuid
+        source: uuid
+      - id: vcf
+        source: db_snp_vcf
+        valueFrom: $(self.basename)
+    out:
+      - id: log
+      - id: sqlite
+
+  - id: picard_collectwgsmetrics
+    run: ../../tools/picard_collectwgsmetrics.cwl
+    in:
+      - id: INPUT
+        source: bam
+      - id: REFERENCE_SEQUENCE
+        source: fasta
+    out:
+      - id: OUTPUT
+
+  - id: picard_collectwgsmetrics_to_sqlite
+    run: ../../tools/picard_collectwgsmetrics_to_sqlite.cwl
+    in:
+      - id: bam
+        source: bam
+        valueFrom: $(self.basename)
+      - id: fasta
+        source: fasta
+        valueFrom: $(self.basename)
+      - id: input_state
+        source: input_state
+      - id: metric_path
+        source: picard_collectwgsmetrics/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: log
+      - id: sqlite
+
+  - id: samtools_flagstat
+    run: ../../tools/samtools_flagstat.cwl
+    in:
+      - id: INPUT
+        source: bam
+    out:
+      - id: OUTPUT
+
+  - id: samtools_flagstat_to_sqlite
+    run: ../../tools/samtools_flagstat_to_sqlite.cwl
+    in:
+      - id: bam
+        source: bam
+        valueFrom: $(self.basename)
+      - id: input_state
+        source: input_state
+      - id: metric_path
+        source: samtools_flagstat/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: sqlite
+
+  - id: samtools_idxstats
+    run: ../../tools/samtools_idxstats.cwl
+    in:
+      - id: INPUT
+        source: bam
+    out:
+      - id: OUTPUT
+
+  - id: samtools_idxstats_to_sqlite
+    run: ../../tools/samtools_idxstats_to_sqlite.cwl
+    in:
+      - id: bam
+        source: bam
+        valueFrom: $(self.basename)
+      - id: input_state
+        source: input_state
+      - id: metric_path
+        source: samtools_idxstats/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: sqlite
+
+  - id: samtools_stats
+    run: ../../tools/samtools_stats.cwl
+    in:
+      - id: INPUT
+        source: bam
+    out:
+      - id: OUTPUT
+
+  - id: samtools_stats_to_sqlite
+    run: ../../tools/samtools_stats_to_sqlite.cwl
+    in:
+      - id: bam
+        source: bam
+        valueFrom: $(self.basename)
+      - id: input_state
+        source: input_state
+      - id: metric_path
+        source: samtools_stats/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: sqlite
+
+  - id: merge_sqlite
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: [
+#          picard_collecthsmetrics_to_sqlite/sqlite,
+          picard_collectmultiplemetrics_to_sqlite/sqlite,
+          picard_collectoxogmetrics_to_sqlite/sqlite,
+          picard_collectwgsmetrics_to_sqlite/sqlite,
+          samtools_flagstat_to_sqlite/sqlite,
+          samtools_idxstats_to_sqlite/sqlite,
+          samtools_stats_to_sqlite/sqlite
+        ]
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log

--- a/dockstore-launcher/src/test/resources/gdc/cwl/workflows/dnaseq/mixed_library_metrics.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/workflows/dnaseq/mixed_library_metrics.cwl
@@ -1,0 +1,245 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+class: Workflow
+
+requirements:
+  - class: InlineJavascriptRequirement
+
+inputs:
+  - id: bam
+    type: File
+  - id: db_snp_vcf
+    type: File
+  - id: fasta
+    type: File
+  - id: input_state
+    type: string
+  - id: thread_count
+    type: int
+  - id: uuid
+    type: string
+
+outputs:
+  - id: merge_sqlite_destination_sqlite
+    type: File
+    outputSource: merge_sqlite/destination_sqlite
+
+steps:
+  - id: picard_collectmultiplemetrics
+    run: ../../tools/picard_collectmultiplemetrics.cwl
+    in:
+      - id: DB_SNP
+        source: db_snp_vcf
+      - id: INPUT
+        source: bam
+      - id: REFERENCE_SEQUENCE
+        source: fasta
+    out:
+      - id: alignment_summary_metrics
+      - id: bait_bias_detail_metrics
+      - id: bait_bias_summary_metrics
+      - id: base_distribution_by_cycle_metrics
+      - id: gc_bias_detail_metrics
+      - id: gc_bias_summary_metrics
+      - id: insert_size_metrics
+      - id: pre_adapter_detail_metrics
+      - id: pre_adapter_summary_metrics
+      - id: quality_by_cycle_metrics
+      - id: quality_distribution_metrics
+      - id: quality_yield_metrics
+
+  - id: picard_collectmultiplemetrics_to_sqlite
+    run: ../../tools/picard_collectmultiplemetrics_to_sqlite.cwl
+    in:
+      - id: bam
+        source: bam
+        valueFrom: $(self.basename)
+      - id: fasta
+        source: fasta
+        valueFrom: $(self.basename)
+      - id: input_state
+        source: input_state
+      - id: uuid
+        source: uuid
+      - id: vcf
+        source: db_snp_vcf
+        valueFrom: $(self.basename)
+      - id: alignment_summary_metrics
+        source: picard_collectmultiplemetrics/alignment_summary_metrics
+      - id: bait_bias_detail_metrics
+        source: picard_collectmultiplemetrics/bait_bias_detail_metrics
+      - id: bait_bias_summary_metrics
+        source: picard_collectmultiplemetrics/bait_bias_summary_metrics
+      - id: base_distribution_by_cycle_metrics
+        source: picard_collectmultiplemetrics/base_distribution_by_cycle_metrics
+      - id: gc_bias_detail_metrics
+        source: picard_collectmultiplemetrics/gc_bias_detail_metrics
+      - id: gc_bias_summary_metrics
+        source: picard_collectmultiplemetrics/gc_bias_summary_metrics
+      - id: insert_size_metrics
+        source: picard_collectmultiplemetrics/insert_size_metrics
+      - id: pre_adapter_detail_metrics
+        source: picard_collectmultiplemetrics/pre_adapter_detail_metrics
+      - id: pre_adapter_summary_metrics
+        source: picard_collectmultiplemetrics/pre_adapter_summary_metrics
+      - id: quality_by_cycle_metrics
+        source: picard_collectmultiplemetrics/quality_by_cycle_metrics
+      - id: quality_distribution_metrics
+        source: picard_collectmultiplemetrics/quality_distribution_metrics
+      - id: quality_yield_metrics
+        source: picard_collectmultiplemetrics/quality_yield_metrics
+    out:
+      - id: log
+      - id: sqlite
+
+  - id: picard_collectoxogmetrics
+    run: ../../tools/picard_collectoxogmetrics.cwl
+    in:
+      - id: DB_SNP
+        source: db_snp_vcf
+      - id: INPUT
+        source: bam
+      - id: REFERENCE_SEQUENCE
+        source: fasta
+    out:
+      - id: OUTPUT
+
+  - id: picard_collectoxogmetrics_to_sqlite
+    run: ../../tools/picard_collectoxogmetrics_to_sqlite.cwl
+    in:
+      - id: bam
+        source: bam
+        valueFrom: $(self.basename)
+      - id: fasta
+        source: fasta
+        valueFrom: $(self.basename)
+      - id: input_state
+        source: input_state
+      - id: metric_path
+        source: picard_collectoxogmetrics/OUTPUT
+      - id: uuid
+        source: uuid
+      - id: vcf
+        source: db_snp_vcf
+        valueFrom: $(self.basename)
+    out:
+      - id: log
+      - id: sqlite
+
+  - id: picard_collectwgsmetrics
+    run: ../../tools/picard_collectwgsmetrics.cwl
+    in:
+      - id: INPUT
+        source: bam
+      - id: REFERENCE_SEQUENCE
+        source: fasta
+    out:
+      - id: OUTPUT
+
+  - id: picard_collectwgsmetrics_to_sqlite
+    run: ../../tools/picard_collectwgsmetrics_to_sqlite.cwl
+    in:
+      - id: bam
+        source: bam
+        valueFrom: $(self.basename)
+      - id: fasta
+        source: fasta
+        valueFrom: $(self.basename)
+      - id: input_state
+        source: input_state
+      - id: metric_path
+        source: picard_collectwgsmetrics/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: log
+      - id: sqlite
+
+  - id: samtools_flagstat
+    run: ../../tools/samtools_flagstat.cwl
+    in:
+      - id: INPUT
+        source: bam
+    out:
+      - id: OUTPUT
+
+  - id: samtools_flagstat_to_sqlite
+    run: ../../tools/samtools_flagstat_to_sqlite.cwl
+    in:
+      - id: bam
+        source: bam
+        valueFrom: $(self.basename)
+      - id: input_state
+        source: input_state
+      - id: metric_path
+        source: samtools_flagstat/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: sqlite
+
+  - id: samtools_idxstats
+    run: ../../tools/samtools_idxstats.cwl
+    in:
+      - id: INPUT
+        source: bam
+    out:
+      - id: OUTPUT
+
+  - id: samtools_idxstats_to_sqlite
+    run: ../../tools/samtools_idxstats_to_sqlite.cwl
+    in:
+      - id: bam
+        source: bam
+        valueFrom: $(self.basename)
+      - id: input_state
+        source: input_state
+      - id: metric_path
+        source: samtools_idxstats/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: sqlite
+
+  - id: samtools_stats
+    run: ../../tools/samtools_stats.cwl
+    in:
+      - id: INPUT
+        source: bam
+    out:
+      - id: OUTPUT
+
+  - id: samtools_stats_to_sqlite
+    run: ../../tools/samtools_stats_to_sqlite.cwl
+    in:
+      - id: bam
+        source: bam
+        valueFrom: $(self.basename)
+      - id: input_state
+        source: input_state
+      - id: metric_path
+        source: samtools_stats/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: sqlite
+
+  - id: merge_sqlite
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: [
+          picard_collectmultiplemetrics_to_sqlite/sqlite,
+          picard_collectoxogmetrics_to_sqlite/sqlite,
+          picard_collectwgsmetrics_to_sqlite/sqlite,
+          samtools_flagstat_to_sqlite/sqlite,
+          samtools_idxstats_to_sqlite/sqlite,
+          samtools_stats_to_sqlite/sqlite
+        ]
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log

--- a/dockstore-launcher/src/test/resources/gdc/cwl/workflows/dnaseq/transform.cwl
+++ b/dockstore-launcher/src/test/resources/gdc/cwl/workflows/dnaseq/transform.cwl
@@ -1,0 +1,799 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+
+class: Workflow
+
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: MultipleInputFeatureRequirement
+  - class: ScatterFeatureRequirement
+  - class: StepInputExpressionRequirement
+  - class: SubworkflowFeatureRequirement
+
+inputs:
+  - id: bam_path
+    type: File
+  - id: db_snp_path
+    type: File
+  - id: reference_fasta_path
+    type: File
+  - id: thread_count
+    type: int
+  - id: uuid
+    type: string
+
+outputs:
+  - id: picard_markduplicates_output
+    type: File
+    outputSource: picard_markduplicates/OUTPUT
+  - id: merge_all_sqlite_destination_sqlite
+    type: File
+    outputSource: merge_all_sqlite/destination_sqlite
+
+steps:
+  - id: samtools_bamtobam
+    run: ../../tools/samtools_bamtobam.cwl
+    in:
+      - id: INPUT
+        source: bam_path
+    out:
+      - id: OUTPUT
+
+  - id: picard_validatesamfile_original
+    run: ../../tools/picard_validatesamfile.cwl
+    in:
+      - id: INPUT
+        source: samtools_bamtobam/OUTPUT
+      - id: VALIDATION_STRINGENCY
+        valueFrom: "LENIENT"
+    out:
+      - id: OUTPUT
+
+  # need eof and dup QNAME detection
+  - id: picard_validatesamfile_original_to_sqlite
+    run: ../../tools/picard_validatesamfile_to_sqlite.cwl
+    in:
+      - id: bam
+        source: bam_path
+        valueFrom: $(self.basename)
+      - id: input_state
+        valueFrom: "original"
+      - id: metric_path
+        source: picard_validatesamfile_original/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: sqlite
+
+  - id: biobambam_bamtofastq
+    run: ../../tools/biobambam2_bamtofastq.cwl
+    in:
+      - id: filename
+        source: samtools_bamtobam/OUTPUT
+    out:
+      - id: output_fastq1
+      - id: output_fastq2
+      - id: output_fastq_o1
+      - id: output_fastq_o2
+      - id: output_fastq_s
+
+  - id: remove_duplicate_fastq1
+    run: ../../tools/fastq_remove_duplicate_qname.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: biobambam_bamtofastq/output_fastq1
+    out:
+      - id: OUTPUT
+
+  - id: remove_duplicate_fastq2
+    run: ../../tools/fastq_remove_duplicate_qname.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: biobambam_bamtofastq/output_fastq2
+    out:
+      - id: OUTPUT
+
+  - id: remove_duplicate_fastq_o1
+    run: ../../tools/fastq_remove_duplicate_qname.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: biobambam_bamtofastq/output_fastq_o1
+    out:
+      - id: OUTPUT
+
+  - id: remove_duplicate_fastq_o2
+    run: ../../tools/fastq_remove_duplicate_qname.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: biobambam_bamtofastq/output_fastq_o2
+    out:
+      - id: OUTPUT
+
+  - id: remove_duplicate_fastq_s
+    run: ../../tools/fastq_remove_duplicate_qname.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: biobambam_bamtofastq/output_fastq_s
+    out:
+      - id: OUTPUT
+
+  - id: sort_scattered_fastq1
+    run: ../../tools/sort_scatter_expression.cwl
+    in:
+      - id: INPUT
+        source: remove_duplicate_fastq1/OUTPUT
+    out:
+      - id: OUTPUT
+
+  - id: sort_scattered_fastq2
+    run: ../../tools/sort_scatter_expression.cwl
+    in:
+      - id: INPUT
+        source: remove_duplicate_fastq2/OUTPUT
+    out:
+      - id: OUTPUT
+
+  - id: sort_scattered_fastq_o1
+    run: ../../tools/sort_scatter_expression.cwl
+    in:
+      - id: INPUT
+        source: remove_duplicate_fastq_o1/OUTPUT
+    out:
+      - id: OUTPUT
+
+  - id: sort_scattered_fastq_o2
+    run: ../../tools/sort_scatter_expression.cwl
+    in:
+      - id: INPUT
+        source: remove_duplicate_fastq_o2/OUTPUT
+    out:
+      - id: OUTPUT
+
+  - id: sort_scattered_fastq_s
+    run: ../../tools/sort_scatter_expression.cwl
+    in:
+      - id: INPUT
+        source: remove_duplicate_fastq_s/OUTPUT
+    out:
+      - id: OUTPUT
+
+  - id: bam_readgroup_to_json
+    run: ../../tools/bam_readgroup_to_json.cwl
+    in:
+      - id: INPUT
+        source: samtools_bamtobam/OUTPUT
+      - id: MODE
+        valueFrom: "lenient"
+    out:
+      - id: OUTPUT
+
+  - id: readgroup_json_db
+    run: ../../tools/readgroup_json_db.cwl
+    scatter: json_path
+    in:
+      - id: json_path
+        source: bam_readgroup_to_json/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: log
+      - id: output_sqlite
+
+  - id: merge_readgroup_json_db
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: readgroup_json_db/output_sqlite
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log
+
+  - id: fastqc1
+    run: ../../tools/fastqc.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: sort_scattered_fastq1/OUTPUT
+      - id: threads
+        source: thread_count
+    out:
+      - id: OUTPUT
+
+  - id: fastqc2
+    run: ../../tools/fastqc.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: sort_scattered_fastq2/OUTPUT
+      - id: threads
+        source: thread_count
+    out:
+      - id: OUTPUT
+
+  - id: fastqc_s
+    run: ../../tools/fastqc.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: sort_scattered_fastq_s/OUTPUT
+      - id: threads
+        source: thread_count
+    out:
+      - id: OUTPUT
+
+  - id: fastqc_o1
+    run: ../../tools/fastqc.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: sort_scattered_fastq_o1/OUTPUT
+      - id: threads
+        source: thread_count
+    out:
+      - id: OUTPUT
+
+  - id: fastqc_o2
+    run: ../../tools/fastqc.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: sort_scattered_fastq_o2/OUTPUT
+      - id: threads
+        source: thread_count
+    out:
+      - id: OUTPUT
+
+  - id: fastqc_db1
+    run: ../../tools/fastqc_db.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: fastqc1/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: LOG
+      - id: OUTPUT
+
+  - id: fastqc_db2
+    run: ../../tools/fastqc_db.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: fastqc2/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: LOG
+      - id: OUTPUT
+
+  - id: fastqc_db_s
+    run: ../../tools/fastqc_db.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: fastqc_s/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: LOG
+      - id: OUTPUT
+
+  - id: fastqc_db_o1
+    run: ../../tools/fastqc_db.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: fastqc_o1/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: LOG
+      - id: OUTPUT
+
+  - id: fastqc_db_o2
+    run: ../../tools/fastqc_db.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: fastqc_o2/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: LOG
+      - id: OUTPUT
+
+  - id: merge_fastqc_db1_sqlite
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: fastqc_db1/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log
+
+  - id: merge_fastqc_db2_sqlite
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: fastqc_db2/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log
+
+  - id: merge_fastqc_db_s_sqlite
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: fastqc_db_s/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log
+
+  - id: merge_fastqc_db_o1_sqlite
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: fastqc_db_o1/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log
+
+  - id: merge_fastqc_db_o2_sqlite
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: fastqc_db_o2/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log
+
+  - id: fastqc_pe_basicstats_json
+    run: ../../tools/fastqc_basicstatistics_json.cwl
+    in:
+      - id: sqlite_path
+        source: merge_fastqc_db1_sqlite/destination_sqlite
+    out:
+      - id: OUTPUT
+
+  - id: fastqc_se_basicstats_json
+    run: ../../tools/fastqc_basicstatistics_json.cwl
+    in:
+      - id: sqlite_path
+        source: merge_fastqc_db_s_sqlite/destination_sqlite
+    out:
+      - id: OUTPUT
+
+  - id: fastqc_o1_basicstats_json
+    run: ../../tools/fastqc_basicstatistics_json.cwl
+    in:
+      - id: sqlite_path
+        source: merge_fastqc_db_o1_sqlite/destination_sqlite
+    out:
+      - id: OUTPUT
+
+  - id: fastqc_o2_basicstats_json
+    run: ../../tools/fastqc_basicstatistics_json.cwl
+    in:
+      - id: sqlite_path
+        source: merge_fastqc_db_o2_sqlite/destination_sqlite
+    out:
+      - id: OUTPUT
+
+  - id: decider_bwa_pe
+    run: ../../tools/decider_bwa_expression.cwl
+    in:
+      - id: fastq_path
+        source: sort_scattered_fastq1/OUTPUT
+      - id: readgroup_path
+        source: bam_readgroup_to_json/OUTPUT
+    out:
+      - id: output_readgroup_paths
+
+  - id: decider_bwa_se
+    run: ../../tools/decider_bwa_expression.cwl
+    in:
+      - id: fastq_path
+        source: sort_scattered_fastq_s/OUTPUT
+      - id: readgroup_path
+        source: bam_readgroup_to_json/OUTPUT
+    out:
+      - id: output_readgroup_paths
+
+  - id: decider_bwa_o1
+    run: ../../tools/decider_bwa_expression.cwl
+    in:
+      - id: fastq_path
+        source: sort_scattered_fastq_o1/OUTPUT
+      - id: readgroup_path
+        source: bam_readgroup_to_json/OUTPUT
+    out:
+      - id: output_readgroup_paths
+
+  - id: decider_bwa_o2
+    run: ../../tools/decider_bwa_expression.cwl
+    in:
+      - id: fastq_path
+        source: sort_scattered_fastq_o2/OUTPUT
+      - id: readgroup_path
+        source: bam_readgroup_to_json/OUTPUT
+    out:
+      - id: output_readgroup_paths
+
+  - id: bwa_pe
+    run: ../../tools/bwa_pe.cwl
+    scatter: [fastq1, fastq2, readgroup_json_path]
+    scatterMethod: "dotproduct"
+    in:
+      - id: fasta
+        source: reference_fasta_path
+      - id: fastq1
+        source: sort_scattered_fastq1/OUTPUT
+      - id: fastq2
+        source: sort_scattered_fastq2/OUTPUT
+      - id: readgroup_json_path
+        source: decider_bwa_pe/output_readgroup_paths
+      - id: fastqc_json_path
+        source: fastqc_pe_basicstats_json/OUTPUT
+      - id: thread_count
+        source: thread_count
+    out:
+      - id: OUTPUT
+
+  - id: bwa_se
+    run: ../../tools/bwa_se.cwl
+    scatter: [fastq, readgroup_json_path]
+    scatterMethod: "dotproduct"
+    in:
+      - id: fasta
+        source: reference_fasta_path
+      - id: fastq
+        source: sort_scattered_fastq_s/OUTPUT
+      - id: readgroup_json_path
+        source: decider_bwa_se/output_readgroup_paths
+      - id: fastqc_json_path
+        source: fastqc_se_basicstats_json/OUTPUT
+      - id: thread_count
+        source: thread_count
+    out:
+      - id: OUTPUT
+
+  - id: bwa_o1
+    run: ../../tools/bwa_se.cwl
+    scatter: [fastq, readgroup_json_path]
+    scatterMethod: "dotproduct"
+    in:
+      - id: fasta
+        source: reference_fasta_path
+      - id: fastq
+        source: sort_scattered_fastq_o1/OUTPUT
+      - id: readgroup_json_path
+        source: decider_bwa_o1/output_readgroup_paths
+      - id: fastqc_json_path
+        source: fastqc_o1_basicstats_json/OUTPUT
+      - id: thread_count
+        source: thread_count
+    out:
+      - id: OUTPUT
+
+  - id: bwa_o2
+    run: ../../tools/bwa_se.cwl
+    scatter: [fastq, readgroup_json_path]
+    scatterMethod: "dotproduct"
+    in:
+      - id: fasta
+        source: reference_fasta_path
+      - id: fastq
+        source: sort_scattered_fastq_o2/OUTPUT
+      - id: readgroup_json_path
+        source: decider_bwa_o2/output_readgroup_paths
+      - id: fastqc_json_path
+        source: fastqc_o2_basicstats_json/OUTPUT
+      - id: thread_count
+        source: thread_count
+    out:
+      - id: OUTPUT
+
+  - id: picard_sortsam_pe
+    run: ../../tools/picard_sortsam.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: bwa_pe/OUTPUT
+      - id: OUTPUT
+        valueFrom: $(inputs.INPUT.basename)
+    out:
+      - id: SORTED_OUTPUT
+
+  - id: picard_sortsam_se
+    run: ../../tools/picard_sortsam.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: bwa_se/OUTPUT
+      - id: OUTPUT
+        valueFrom: $(inputs.INPUT.basename)
+    out:
+      - id: SORTED_OUTPUT
+
+  - id: picard_sortsam_o1
+    run: ../../tools/picard_sortsam.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: bwa_o1/OUTPUT
+      - id: OUTPUT
+        valueFrom: $(inputs.INPUT.basename)
+    out:
+      - id: SORTED_OUTPUT
+
+  - id: picard_sortsam_o2
+    run: ../../tools/picard_sortsam.cwl
+    scatter: INPUT
+    in:
+      - id: INPUT
+        source: bwa_o2/OUTPUT
+      - id: OUTPUT
+        valueFrom: $(inputs.INPUT.basename)
+    out:
+      - id: SORTED_OUTPUT
+
+  - id: metrics_pe
+    run: metrics.cwl
+    scatter: bam
+    in:
+      - id: bam
+        source: picard_sortsam_pe/SORTED_OUTPUT
+      - id: db_snp_vcf
+        source: db_snp_path
+      - id: fasta
+        source: reference_fasta_path
+      - id: input_state
+        valueFrom: "sorted_readgroup"
+      - id: parent_bam
+        source: bam_path
+        valueFrom: $(self.basename)
+      - id: thread_count
+        source: thread_count
+      - id: uuid
+        source: uuid
+    out:
+      - id: merge_sqlite_destination_sqlite
+
+  - id: merge_metrics_pe
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: metrics_pe/merge_sqlite_destination_sqlite
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log
+
+  - id: metrics_se
+    run: metrics.cwl
+    scatter: bam
+    in:
+      - id: bam
+        source: picard_sortsam_se/SORTED_OUTPUT
+      - id: db_snp_vcf
+        source: db_snp_path
+      - id: fasta
+        source: reference_fasta_path
+      - id: input_state
+        valueFrom: "sorted_readgroup"
+      - id: parent_bam
+        source: bam_path
+        valueFrom: $(self.basename)
+      - id: thread_count
+        source: thread_count
+      - id: uuid
+        source: uuid
+    out:
+      - id: merge_sqlite_destination_sqlite
+
+  - id: merge_metrics_se
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: metrics_se/merge_sqlite_destination_sqlite
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log
+
+  - id: picard_mergesamfiles_pe
+    run: ../../tools/picard_mergesamfiles.cwl
+    in:
+      - id: INPUT
+        source: picard_sortsam_pe/SORTED_OUTPUT
+      - id: OUTPUT
+        source: bam_path
+        valueFrom: $(self.basename)
+    out:
+      - id: MERGED_OUTPUT
+
+  - id: picard_mergesamfiles_se
+    run: ../../tools/picard_mergesamfiles.cwl
+    in:
+      - id: INPUT
+        source: picard_sortsam_se/SORTED_OUTPUT
+      - id: OUTPUT
+        source: bam_path
+        valueFrom: $(self.basename)
+    out:
+      - id: MERGED_OUTPUT
+
+  - id: picard_mergesamfiles_o1
+    run: ../../tools/picard_mergesamfiles.cwl
+    in:
+      - id: INPUT
+        source: picard_sortsam_o1/SORTED_OUTPUT
+      - id: OUTPUT
+        source: bam_path
+        valueFrom: $(self.basename)
+    out:
+      - id: MERGED_OUTPUT
+
+  - id: picard_mergesamfiles_o2
+    run: ../../tools/picard_mergesamfiles.cwl
+    in:
+      - id: INPUT
+        source: picard_sortsam_o2/SORTED_OUTPUT
+      - id: OUTPUT
+        source: bam_path
+        valueFrom: $(self.basename)
+    out:
+      - id: MERGED_OUTPUT
+
+  - id: picard_mergesamfiles
+    run: ../../tools/picard_mergesamfiles.cwl
+    in:
+      - id: INPUT
+        source: [
+        picard_mergesamfiles_pe/MERGED_OUTPUT,
+        picard_mergesamfiles_se/MERGED_OUTPUT,
+        picard_mergesamfiles_o1/MERGED_OUTPUT,
+        picard_mergesamfiles_o2/MERGED_OUTPUT
+        ]
+      - id: OUTPUT
+        source: bam_path
+        valueFrom: $(self.basename.slice(0,-4) + "_gdc_realn.bam")
+    out:
+      - id: MERGED_OUTPUT
+
+  - id: bam_reheader
+    run: ../../tools/bam_reheader.cwl
+    in:
+      - id: bam_path
+        source: picard_mergesamfiles/MERGED_OUTPUT
+    out:
+      - id: output_bam
+
+  - id: picard_markduplicates
+    run: ../../tools/picard_markduplicates.cwl
+    in:
+      - id: INPUT
+        source: bam_reheader/output_bam
+    out:
+      - id: OUTPUT
+      - id: METRICS
+
+  - id: picard_markduplicates_to_sqlite
+    run: ../../tools/picard_markduplicates_to_sqlite.cwl
+    in:
+      - id: bam
+        source: picard_markduplicates/OUTPUT
+        valueFrom: $(self.basename)
+      - id: input_state
+        valueFrom: "markduplicates_readgroups"
+      - id: metric_path
+        source: picard_markduplicates/METRICS
+      - id: uuid
+        source: uuid
+    out:
+      - id: sqlite
+
+  - id: picard_validatesamfile_markduplicates
+    run: ../../tools/picard_validatesamfile.cwl
+    in:
+      - id: INPUT
+        source: picard_markduplicates/OUTPUT
+      - id: VALIDATION_STRINGENCY
+        valueFrom: "STRICT"
+    out:
+      - id: OUTPUT
+
+  #need eof and dup QNAME detection
+  - id: picard_validatesamfile_markdupl_to_sqlite
+    run: ../../tools/picard_validatesamfile_to_sqlite.cwl
+    in:
+      - id: bam
+        source: bam_path
+        valueFrom: $(self.basename)
+      - id: input_state
+        valueFrom: "markduplicates_readgroups"
+      - id: metric_path
+        source: picard_validatesamfile_markduplicates/OUTPUT
+      - id: uuid
+        source: uuid
+    out:
+      - id: sqlite
+
+  - id: metrics_markduplicates
+    run: mixed_library_metrics.cwl
+    in:
+      - id: bam
+        source: picard_markduplicates/OUTPUT
+      - id: db_snp_vcf
+        source: db_snp_path
+      - id: fasta
+        source: reference_fasta_path
+      - id: input_state
+        valueFrom: "markduplicates_readgroups"
+      - id: thread_count
+        source: thread_count
+      - id: uuid
+        source: uuid
+    out:
+      - id: merge_sqlite_destination_sqlite
+
+  - id: integrity
+    run: integrity.cwl
+    in:
+      - id: bai_path
+        source: picard_markduplicates/OUTPUT
+        valueFrom: $(self.secondaryFiles[0])
+      - id: bam_path
+        source: picard_markduplicates/OUTPUT
+      - id: input_state
+        valueFrom: "markduplicates_readgroups"
+      - id: uuid
+        source: uuid
+    out:
+      - id: merge_sqlite_destination_sqlite
+
+  - id: merge_all_sqlite
+    run: ../../tools/merge_sqlite.cwl
+    in:
+      - id: source_sqlite
+        source: [
+          picard_validatesamfile_original_to_sqlite/sqlite,
+          picard_validatesamfile_markdupl_to_sqlite/sqlite,
+          merge_readgroup_json_db/destination_sqlite,
+          merge_fastqc_db1_sqlite/destination_sqlite,
+          merge_fastqc_db2_sqlite/destination_sqlite,
+          merge_fastqc_db_s_sqlite/destination_sqlite,
+          merge_fastqc_db_o1_sqlite/destination_sqlite,
+          merge_fastqc_db_o2_sqlite/destination_sqlite,
+          merge_metrics_pe/destination_sqlite,
+          merge_metrics_se/destination_sqlite,
+          metrics_markduplicates/merge_sqlite_destination_sqlite,
+          picard_markduplicates_to_sqlite/sqlite,
+          integrity/merge_sqlite_destination_sqlite
+        ]
+      - id: uuid
+        source: uuid
+    out:
+      - id: destination_sqlite
+      - id: log


### PR DESCRIPTION
This fixes the concurrency issue present with parallelstream().  As a result, speed has decreased by less than 10%.  Added a unit test for the secondary files utility that runs 5 times to test concurrency.
