### PR TITLE
Workaround aws issue with doubled ending slash

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -302,6 +302,9 @@ public class WorkflowClient extends AbstractEntryClient {
         String tsvRun = commandLaunch.tsv;
         String wdlOutputTarget = commandLaunch.wdlOutputTarget;
 
+        // trim the final slash on output if it is present, probably an error ( https://github.com/aws/aws-cli/issues/421 ) causes a double slash which can fail
+        wdlOutputTarget = wdlOutputTarget.replaceAll("/$", "");
+
         if (this.commandLaunch.help) {
             JCommanderUtility.printJCommanderHelpLaunch(jCommander, "dockstore workflow", commandName);
         } else {

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -303,7 +303,7 @@ public class WorkflowClient extends AbstractEntryClient {
         String wdlOutputTarget = commandLaunch.wdlOutputTarget;
 
         // trim the final slash on output if it is present, probably an error ( https://github.com/aws/aws-cli/issues/421 ) causes a double slash which can fail
-        wdlOutputTarget = wdlOutputTarget.replaceAll("/$", "");
+        wdlOutputTarget = wdlOutputTarget != null ? wdlOutputTarget.replaceAll("/$", "") : null;
 
         if (this.commandLaunch.help) {
             JCommanderUtility.printJCommanderHelpLaunch(jCommander, "dockstore workflow", commandName);

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
@@ -832,7 +832,7 @@ public class LaunchTestIT {
     }
 
     @Test
-    @Ignore("Detection code is not robust enough for biowardrobe wdl")
+    @Ignore("Detection code is not robust enough for biowardrobe wdl using --local-entry")
     public void toolAsWorkflow() {
         File cwlFile = new File(ResourceHelpers.resourceFilePath("dir6.cwl"));
         File cwlJSON = new File(ResourceHelpers.resourceFilePath("dir6.cwl.json"));


### PR DESCRIPTION
Workaround since the aws SDK doesn't actually recognize this situation as an error, is just confusing
- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
