### PR TITLE
Match all relative paths

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2IT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2IT.java
@@ -8,6 +8,7 @@ import javax.ws.rs.core.Response;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.swagger.client.model.MetadataV2;
 import io.swagger.client.model.ToolClass;
+import io.swagger.client.model.ToolDescriptor;
 import io.swagger.client.model.ToolV2;
 import io.swagger.client.model.ToolVersionV2;
 import io.swagger.model.ToolFile;
@@ -97,6 +98,15 @@ public class GA4GHV2IT extends GA4GHIT {
     public void toolsIdVersionsVersionIdTypeFile() throws Exception {
         toolsIdVersionsVersionIdTypeFileCWL();
         toolsIdVersionsVersionIdTypeFileWDL();
+    }
+
+    @Test
+    public void toolsIdVersionsVersionIdTypeDescriptorRelativePathNoEncode() throws Exception {
+        Response response = checkedResponse(
+                basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor//Dockstore.cwl");
+        ToolDescriptor responseObject = response.readEntity(ToolDescriptor.class);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertDescriptor(MAPPER.writeValueAsString(responseObject));
     }
 
     private void toolsIdVersionsVersionIdTypeFileCWL() throws Exception {

--- a/dockstore-webservice/src/main/java/io/swagger/api/ToolsApi.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/ToolsApi.java
@@ -145,7 +145,7 @@ public class ToolsApi {
     }
 
     @GET
-    @Path("/{id}/versions/{version_id}/{type}/descriptor/{relative_path}")
+    @Path("/{id}/versions/{version_id}/{type}/descriptor/{relative_path : .+}")
     @UnitOfWork
     @Produces({ "application/json", "text/plain" })
     @io.swagger.annotations.ApiOperation(value = "Get additional tool descriptor files (CWL/WDL) relative to the main file", notes = "Returns additional CWL or WDL descriptors for the specified tool in the same or subdirectories", response = ToolDescriptor.class, tags = {

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -835,6 +835,7 @@ paths:
           \ as the main descriptor"
         required: true
         type: "string"
+        pattern: ".+"
       responses:
         200:
           description: "The tool descriptor."


### PR DESCRIPTION
For the GA4GH descriptor relative path endpoint, Dropwizard (or Jersey) doesn't recognize which endpoint to hit when relative paths has slashes in it.  Using a regular expression to match all