### PR TITLE
Removing travis deprecation setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ notifications:
     rooms:
     - oicr:S9k4EowgQv9AnbCfEZHSzCsg
 sudo: required
-group: deprecated-2017Q4
 services:
 - docker
 


### PR DESCRIPTION
While troubleshooting the localstack issue, looks like this workaround is no longer necessary