### PR TITLE
Improve error message for missing tag #1050

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
@@ -49,7 +49,6 @@ import io.swagger.client.model.User;
 import io.swagger.client.model.VerifyRequest;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.validator.routines.EmailValidator;
-import org.apache.http.HttpStatus;
 
 import static io.dockstore.client.cli.ArgumentUtility.CWL_STRING;
 import static io.dockstore.client.cli.ArgumentUtility.DESCRIPTION_HEADER;
@@ -1001,18 +1000,10 @@ public class ToolClient extends AbstractEntryClient {
         }
 
         if (container != null) {
-            try {
-                if (descriptorType.equals(CWL_STRING)) {
-                    file = containersApi.cwl(container.getId(), tag);
-                } else if (descriptorType.equals(WDL_STRING)) {
-                    file = containersApi.wdl(container.getId(), tag);
-                }
-            } catch (ApiException ex) {
-                if (ex.getCode() == HttpStatus.SC_BAD_REQUEST) {
-                    exceptionMessage(ex, "Invalid tag", Client.API_ERROR);
-                } else {
-                    exceptionMessage(ex, "No " + descriptorType + " file found.", Client.API_ERROR);
-                }
+            if (descriptorType.equals(CWL_STRING)) {
+                file = containersApi.cwl(container.getId(), tag);
+            } else if (descriptorType.equals(WDL_STRING)) {
+                file = containersApi.wdl(container.getId(), tag);
             }
         } else {
             errorMessage("No tool found with path " + entry, Client.API_ERROR);

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/nested/ToolClientTest.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/nested/ToolClientTest.java
@@ -1,0 +1,82 @@
+package io.dockstore.client.cli.nested;
+
+import io.dockstore.client.cli.Client;
+import io.swagger.client.ApiException;
+import io.swagger.client.api.ContainersApi;
+import io.swagger.client.api.ContainertagsApi;
+import io.swagger.client.api.UsersApi;
+import io.swagger.client.model.DockstoreTool;
+import io.swagger.client.model.SourceFile;
+import org.apache.http.HttpStatus;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.when;
+
+public class ToolClientTest {
+
+    private static final String MISSING_TAG = "0.3.1";
+    private static final String GOOD_TAG = "0.3.0";
+    private static final String REPOSITORY = "registry.hub.docker.com/ucsctreehouse/fusion";
+    private static final long CONTAINER_ID = 1L;
+
+    private ContainersApi containersApi;
+    private ContainertagsApi containertagsApi;
+    private UsersApi usersApi;
+    private Client client;
+    private DockstoreTool dockstoreTool;
+    private ApiException apiException;
+
+    @Before
+    public void setup() {
+        containersApi = Mockito.mock(ContainersApi.class);
+        containertagsApi = Mockito.mock(ContainertagsApi.class);
+        usersApi = Mockito.mock(UsersApi.class);
+        client = Mockito.mock(Client.class);
+        dockstoreTool = Mockito.mock(DockstoreTool.class);
+        apiException = Mockito.mock(ApiException.class);
+        when(apiException.getCode()).thenReturn(HttpStatus.SC_BAD_REQUEST);
+        when(dockstoreTool.getId()).thenReturn(CONTAINER_ID);
+        when(containersApi.cwl(CONTAINER_ID, MISSING_TAG)).thenThrow(apiException);
+        when(containersApi.cwl(CONTAINER_ID, null)).thenThrow(apiException);
+        when(containersApi.cwl(CONTAINER_ID, GOOD_TAG)).thenReturn(Mockito.mock(SourceFile.class));
+        when(containersApi
+                .getPublishedContainerByToolPath(REPOSITORY))
+                .thenReturn(dockstoreTool);
+    }
+
+    @Test
+    public void getDescriptorFromServer_missingTag()  {
+        ToolClient toolClient = new ToolClient(containersApi, containertagsApi, usersApi, client, false);
+        boolean exceptionThrown = false;
+        try {
+            toolClient.getDescriptorFromServer(REPOSITORY + ":" + MISSING_TAG, "cwl");
+        }
+        catch (Exception ex) {
+            exceptionThrown = true;
+        }
+        Assert.assertTrue(exceptionThrown);
+    }
+
+    @Test
+    public void getDescriptorFromServer_noTag()  {
+        ToolClient toolClient = new ToolClient(containersApi, containertagsApi, usersApi, client, false);
+        boolean exceptionThrown = false;
+        try {
+            toolClient.getDescriptorFromServer(REPOSITORY , "cwl");
+        }
+        catch (Exception ex) {
+            exceptionThrown = true;
+        }
+        Assert.assertTrue(exceptionThrown);
+    }
+
+    @Test
+    public void getDescriptorFromServer_goodTag() {
+        ToolClient toolClient = new ToolClient(containersApi, containertagsApi, usersApi, client, false);
+        SourceFile cwl = toolClient.getDescriptorFromServer(REPOSITORY + ":" + GOOD_TAG, "cwl");
+        Assert.assertNotNull(cwl);
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -170,7 +170,7 @@ public interface EntryVersionHelper<T extends Entry> extends AuthenticatedResour
         }
 
         if (tagInstance == null) {
-            throw new CustomWebApplicationException("Invalid version.", HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException("Invalid or missing tag " + tag + ".", HttpStatus.SC_BAD_REQUEST);
         }
 
         if (tagInstance instanceof WorkflowVersion) {


### PR DESCRIPTION
* Error from dockstore-webservice now returns the tag name as part of
its error message, so it's now `Invalid or missing tag <tag>.` instead
of `Invalid version.`.
* In ToolClient, only rely on the above message returned by
dockstore-webservice and no longer prepend `Invalid tag`. This is the
similar behavior when an entry, without the tag, is not present.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
