### PR TITLE
fix registry bean to have enum name

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/Registry.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/Registry.java
@@ -92,14 +92,15 @@ public enum Registry {
 
         @JsonProperty("enum")
         public String value;
-
+        public String dockerPath;
         public String friendlyName;
         public String url;
         public String privateOnly;
         public String customDockerPath;
 
         public RegistryBean(Registry registry) {
-            this.value = registry.toString();
+            this.value = registry.name();
+            this.dockerPath = registry.toString();
             this.friendlyName = registry.getFriendlyName();
             this.url = registry.url;
             this.privateOnly = Boolean.toString(registry.isPrivateOnly());

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -3555,9 +3555,9 @@ definitions:
   DescriptorLanguageBean:
     type: "object"
     properties:
-      value:
-        type: "string"
       friendlyName:
+        type: "string"
+      enum:
         type: "string"
   DockstoreTool:
     type: "object"
@@ -3870,6 +3870,8 @@ definitions:
   RegistryBean:
     type: "object"
     properties:
+      dockerPath:
+        type: "string"
       friendlyName:
         type: "string"
       url:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -3555,9 +3555,9 @@ definitions:
   DescriptorLanguageBean:
     type: "object"
     properties:
-      friendlyName:
+      value:
         type: "string"
-      enum:
+      friendlyName:
         type: "string"
   DockstoreTool:
     type: "object"


### PR DESCRIPTION
Once again store registry enum (matching registry in the database) in the registry bean.