### PR TITLE
Update cwlavro to merge 1.0.9 hotfix to 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <powermock.version>1.6.5</powermock.version>
         <postgresql.version>42.1.4</postgresql.version>
         <mockito.version>1.10.19</mockito.version>
-        <cwlavro.version>2.0.0</cwlavro.version>
+        <cwlavro.version>2.0.1</cwlavro.version>
         <okhttp.version>3.2.0</okhttp.version>
         <slf4j.version>1.7.25</slf4j.version>
         <swagger-ui.version>3.1.7</swagger-ui.version>


### PR DESCRIPTION
Looks like some updates to cwlavro 1.0.9 were not properly merged with cwlavro's 2.0.0 develop branch. 

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
