### PR TITLE
Clean up build log a bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script: ./scripts/run-tests.sh
 
 before_install:
 - pip install --upgrade pip
-- mvn dependency:get -Dartifact=org.eluder.coveralls:coveralls-maven-plugin:4.2.0
+- mvn --batch-mode dependency:get -Dartifact=org.eluder.coveralls:coveralls-maven-plugin:4.2.0
 - openssl aes-256-cbc -K $encrypted_3fcf447b96fd_key -iv $encrypted_3fcf447b96fd_iv -in dockstore-integration-testing/src/test/resources/secrets.tar.enc -out dockstore-integration-testing/src/test/resources/secrets.tar -d
 - tar xvf dockstore-integration-testing/src/test/resources/secrets.tar
 

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
@@ -48,11 +48,13 @@ public class LaunchTestIT {
     //create tests that will call client.checkEntryFile for workflow launch with different files and descriptor
 
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+
     @Rule
     public final ExpectedSystemExit exit = ExpectedSystemExit.none();
-    @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog();
 
     private static AbstractEntryClient entryClient = new ToolClient(null, true);
 

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WorkflowInDirectoryTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WorkflowInDirectoryTestIT.java
@@ -10,12 +10,20 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 
 /**
  * @author gluu
  * @since 02/08/17
  */
 public class WorkflowInDirectoryTestIT {
+
+    @Rule
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
 
     private static File configFile;
 

--- a/dockstore-client/src/test/java/io/github/collaboratory/LauncherTest.java
+++ b/dockstore-client/src/test/java/io/github/collaboratory/LauncherTest.java
@@ -36,6 +36,8 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.rules.ExpectedException;
 
 import static io.dockstore.common.FileProvisioning.getCacheDirectory;
@@ -45,6 +47,12 @@ import static org.junit.Assert.assertTrue;
  * @author dyuen
  */
 public abstract class LauncherTest {
+
+    @Rule
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
 
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AdvancedIndexingBenchmarkIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AdvancedIndexingBenchmarkIT.java
@@ -52,7 +52,10 @@ import org.hibernate.context.internal.ManagedSessionContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,6 +69,13 @@ import static junit.framework.TestCase.assertTrue;
  */
 @Category(BenchmarkTest.class)
 public class AdvancedIndexingBenchmarkIT {
+
+    @Rule
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+
     private static final int TOOL_COUNT = 10;
     private static final int MAX_LABELS_PER_TOOL = 5;
     private static final int MAX_AUTHORS = 10;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
@@ -37,6 +37,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.Assertion;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
 
 import static io.dockstore.common.CommonTestUtilities.clearStateMakePrivate;
@@ -56,6 +58,12 @@ public class BasicIT {
 
     @Rule
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
+
+    @Rule
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
 
     @Before
     public void clearDBandSetup() throws IOException, TimeoutException {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
@@ -37,6 +37,7 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 
 import static io.dockstore.common.CommonTestUtilities.clearState;
@@ -53,6 +54,10 @@ public class ClientIT {
 
     @Rule
     public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+
     @Rule
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -53,6 +53,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
@@ -69,6 +70,13 @@ import static org.junit.Assert.assertTrue;
  */
 @Category(ConfidentialTest.class)
 public class GeneralIT {
+
+    @Rule
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+
     @ClassRule
     public static final DropwizardAppRule<DockstoreWebserviceConfiguration> RULE = new DropwizardAppRule<>(
             DockstoreWebserviceApplication.class, ResourceHelpers.resourceFilePath("dockstoreTest.yml"));
@@ -82,12 +90,7 @@ public class GeneralIT {
 
     @Rule
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
-
-    @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog();
-
-    @Rule
-    public final SystemErrRule systemOutRule = new SystemErrRule().enableLog();
+    
 
     @Before
     public void clearDBandSetup() throws IOException, TimeoutException {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -41,6 +41,8 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
 
 import static io.dockstore.common.CommonTestUtilities.clearStateMakePrivate2;
@@ -58,6 +60,12 @@ public class GeneralWorkflowIT {
 
     @Rule
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
+
+    @Rule
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
 
     @Before
     public void clearDBandSetup() throws IOException, TimeoutException {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MockedIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MockedIT.java
@@ -40,6 +40,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
@@ -68,8 +69,13 @@ public class MockedIT {
     @ClassRule
     public static final DropwizardAppRule<DockstoreWebserviceConfiguration> RULE = new DropwizardAppRule<>(
             DockstoreWebserviceApplication.class, ResourceHelpers.resourceFilePath("dockstore.yml"));
+
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+
     @Rule
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -45,6 +45,8 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
 
 import static io.dockstore.common.CommonTestUtilities.clearStateMakePrivate2;
@@ -58,6 +60,12 @@ import static org.junit.Assert.assertTrue;
  */
 @Category(ConfidentialTest.class)
 public class WorkflowIT {
+
+    @Rule
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
 
     @ClassRule
     public static final DropwizardAppRule<DockstoreWebserviceConfiguration> RULE = new DropwizardAppRule<>(

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -8,10 +8,10 @@ echo "${TRAVIS_PULL_REQUEST_SHA}"
 
 if [ ${#EXTRA_MAVEN_VAR} -eq 0 ]; then
         # always do non-coverage builds
-	mvn -B clean install -Ptravis-tests ${EXTRA_MAVEN_VAR}
+	mvn --batch-mode clean install -Ptravis-tests ${EXTRA_MAVEN_VAR}
 else
         # for coverage builds, we need to be more picky, let's exclude builds from branches other than develop and master
         if [ "${TRAVIS_BRANCH}" = "master" ] || [ "${TRAVIS_BRANCH}" = "develop" ]; then
-		mvn -B clean install -Ptravis-tests ${EXTRA_MAVEN_VAR}
+		mvn --batch-mode clean install -Ptravis-tests ${EXTRA_MAVEN_VAR}
         fi
 fi


### PR DESCRIPTION
Inspired by some work on UI2 to get under the travis build log limit 

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
