### PR TITLE
Feature/fix swagger positions

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -52,6 +52,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 @Entity
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@SuppressWarnings("checkstyle:magicnumber")
 public abstract class Entry<S extends Entry, T extends Version> {
 
     /**
@@ -60,51 +61,51 @@ public abstract class Entry<S extends Entry, T extends Version> {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "container_id_seq")
     @SequenceGenerator(name = "container_id_seq", sequenceName = "container_id_seq")
-    @ApiModelProperty("Implementation specific ID for the container in this web service")
+    @ApiModelProperty(value = "Implementation specific ID for the container in this web service", position = 0)
     private long id;
 
     @Column
-    @ApiModelProperty("This is the name of the author stated in the Dockstore.cwl")
+    @ApiModelProperty(value = "This is the name of the author stated in the Dockstore.cwl", position = 1)
     private String author;
     @Column(columnDefinition = "TEXT")
-    @ApiModelProperty("This is a human-readable description of this container and what it is trying to accomplish, required GA4GH")
+    @ApiModelProperty(value = "This is a human-readable description of this container and what it is trying to accomplish, required GA4GH", position = 2)
     private String description;
 
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "entry_label", joinColumns = @JoinColumn(name = "entryid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "labelid", referencedColumnName = "id"))
-    @ApiModelProperty("Labels (i.e. meta tags) for describing the purpose and contents of containers")
+    @ApiModelProperty(value = "Labels (i.e. meta tags) for describing the purpose and contents of containers", position = 3)
     @OrderBy("id")
     private SortedSet<Label> labels = new TreeSet<>();
 
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(name = "user_entry", inverseJoinColumns = @JoinColumn(name = "userid", nullable = false, updatable = false, referencedColumnName = "id"), joinColumns = @JoinColumn(name = "entryid", nullable = false, updatable = false, referencedColumnName = "id"))
-    @ApiModelProperty(value = "This indicates the users that have control over this entry, dockstore specific", required = false)
+    @ApiModelProperty(value = "This indicates the users that have control over this entry, dockstore specific", required = false, position = 4)
     private Set<User> users;
 
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "starred", inverseJoinColumns = @JoinColumn(name = "userid", nullable = false, updatable = false, referencedColumnName = "id"), joinColumns = @JoinColumn(name = "entryid", nullable = false, updatable = false, referencedColumnName = "id"))
-    @ApiModelProperty(value = "This indicates the users that have starred this entry, dockstore specific", required = false)
+    @ApiModelProperty(value = "This indicates the users that have starred this entry, dockstore specific", required = false, position = 5)
     @JsonSerialize(using = EntryStarredSerializer.class)
     private Set<User> starredUsers;
 
     @Column
-    @ApiModelProperty("This is the email of the git organization")
+    @ApiModelProperty(value = "This is the email of the git organization", position = 6)
     private String email;
     @Column
-    @ApiModelProperty("This is the default version of the entry")
+    @ApiModelProperty(value = "This is the default version of the entry", position = 7)
     private String defaultVersion;
     @Column
     @JsonProperty("is_published")
-    @ApiModelProperty("Implementation specific visibility in this web service")
+    @ApiModelProperty(value = "Implementation specific visibility in this web service", position = 8)
     private boolean isPublished;
     @Column
-    @ApiModelProperty("Implementation specific timestamp for last modified")
+    @ApiModelProperty(value = "Implementation specific timestamp for last modified", position = 9)
     private Integer lastModified;
     @Column
-    @ApiModelProperty("Implementation specific timestamp for last updated on webservice")
+    @ApiModelProperty(value = "Implementation specific timestamp for last updated on webservice", position = 10)
     private Date lastUpdated;
     @Column
-    @ApiModelProperty(value = "This is a link to the associated repo with a descriptor, required GA4GH", required = true)
+    @ApiModelProperty(value = "This is a link to the associated repo with a descriptor, required GA4GH", required = true, position = 11)
     private String gitUrl;
 
     public Entry() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Label.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Label.java
@@ -38,15 +38,16 @@ import io.swagger.annotations.ApiModelProperty;
 @Entity
 @Table(name = "label")
 @NamedQuery(name = "io.dockstore.webservice.core.Label.findByLabelValue", query = "SELECT l FROM Label l WHERE l.value = :labelValue")
+@SuppressWarnings("checkstyle:magicnumber")
 public class Label implements Comparable<Label> {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @ApiModelProperty("Implementation specific ID for the container in this web service")
+    @ApiModelProperty(value = "Implementation specific ID for the container in this web service", position = 0)
     private long id;
 
     @Column(unique = true)
-    @ApiModelProperty(value = "String representation of the tag", required = true)
+    @ApiModelProperty(value = "String representation of the tag", required = true, position = 1)
     private String value;
 
     @JsonProperty

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -38,6 +38,7 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel("SourceFile")
 @Entity
 @Table(name = "sourcefile")
+@SuppressWarnings("checkstyle:magicnumber")
 public class SourceFile {
     /**
      * NextFlow parameter files are described here https://github.com/nextflow-io/nextflow/issues/208
@@ -50,19 +51,19 @@ public class SourceFile {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @ApiModelProperty("Implementation specific ID for the source file in this web service")
+    @ApiModelProperty(value = "Implementation specific ID for the source file in this web service", position = 0)
     private long id;
 
     @Enumerated(EnumType.STRING)
-    @ApiModelProperty(value = "Enumerates the type of file", required = true)
+    @ApiModelProperty(value = "Enumerates the type of file", required = true, position = 1)
     private FileType type;
 
     @Column(columnDefinition = "TEXT")
-    @ApiModelProperty("Cache for the contents of the target file")
+    @ApiModelProperty(value = "Cache for the contents of the target file", position = 2)
     private String content;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "Path to source file in git repo", required = true)
+    @ApiModelProperty(value = "Path to source file in git repo", required = true, position = 3)
     private String path;
 
     public long getId() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
@@ -42,31 +42,31 @@ public class Tag extends Version<Tag> {
 
     @Column
     @JsonProperty("image_id")
-    @ApiModelProperty(value = "Tag for this image in quay.ui/docker hub", required = true, position = 0)
+    @ApiModelProperty(value = "Tag for this image in quay.io/docker hub", required = true, position = 12)
     private String imageId;
 
     @Column
-    @ApiModelProperty(value = "Size of the image", position = 1)
+    @ApiModelProperty(value = "Size of the image", position = 13)
     private long size;
 
     @Column(columnDefinition = "text", nullable = false)
     @JsonProperty("dockerfile_path")
-    @ApiModelProperty(value = "Path for the Dockerfile", position = 2)
+    @ApiModelProperty(value = "Path for the Dockerfile", position = 14)
     private String dockerfilePath = "/Dockerfile";
 
     // Add for new descriptor types
     @Column(columnDefinition = "text", nullable = false)
     @JsonProperty("cwl_path")
-    @ApiModelProperty(value = "Path for the CWL document", position = 3)
+    @ApiModelProperty(value = "Path for the CWL document", position = 15)
     private String cwlPath = "/Dockstore.cwl";
 
     @Column(columnDefinition = "text default '/Dockstore.wdl'", nullable = false)
     @JsonProperty("wdl_path")
-    @ApiModelProperty(value = "Path for the WDL document", position = 4)
+    @ApiModelProperty(value = "Path for the WDL document", position = 16)
     private String wdlPath = "/Dockstore.wdl";
 
     @Column
-    @ApiModelProperty(value = "Implementation specific, indicates whether this is an automated build on quay.io", position = 5)
+    @ApiModelProperty(value = "Implementation specific, indicates whether this is an automated build on quay.io", position = 17)
     private boolean automated;
 
     public Tag() {
@@ -74,6 +74,7 @@ public class Tag extends Version<Tag> {
     }
 
     @Override
+    @ApiModelProperty(position = 18)
     public String getWorkingDirectory() {
         if (!cwlPath.isEmpty()) {
             return FilenameUtils.getPathNoEndSeparator(cwlPath);
@@ -126,6 +127,7 @@ public class Tag extends Version<Tag> {
     }
 
     @JsonProperty
+    @ApiModelProperty(position = 19)
     public String getImageId() {
         return imageId;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
@@ -42,31 +42,31 @@ public class Tag extends Version<Tag> {
 
     @Column
     @JsonProperty("image_id")
-    @ApiModelProperty(value = "Tag for this image in quay.ui/docker hub", required = true, position = 12)
+    @ApiModelProperty(value = "Tag for this image in quay.ui/docker hub", required = true, position = 0)
     private String imageId;
 
     @Column
-    @ApiModelProperty(value = "Size of the image", position = 13)
+    @ApiModelProperty(value = "Size of the image", position = 1)
     private long size;
 
     @Column(columnDefinition = "text", nullable = false)
     @JsonProperty("dockerfile_path")
-    @ApiModelProperty(value = "Path for the Dockerfile", position = 14)
+    @ApiModelProperty(value = "Path for the Dockerfile", position = 2)
     private String dockerfilePath = "/Dockerfile";
 
     // Add for new descriptor types
     @Column(columnDefinition = "text", nullable = false)
     @JsonProperty("cwl_path")
-    @ApiModelProperty(value = "Path for the CWL document", position = 15)
+    @ApiModelProperty(value = "Path for the CWL document", position = 3)
     private String cwlPath = "/Dockstore.cwl";
 
     @Column(columnDefinition = "text default '/Dockstore.wdl'", nullable = false)
     @JsonProperty("wdl_path")
-    @ApiModelProperty(value = "Path for the WDL document", position = 16)
+    @ApiModelProperty(value = "Path for the WDL document", position = 4)
     private String wdlPath = "/Dockstore.wdl";
 
     @Column
-    @ApiModelProperty(value = "Implementation specific, indicates whether this is an automated build on quay.io", position = 17)
+    @ApiModelProperty(value = "Implementation specific, indicates whether this is an automated build on quay.io", position = 5)
     private boolean automated;
 
     public Tag() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
@@ -37,35 +37,36 @@ import org.apache.commons.io.FilenameUtils;
 @ApiModel(value = "Tag", description = "This describes one tag associated with a container.")
 @Entity
 @DiscriminatorValue("tool")
+@SuppressWarnings("checkstyle:magicnumber")
 public class Tag extends Version<Tag> {
 
     @Column
     @JsonProperty("image_id")
-    @ApiModelProperty(value = "Tag for this image in quay.ui/docker hub", required = true)
+    @ApiModelProperty(value = "Tag for this image in quay.ui/docker hub", required = true, position = 12)
     private String imageId;
 
     @Column
-    @ApiModelProperty("Size of the image")
+    @ApiModelProperty(value = "Size of the image", position = 13)
     private long size;
 
     @Column(columnDefinition = "text", nullable = false)
     @JsonProperty("dockerfile_path")
-    @ApiModelProperty("Path for the Dockerfile")
+    @ApiModelProperty(value = "Path for the Dockerfile", position = 14)
     private String dockerfilePath = "/Dockerfile";
 
     // Add for new descriptor types
     @Column(columnDefinition = "text", nullable = false)
     @JsonProperty("cwl_path")
-    @ApiModelProperty("Path for the CWL document")
+    @ApiModelProperty(value = "Path for the CWL document", position = 15)
     private String cwlPath = "/Dockstore.cwl";
 
     @Column(columnDefinition = "text default '/Dockstore.wdl'", nullable = false)
     @JsonProperty("wdl_path")
-    @ApiModelProperty("Path for the WDL document")
+    @ApiModelProperty(value = "Path for the WDL document", position = 16)
     private String wdlPath = "/Dockstore.wdl";
 
     @Column
-    @ApiModelProperty("Implementation specific, indicates whether this is an automated build on quay.io")
+    @ApiModelProperty(value = "Implementation specific, indicates whether this is an automated build on quay.io", position = 17)
     private boolean automated;
 
     public Tag() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
@@ -75,6 +75,7 @@ public class Token {
 
     // TODO: tokens will need to be associated with a particular user
     @Column
+    @ApiModelProperty(position = 5)
     private long userId;
 
     public Token() {
@@ -95,7 +96,7 @@ public class Token {
     }
 
     @JsonProperty
-    @ApiModelProperty(value = "Contents of the access token", position = 5)
+    @ApiModelProperty(value = "Contents of the access token", position = 6)
     public String getToken() {
         return content;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
@@ -49,24 +49,28 @@ import io.swagger.annotations.ApiModelProperty;
         @NamedQuery(name = "io.dockstore.webservice.core.Token.findQuayByUserId", query = "SELECT t FROM Token t WHERE t.userId = :userId AND t.tokenSource = 'quay.io'"),
         @NamedQuery(name = "io.dockstore.webservice.core.Token.findGitlabByUserId", query = "SELECT t FROM Token t WHERE t.userId = :userId AND t.tokenSource = 'gitlab.com'"),
         @NamedQuery(name = "io.dockstore.webservice.core.Token.findBitbucketByUserId", query = "SELECT t FROM Token t WHERE t.userId = :userId AND t.tokenSource = 'bitbucket.org'") })
+@SuppressWarnings("checkstyle:magicnumber")
 public class Token {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @ApiModelProperty("Implementation specific ID for the token in this web service")
+    @ApiModelProperty(value = "Implementation specific ID for the token in this web service", position = 0)
     private long id;
+
     @Column(nullable = false)
-    @ApiModelProperty("Source website for this token")
+    @ApiModelProperty(value = "Source website for this token", position = 1)
     private String tokenSource;
 
     @Column(nullable = false)
-    @ApiModelProperty("Contents of the access token")
+    @ApiModelProperty(value = "Contents of the access token", position = 2)
     private String content;
+
     @Column(nullable = false)
-    @ApiModelProperty("When an integrated service is not aware of the username, we store it")
+    @ApiModelProperty(value = "When an integrated service is not aware of the username, we store it", position = 3)
     private String username;
+
     @Column
-    @ApiModelProperty("")
+    @ApiModelProperty(position = 4)
     private String refreshToken;
 
     // TODO: tokens will need to be associated with a particular user
@@ -91,7 +95,7 @@ public class Token {
     }
 
     @JsonProperty
-    @ApiModelProperty("Contents of the access token")
+    @ApiModelProperty(value = "Contents of the access token", position = 5)
     public String getToken() {
         return content;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -75,51 +75,52 @@ import org.hibernate.annotations.Check;
         @NamedQuery(name = "io.dockstore.webservice.core.Tool.findPublishedByToolPathNullToolName", query = "SELECT c FROM Tool c WHERE c.registry = :registry AND c.namespace = :namespace AND c.name = :name AND c.toolname = '' AND c.isPublished = true") })
 
 @Check(constraints = "(defaultwdlpath is not null or defaultcwlpath is not null)")
+@SuppressWarnings("checkstyle:magicnumber")
 public class Tool extends Entry<Tool, Tag> {
 
     @Column(nullable = false, columnDefinition = "Text default 'AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS'")
     @Enumerated(EnumType.STRING)
-    @ApiModelProperty(value = "This indicates what mode this is in which informs how we do things like refresh, dockstore specific", required = true)
+    @ApiModelProperty(value = "This indicates what mode this is in which informs how we do things like refresh, dockstore specific", required = true, position = 12)
     private ToolMode mode = ToolMode.AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "This is the name of the container, required: GA4GH", required = true)
+    @ApiModelProperty(value = "This is the name of the container, required: GA4GH", required = true, position = 13)
     private String name;
 
     @Column(columnDefinition = "text", nullable = false)
     @JsonProperty("default_dockerfile_path")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the Dockerfile, required: GA4GH", required = true)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the Dockerfile, required: GA4GH", required = true, position = 14)
     private String defaultDockerfilePath = "/Dockerfile";
 
     // Add for new descriptor types
     @Column(columnDefinition = "text")
     @JsonProperty("default_cwl_path")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the CWL document, required: GA4GH", required = true)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the CWL document, required: GA4GH", required = true, position = 15)
     private String defaultCwlPath = "/Dockstore.cwl";
 
     @Column(columnDefinition = "text default '/Dockstore.wdl'")
     @JsonProperty("default_wdl_path")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the WDL document", required = true)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the WDL document", required = true, position = 16)
     private String defaultWdlPath = "/Dockstore.wdl";
 
     @Column(columnDefinition = "text")
     @JsonProperty("defaultCWLTestParameterFile")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the CWL test parameter file", required = true)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the CWL test parameter file", required = true, position = 17)
     private String defaultTestCwlParameterFile = "/test.json";
 
     @Column(columnDefinition = "text")
     @JsonProperty("defaultWDLTestParameterFile")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the WDL test parameter file", required = true)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the WDL test parameter file", required = true, position = 18)
     private String defaultTestWdlParameterFile = "/test.json";
 
     @Column
     @JsonProperty("tool_maintainer_email")
-    @ApiModelProperty(value = "The email address of the tool maintainer. Required for private repositories", required = false)
+    @ApiModelProperty(value = "The email address of the tool maintainer. Required for private repositories", position = 19)
     private String toolMaintainerEmail = "";
 
     @Column(columnDefinition = "boolean default false")
     @JsonProperty("private_access")
-    @ApiModelProperty(value = "Is the docker image private or not.", required = true)
+    @ApiModelProperty(value = "Is the docker image private or not.", required = true, position = 20)
     private boolean privateAccess = false;
 
     @Column(nullable = false, columnDefinition = "Text default ''")
@@ -127,29 +128,29 @@ public class Tool extends Entry<Tool, Tag> {
             + "when present, this can be used to distinguish between two containers based on the same image, but associated with different "
             + "CWL and Dockerfile documents. i.e. two containers with the same registry+namespace+name but different toolnames "
             + "will be two different entries in the dockstore registry/namespace/name/tool, different options to edit tags, and "
-            + "only the same insofar as they would \"docker pull\" the same image, required: GA4GH", required = true)
+            + "only the same insofar as they would \"docker pull\" the same image, required: GA4GH", required = true, position = 21)
     private String toolname = "";
 
     @Column
-    @ApiModelProperty(value = "This is a docker namespace for the container, required: GA4GH", required = true)
+    @ApiModelProperty(value = "This is a docker namespace for the container, required: GA4GH", required = true, position = 22)
     private String namespace;
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    @ApiModelProperty(value = "This is a specific docker provider like quay.io or dockerhub or n/a?, required: GA4GH", required = true)
+    @ApiModelProperty(value = "This is a specific docker provider like quay.io or dockerhub or n/a?, required: GA4GH", required = true, position = 23)
     private Registry registry;
 
     @Column
-    @ApiModelProperty("Implementation specific timestamp for last built")
+    @ApiModelProperty(value = "Implementation specific timestamp for last built", position = 24)
     private Date lastBuild;
 
     @Column
     @JsonProperty("custom_docker_registry_path")
-    @ApiModelProperty(value = "Only used for docker registries that allow for custom paths")
+    @ApiModelProperty(value = "Only used for docker registries that allow for custom paths", position = 25)
     private String customDockerRegistryPath = null;
 
     @OneToMany(fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinTable(name = "tool_tag", joinColumns = @JoinColumn(name = "toolid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "tagid", referencedColumnName = "id"))
-    @ApiModelProperty("Implementation specific tracking of valid build tags for the docker container")
+    @ApiModelProperty(value = "Implementation specific tracking of valid build tags for the docker container", position = 26)
     @OrderBy("id")
     private final SortedSet<Tag> tags;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -80,47 +80,47 @@ public class Tool extends Entry<Tool, Tag> {
 
     @Column(nullable = false, columnDefinition = "Text default 'AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS'")
     @Enumerated(EnumType.STRING)
-    @ApiModelProperty(value = "This indicates what mode this is in which informs how we do things like refresh, dockstore specific", required = true, position = 0)
+    @ApiModelProperty(value = "This indicates what mode this is in which informs how we do things like refresh, dockstore specific", required = true, position = 12)
     private ToolMode mode = ToolMode.AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "This is the name of the container, required: GA4GH", required = true, position = 1)
+    @ApiModelProperty(value = "This is the name of the container, required: GA4GH", required = true, position = 13)
     private String name;
 
     @Column(columnDefinition = "text", nullable = false)
     @JsonProperty("default_dockerfile_path")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the Dockerfile, required: GA4GH", required = true, position = 2)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the Dockerfile, required: GA4GH", required = true, position = 14)
     private String defaultDockerfilePath = "/Dockerfile";
 
     // Add for new descriptor types
     @Column(columnDefinition = "text")
     @JsonProperty("default_cwl_path")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the CWL document, required: GA4GH", required = true, position = 3)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the CWL document, required: GA4GH", required = true, position = 15)
     private String defaultCwlPath = "/Dockstore.cwl";
 
     @Column(columnDefinition = "text default '/Dockstore.wdl'")
     @JsonProperty("default_wdl_path")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the WDL document", required = true, position = 4)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the WDL document", required = true, position = 16)
     private String defaultWdlPath = "/Dockstore.wdl";
 
     @Column(columnDefinition = "text")
     @JsonProperty("defaultCWLTestParameterFile")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the CWL test parameter file", required = true, position = 5)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the CWL test parameter file", required = true, position = 17)
     private String defaultTestCwlParameterFile = "/test.json";
 
     @Column(columnDefinition = "text")
     @JsonProperty("defaultWDLTestParameterFile")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the WDL test parameter file", required = true, position = 6)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the WDL test parameter file", required = true, position = 18)
     private String defaultTestWdlParameterFile = "/test.json";
 
     @Column
     @JsonProperty("tool_maintainer_email")
-    @ApiModelProperty(value = "The email address of the tool maintainer. Required for private repositories", position = 7)
+    @ApiModelProperty(value = "The email address of the tool maintainer. Required for private repositories", position = 19)
     private String toolMaintainerEmail = "";
 
     @Column(columnDefinition = "boolean default false")
     @JsonProperty("private_access")
-    @ApiModelProperty(value = "Is the docker image private or not.", required = true, position = 8)
+    @ApiModelProperty(value = "Is the docker image private or not.", required = true, position = 20)
     private boolean privateAccess = false;
 
     @Column(nullable = false, columnDefinition = "Text default ''")
@@ -128,29 +128,29 @@ public class Tool extends Entry<Tool, Tag> {
             + "when present, this can be used to distinguish between two containers based on the same image, but associated with different "
             + "CWL and Dockerfile documents. i.e. two containers with the same registry+namespace+name but different toolnames "
             + "will be two different entries in the dockstore registry/namespace/name/tool, different options to edit tags, and "
-            + "only the same insofar as they would \"docker pull\" the same image, required: GA4GH", required = true, position = 9)
+            + "only the same insofar as they would \"docker pull\" the same image, required: GA4GH", required = true, position = 21)
     private String toolname = "";
 
     @Column
-    @ApiModelProperty(value = "This is a docker namespace for the container, required: GA4GH", required = true, position = 10)
+    @ApiModelProperty(value = "This is a docker namespace for the container, required: GA4GH", required = true, position = 22)
     private String namespace;
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    @ApiModelProperty(value = "This is a specific docker provider like quay.io or dockerhub or n/a?, required: GA4GH", required = true, position = 11)
+    @ApiModelProperty(value = "This is a specific docker provider like quay.io or dockerhub or n/a?, required: GA4GH", required = true, position = 23)
     private Registry registry;
 
     @Column
-    @ApiModelProperty(value = "Implementation specific timestamp for last built", position = 12)
+    @ApiModelProperty(value = "Implementation specific timestamp for last built", position = 24)
     private Date lastBuild;
 
     @Column
     @JsonProperty("custom_docker_registry_path")
-    @ApiModelProperty(value = "Only used for docker registries that allow for custom paths", position = 13)
+    @ApiModelProperty(value = "Only used for docker registries that allow for custom paths", position = 25)
     private String customDockerRegistryPath = null;
 
     @OneToMany(fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinTable(name = "tool_tag", joinColumns = @JoinColumn(name = "toolid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "tagid", referencedColumnName = "id"))
-    @ApiModelProperty(value = "Implementation specific tracking of valid build tags for the docker container", position = 14)
+    @ApiModelProperty(value = "Implementation specific tracking of valid build tags for the docker container", position = 26)
     @OrderBy("id")
     private final SortedSet<Tag> tags;
 
@@ -216,7 +216,7 @@ public class Tool extends Entry<Tool, Tag> {
         this.registry = registry;
     }
 
-    @ApiModelProperty(position = 10)
+    @ApiModelProperty(position = 27)
     public String getPath() {
         String repositoryPath;
         if (registry == Registry.AMAZON_ECR) {
@@ -241,6 +241,7 @@ public class Tool extends Entry<Tool, Tag> {
      * @return the languages that this tool supports
      */
     @JsonProperty
+    @ApiModelProperty(position = 28)
     public List<String> getDescriptorType() {
         Set<SourceFile.FileType> set = this.getTags().stream().flatMap(tag -> tag.getSourceFiles().stream()).map(SourceFile::getType)
             .distinct().collect(Collectors.toSet());
@@ -324,7 +325,7 @@ public class Tool extends Entry<Tool, Tag> {
     }
 
     @JsonProperty("tool_path")
-    @ApiModelProperty(position = 11)
+    @ApiModelProperty(position = 29)
     public String getToolPath() {
         return getPath() + (toolname == null || toolname.isEmpty() ? "" : '/' + toolname);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -216,6 +216,7 @@ public class Tool extends Entry<Tool, Tag> {
         this.registry = registry;
     }
 
+    @ApiModelProperty(position = 10)
     public String getPath() {
         String repositoryPath;
         if (registry == Registry.AMAZON_ECR) {
@@ -323,6 +324,7 @@ public class Tool extends Entry<Tool, Tag> {
     }
 
     @JsonProperty("tool_path")
+    @ApiModelProperty(position = 11)
     public String getToolPath() {
         return getPath() + (toolname == null || toolname.isEmpty() ? "" : '/' + toolname);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -80,47 +80,47 @@ public class Tool extends Entry<Tool, Tag> {
 
     @Column(nullable = false, columnDefinition = "Text default 'AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS'")
     @Enumerated(EnumType.STRING)
-    @ApiModelProperty(value = "This indicates what mode this is in which informs how we do things like refresh, dockstore specific", required = true, position = 12)
+    @ApiModelProperty(value = "This indicates what mode this is in which informs how we do things like refresh, dockstore specific", required = true, position = 0)
     private ToolMode mode = ToolMode.AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "This is the name of the container, required: GA4GH", required = true, position = 13)
+    @ApiModelProperty(value = "This is the name of the container, required: GA4GH", required = true, position = 1)
     private String name;
 
     @Column(columnDefinition = "text", nullable = false)
     @JsonProperty("default_dockerfile_path")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the Dockerfile, required: GA4GH", required = true, position = 14)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the Dockerfile, required: GA4GH", required = true, position = 2)
     private String defaultDockerfilePath = "/Dockerfile";
 
     // Add for new descriptor types
     @Column(columnDefinition = "text")
     @JsonProperty("default_cwl_path")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the CWL document, required: GA4GH", required = true, position = 15)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the CWL document, required: GA4GH", required = true, position = 3)
     private String defaultCwlPath = "/Dockstore.cwl";
 
     @Column(columnDefinition = "text default '/Dockstore.wdl'")
     @JsonProperty("default_wdl_path")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the WDL document", required = true, position = 16)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the WDL document", required = true, position = 4)
     private String defaultWdlPath = "/Dockstore.wdl";
 
     @Column(columnDefinition = "text")
     @JsonProperty("defaultCWLTestParameterFile")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the CWL test parameter file", required = true, position = 17)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the CWL test parameter file", required = true, position = 5)
     private String defaultTestCwlParameterFile = "/test.json";
 
     @Column(columnDefinition = "text")
     @JsonProperty("defaultWDLTestParameterFile")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the WDL test parameter file", required = true, position = 18)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the WDL test parameter file", required = true, position = 6)
     private String defaultTestWdlParameterFile = "/test.json";
 
     @Column
     @JsonProperty("tool_maintainer_email")
-    @ApiModelProperty(value = "The email address of the tool maintainer. Required for private repositories", position = 19)
+    @ApiModelProperty(value = "The email address of the tool maintainer. Required for private repositories", position = 7)
     private String toolMaintainerEmail = "";
 
     @Column(columnDefinition = "boolean default false")
     @JsonProperty("private_access")
-    @ApiModelProperty(value = "Is the docker image private or not.", required = true, position = 20)
+    @ApiModelProperty(value = "Is the docker image private or not.", required = true, position = 8)
     private boolean privateAccess = false;
 
     @Column(nullable = false, columnDefinition = "Text default ''")
@@ -128,29 +128,29 @@ public class Tool extends Entry<Tool, Tag> {
             + "when present, this can be used to distinguish between two containers based on the same image, but associated with different "
             + "CWL and Dockerfile documents. i.e. two containers with the same registry+namespace+name but different toolnames "
             + "will be two different entries in the dockstore registry/namespace/name/tool, different options to edit tags, and "
-            + "only the same insofar as they would \"docker pull\" the same image, required: GA4GH", required = true, position = 21)
+            + "only the same insofar as they would \"docker pull\" the same image, required: GA4GH", required = true, position = 9)
     private String toolname = "";
 
     @Column
-    @ApiModelProperty(value = "This is a docker namespace for the container, required: GA4GH", required = true, position = 22)
+    @ApiModelProperty(value = "This is a docker namespace for the container, required: GA4GH", required = true, position = 10)
     private String namespace;
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    @ApiModelProperty(value = "This is a specific docker provider like quay.io or dockerhub or n/a?, required: GA4GH", required = true, position = 23)
+    @ApiModelProperty(value = "This is a specific docker provider like quay.io or dockerhub or n/a?, required: GA4GH", required = true, position = 11)
     private Registry registry;
 
     @Column
-    @ApiModelProperty(value = "Implementation specific timestamp for last built", position = 24)
+    @ApiModelProperty(value = "Implementation specific timestamp for last built", position = 12)
     private Date lastBuild;
 
     @Column
     @JsonProperty("custom_docker_registry_path")
-    @ApiModelProperty(value = "Only used for docker registries that allow for custom paths", position = 25)
+    @ApiModelProperty(value = "Only used for docker registries that allow for custom paths", position = 13)
     private String customDockerRegistryPath = null;
 
     @OneToMany(fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinTable(name = "tool_tag", joinColumns = @JoinColumn(name = "toolid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "tagid", referencedColumnName = "id"))
-    @ApiModelProperty(value = "Implementation specific tracking of valid build tags for the docker container", position = 26)
+    @ApiModelProperty(value = "Implementation specific tracking of valid build tags for the docker container", position = 14)
     @OrderBy("id")
     private final SortedSet<Tag> tags;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -206,6 +206,7 @@ public class User implements Principal {
     }
 
     @Override
+    @ApiModelProperty(position = 8)
     public String getName() {
         return getUsername();
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -57,56 +57,57 @@ import org.apache.http.HttpStatus;
 @Table(name = "enduser")
 @NamedQueries({ @NamedQuery(name = "io.dockstore.webservice.core.User.findAll", query = "SELECT t FROM User t"),
         @NamedQuery(name = "io.dockstore.webservice.core.User.findByUsername", query = "SELECT t FROM User t WHERE t.username = :username") })
+@SuppressWarnings("checkstyle:magicnumber")
 public class User implements Principal {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", unique = true, nullable = false)
-    @ApiModelProperty("Implementation specific ID for the container in this web service")
+    @ApiModelProperty(value = "Implementation specific ID for the container in this web service", position = 0)
     private long id;
 
     @Column(nullable = false, unique = true)
-    @ApiModelProperty("Username on dockstore")
+    @ApiModelProperty(value = "Username on dockstore", position = 1)
     private String username;
 
     @Column
-    @ApiModelProperty(value = "Indicates whether this user is an admin", required = true)
+    @ApiModelProperty(value = "Indicates whether this user is an admin", required = true, position = 2)
     private boolean isAdmin;
 
     @Column
-    @ApiModelProperty(value = "Company of user", required = false)
+    @ApiModelProperty(value = "Company of user", position = 3)
     private String company;
 
     @Column
-    @ApiModelProperty(value = "Bio of user", required = false)
+    @ApiModelProperty(value = "Bio of user", position = 4)
     private String bio;
 
     @Column
-    @ApiModelProperty(value = "Location of user", required = false)
+    @ApiModelProperty(value = "Location of user", position = 5)
     private String location;
 
     @Column
-    @ApiModelProperty(value = "Email of user", required = false)
+    @ApiModelProperty(value = "Email of user", position = 6)
     private String email;
 
     @Column
-    @ApiModelProperty(value = "URL of user avatar on Github.", required = false)
+    @ApiModelProperty(value = "URL of user avatar on Github.", position = 7)
     private String avatarUrl;
 
     @ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinTable(name = "endusergroup", joinColumns = @JoinColumn(name = "userid", nullable = false, updatable = false, referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "groupid", nullable = false, updatable = false, referencedColumnName = "id"))
-    @ApiModelProperty("Groups that this user belongs to")
+    @ApiModelProperty(value = "Groups that this user belongs to", position = 8)
     @JsonIgnore
     private final Set<Group> groups;
 
     @ManyToMany(fetch = FetchType.LAZY, cascade = { CascadeType.PERSIST, CascadeType.MERGE })
     @JoinTable(name = "user_entry", inverseJoinColumns = @JoinColumn(name = "entryid", nullable = false, updatable = false, referencedColumnName = "id"), joinColumns = @JoinColumn(name = "userid", nullable = false, updatable = false, referencedColumnName = "id"))
-    @ApiModelProperty("Entries in the dockstore that this user manages")
+    @ApiModelProperty(value = "Entries in the dockstore that this user manages", position = 9)
     @JsonIgnore
     private final Set<Entry> entries;
 
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "starred", inverseJoinColumns = @JoinColumn(name = "entryid", nullable = false, updatable = false, referencedColumnName = "id"), joinColumns = @JoinColumn(name = "userid", nullable = false, updatable = false, referencedColumnName = "id"))
-    @ApiModelProperty("Entries in the dockstore that this user starred")
+    @ApiModelProperty(value = "Entries in the dockstore that this user starred", position = 10)
     @OrderBy("id")
     @JsonIgnore
     private final Set<Entry> starredEntries;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -51,6 +51,7 @@ import io.swagger.annotations.ApiModelProperty;
 @Entity
 @ApiModel(value = "Base class for versions of entries in the Dockstore")
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@SuppressWarnings("checkstyle:magicnumber")
 public abstract class Version<T extends Version> implements Comparable<T> {
     /**
      * re-use existing generator for backwards compatibility
@@ -58,53 +59,53 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "tag_id_seq")
     @SequenceGenerator(name = "tag_id_seq", sequenceName = "tag_id_seq")
-    @ApiModelProperty("Implementation specific ID for the tag in this web service")
+    @ApiModelProperty(value = "Implementation specific ID for the tag in this web service", position = 0)
     private long id;
 
     @Column
     @JsonProperty("last_modified")
-    @ApiModelProperty("The last time this image was modified in the image registry")
+    @ApiModelProperty(value = "The last time this image was modified in the image registry", position = 1)
     private Date lastModified;
 
     @Column
-    @ApiModelProperty(value = "git commit/tag/branch", required = true)
+    @ApiModelProperty(value = "git commit/tag/branch", required = true, position = 2)
     private String reference;
 
     @OneToMany(fetch = FetchType.EAGER, orphanRemoval = true, cascade = CascadeType.ALL)
     @JoinTable(name = "version_sourcefile", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "sourcefileid", referencedColumnName = "id"))
-    @ApiModelProperty("Cached files for each version. Includes Dockerfile and Descriptor files")
+    @ApiModelProperty(value = "Cached files for each version. Includes Dockerfile and Descriptor files", position = 3)
     private final Set<SourceFile> sourceFiles;
 
     @Column
-    @ApiModelProperty("Implementation specific, whether this row is visible to other users aside from the owner")
+    @ApiModelProperty(value = "Implementation specific, whether this row is visible to other users aside from the owner", position = 4)
     private boolean hidden;
 
     @Column
-    @ApiModelProperty("Implementation specific, whether this tag has valid files from source code repo")
+    @ApiModelProperty(value = "Implementation specific, whether this tag has valid files from source code repo", position = 5)
     private boolean valid;
 
     @Column
-    @ApiModelProperty(value = "Implementation specific, can be a quay.io or docker hub tag name", required = true)
+    @ApiModelProperty(value = "Implementation specific, can be a quay.io or docker hub tag name", required = true, position = 6)
     private String name;
 
     @Column(columnDefinition = "boolean default false")
-    @ApiModelProperty(value = "True if user has altered the tag")
+    @ApiModelProperty(value = "True if user has altered the tag", position = 7)
     private boolean dirtyBit = false;
 
     @Column(columnDefinition =  "boolean default false")
-    @ApiModelProperty("Whether this version has been verified or not")
+    @ApiModelProperty(value = "Whether this version has been verified or not", position = 8)
     private boolean verified;
     @Column
-    @ApiModelProperty("Verified source for the version")
+    @ApiModelProperty(value = "Verified source for the version", position = 9)
     private String verifiedSource;
 
     @Column
-    @ApiModelProperty("This is a URL for the DOI for the version of the entry")
+    @ApiModelProperty(value = "This is a URL for the DOI for the version of the entry", position = 10)
     private String doiURL;
 
     @Column(columnDefinition = "text default 'NOT_REQUESTED'", nullable = false)
     @Enumerated(EnumType.STRING)
-    @ApiModelProperty("This indicates the DOI status")
+    @ApiModelProperty(value = "This indicates the DOI status", position = 11)
     private DOIStatus doiStatus;
 
     public Version() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -226,10 +226,12 @@ public class Workflow extends Entry<Workflow, WorkflowVersion> {
     }
 
     @JsonProperty("full_workflow_path")
+    @ApiModelProperty(position = 10)
     public String getWorkflowPath() {
         return getPath() + (workflowName == null || "".equals(workflowName) ? "" : '/' + workflowName);
     }
 
+    @ApiModelProperty(position = 11)
     public String getPath() {
         return getSourceControl().toString() + '/' + organization + '/' + repository;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -73,44 +73,44 @@ public class Workflow extends Entry<Workflow, WorkflowVersion> {
 
     @Column(nullable = false, columnDefinition = "Text default 'STUB'")
     @Enumerated(EnumType.STRING)
-    @ApiModelProperty(value = "This indicates what mode this is in which informs how we do things like refresh, dockstore specific", required = true, position = 0)
+    @ApiModelProperty(value = "This indicates what mode this is in which informs how we do things like refresh, dockstore specific", required = true, position = 12)
     private WorkflowMode mode = WorkflowMode.STUB;
 
     @Column(columnDefinition = "text")
-    @ApiModelProperty(value = "This is the name of the workflow, not needed when only one workflow in a repo", position = 1)
+    @ApiModelProperty(value = "This is the name of the workflow, not needed when only one workflow in a repo", position = 13)
     private String workflowName;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "This is a git organization for the workflow", required = true, position = 2)
+    @ApiModelProperty(value = "This is a git organization for the workflow", required = true, position = 14)
     private String organization;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "This is a git repository name", required = true, position = 3)
+    @ApiModelProperty(value = "This is a git repository name", required = true, position = 15)
     private String repository;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    @ApiModelProperty(value = "This is a specific source control provider like github or bitbucket or n/a?, required: GA4GH", required = true, position = 4)
+    @ApiModelProperty(value = "This is a specific source control provider like github or bitbucket or n/a?, required: GA4GH", required = true, position = 16)
     private SourceControl sourceControl;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "This is a descriptor type for the workflow, either CWL or WDL (Defaults to CWL)", required = true, position = 5)
+    @ApiModelProperty(value = "This is a descriptor type for the workflow, either CWL or WDL (Defaults to CWL)", required = true, position = 17)
     private String descriptorType;
 
     // Add for new descriptor types
     @Column(columnDefinition = "text")
     @JsonProperty("workflow_path")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the CWL document", required = true, position = 6)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the CWL document", required = true, position = 18)
     private String defaultWorkflowPath = "/Dockstore.cwl";
 
     @Column(columnDefinition = "text")
     @JsonProperty("defaultTestParameterFilePath")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the test parameter file", required = true, position = 7)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the test parameter file", required = true, position = 19)
     private String defaultTestParameterFilePath = "/test.json";
 
     @OneToMany(fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinTable(name = "workflow_workflowversion", joinColumns = @JoinColumn(name = "workflowid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "workflowversionid", referencedColumnName = "id"))
-    @ApiModelProperty(value = "Implementation specific tracking of valid build workflowVersions for the docker container", position = 8)
+    @ApiModelProperty(value = "Implementation specific tracking of valid build workflowVersions for the docker container", position = 20)
     @OrderBy("id")
     private final SortedSet<WorkflowVersion> workflowVersions;
 
@@ -226,12 +226,12 @@ public class Workflow extends Entry<Workflow, WorkflowVersion> {
     }
 
     @JsonProperty("full_workflow_path")
-    @ApiModelProperty(position = 10)
+    @ApiModelProperty(position = 21)
     public String getWorkflowPath() {
         return getPath() + (workflowName == null || "".equals(workflowName) ? "" : '/' + workflowName);
     }
 
-    @ApiModelProperty(position = 11)
+    @ApiModelProperty(position = 22)
     public String getPath() {
         return getSourceControl().toString() + '/' + organization + '/' + repository;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -68,48 +68,49 @@ import org.apache.http.HttpStatus;
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findPublishedByOrganization", query = "SELECT c FROM Workflow c WHERE lower(c.organization) = lower(:organization) AND c.isPublished = true"),
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.searchPattern", query = "SELECT c FROM Workflow c WHERE ((c.defaultWorkflowPath LIKE :pattern) OR (c.description LIKE :pattern) OR (CONCAT(c.sourceControl, '/', c.organization, '/', c.repository, '/', c.workflowName) LIKE :pattern)) AND c.isPublished = true") })
 @DiscriminatorValue("workflow")
+@SuppressWarnings("checkstyle:magicnumber")
 public class Workflow extends Entry<Workflow, WorkflowVersion> {
 
     @Column(nullable = false, columnDefinition = "Text default 'STUB'")
     @Enumerated(EnumType.STRING)
-    @ApiModelProperty(value = "This indicates what mode this is in which informs how we do things like refresh, dockstore specific", required = true)
+    @ApiModelProperty(value = "This indicates what mode this is in which informs how we do things like refresh, dockstore specific", required = true, position = 12)
     private WorkflowMode mode = WorkflowMode.STUB;
 
     @Column(columnDefinition = "text")
-    @ApiModelProperty(value = "This is the name of the workflow, not needed when only one workflow in a repo")
+    @ApiModelProperty(value = "This is the name of the workflow, not needed when only one workflow in a repo", position = 13)
     private String workflowName;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "This is a git organization for the workflow", required = true)
+    @ApiModelProperty(value = "This is a git organization for the workflow", required = true, position = 14)
     private String organization;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "This is a git repository name", required = true)
+    @ApiModelProperty(value = "This is a git repository name", required = true, position = 15)
     private String repository;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    @ApiModelProperty(value = "This is a specific source control provider like github or bitbucket or n/a?, required: GA4GH", required = true)
+    @ApiModelProperty(value = "This is a specific source control provider like github or bitbucket or n/a?, required: GA4GH", required = true, position = 16)
     private SourceControl sourceControl;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "This is a descriptor type for the workflow, either CWL or WDL (Defaults to CWL)", required = true)
+    @ApiModelProperty(value = "This is a descriptor type for the workflow, either CWL or WDL (Defaults to CWL)", required = true, position = 17)
     private String descriptorType;
 
     // Add for new descriptor types
     @Column(columnDefinition = "text")
     @JsonProperty("workflow_path")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the CWL document", required = true)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the CWL document", required = true, position = 18)
     private String defaultWorkflowPath = "/Dockstore.cwl";
 
     @Column(columnDefinition = "text")
     @JsonProperty("defaultTestParameterFilePath")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the test parameter file", required = true)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the test parameter file", required = true, position = 19)
     private String defaultTestParameterFilePath = "/test.json";
 
     @OneToMany(fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinTable(name = "workflow_workflowversion", joinColumns = @JoinColumn(name = "workflowid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "workflowversionid", referencedColumnName = "id"))
-    @ApiModelProperty(value = "Implementation specific tracking of valid build workflowVersions for the docker container")
+    @ApiModelProperty(value = "Implementation specific tracking of valid build workflowVersions for the docker container", position = 20)
     @OrderBy("id")
     private final SortedSet<WorkflowVersion> workflowVersions;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -73,44 +73,44 @@ public class Workflow extends Entry<Workflow, WorkflowVersion> {
 
     @Column(nullable = false, columnDefinition = "Text default 'STUB'")
     @Enumerated(EnumType.STRING)
-    @ApiModelProperty(value = "This indicates what mode this is in which informs how we do things like refresh, dockstore specific", required = true, position = 12)
+    @ApiModelProperty(value = "This indicates what mode this is in which informs how we do things like refresh, dockstore specific", required = true, position = 0)
     private WorkflowMode mode = WorkflowMode.STUB;
 
     @Column(columnDefinition = "text")
-    @ApiModelProperty(value = "This is the name of the workflow, not needed when only one workflow in a repo", position = 13)
+    @ApiModelProperty(value = "This is the name of the workflow, not needed when only one workflow in a repo", position = 1)
     private String workflowName;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "This is a git organization for the workflow", required = true, position = 14)
+    @ApiModelProperty(value = "This is a git organization for the workflow", required = true, position = 2)
     private String organization;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "This is a git repository name", required = true, position = 15)
+    @ApiModelProperty(value = "This is a git repository name", required = true, position = 3)
     private String repository;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    @ApiModelProperty(value = "This is a specific source control provider like github or bitbucket or n/a?, required: GA4GH", required = true, position = 16)
+    @ApiModelProperty(value = "This is a specific source control provider like github or bitbucket or n/a?, required: GA4GH", required = true, position = 4)
     private SourceControl sourceControl;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "This is a descriptor type for the workflow, either CWL or WDL (Defaults to CWL)", required = true, position = 17)
+    @ApiModelProperty(value = "This is a descriptor type for the workflow, either CWL or WDL (Defaults to CWL)", required = true, position = 5)
     private String descriptorType;
 
     // Add for new descriptor types
     @Column(columnDefinition = "text")
     @JsonProperty("workflow_path")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the CWL document", required = true, position = 18)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the CWL document", required = true, position = 6)
     private String defaultWorkflowPath = "/Dockstore.cwl";
 
     @Column(columnDefinition = "text")
     @JsonProperty("defaultTestParameterFilePath")
-    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the test parameter file", required = true, position = 19)
+    @ApiModelProperty(value = "This indicates for the associated git repository, the default path to the test parameter file", required = true, position = 7)
     private String defaultTestParameterFilePath = "/test.json";
 
     @OneToMany(fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinTable(name = "workflow_workflowversion", joinColumns = @JoinColumn(name = "workflowid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "workflowversionid", referencedColumnName = "id"))
-    @ApiModelProperty(value = "Implementation specific tracking of valid build workflowVersions for the docker container", position = 20)
+    @ApiModelProperty(value = "Implementation specific tracking of valid build workflowVersions for the docker container", position = 8)
     @OrderBy("id")
     private final SortedSet<WorkflowVersion> workflowVersions;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -35,11 +35,12 @@ import org.apache.commons.io.FilenameUtils;
  */
 @ApiModel(value = "WorkflowVersion", description = "This describes one workflow version associated with a workflow.")
 @Entity
+@SuppressWarnings("checkstyle:magicnumber")
 public class WorkflowVersion extends Version<WorkflowVersion> implements Comparable<WorkflowVersion> {
 
     @Column(columnDefinition = "text", nullable = false)
     @JsonProperty("workflow_path")
-    @ApiModelProperty("Path for the workflow")
+    @ApiModelProperty(value = "Path for the workflow", position = 12)
     private String workflowPath;
 
     public WorkflowVersion() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -40,7 +40,7 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
 
     @Column(columnDefinition = "text", nullable = false)
     @JsonProperty("workflow_path")
-    @ApiModelProperty(value = "Path for the workflow", position = 12)
+    @ApiModelProperty(value = "Path for the workflow", position = 0)
     private String workflowPath;
 
     public WorkflowVersion() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -40,7 +40,7 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
 
     @Column(columnDefinition = "text", nullable = false)
     @JsonProperty("workflow_path")
-    @ApiModelProperty(value = "Path for the workflow", position = 0)
+    @ApiModelProperty(value = "Path for the workflow", position = 12)
     private String workflowPath;
 
     public WorkflowVersion() {

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4171,15 +4171,28 @@ definitions:
         type: "integer"
         format: "int64"
         description: "Implementation specific ID for the container in this web service"
+      descriptorType:
+        type: "array"
+        readOnly: true
+        items:
+          type: "string"
+      path:
+        type: "string"
+      tool_path:
+        type: "string"
+        readOnly: true
       author:
         type: "string"
+        position: 1
         description: "This is the name of the author stated in the Dockstore.cwl"
       description:
         type: "string"
+        position: 2
         description: "This is a human-readable description of this container and what\
           \ it is trying to accomplish, required GA4GH"
       labels:
         type: "array"
+        position: 3
         description: "Labels (i.e. meta tags) for describing the purpose and contents\
           \ of containers"
         uniqueItems: true
@@ -4187,6 +4200,7 @@ definitions:
           $ref: "#/definitions/Label"
       users:
         type: "array"
+        position: 4
         description: "This indicates the users that have control over this entry,\
           \ dockstore specific"
         uniqueItems: true
@@ -4194,6 +4208,7 @@ definitions:
           $ref: "#/definitions/User"
       starredUsers:
         type: "array"
+        position: 5
         description: "This indicates the users that have starred this entry, dockstore\
           \ specific"
         uniqueItems: true
@@ -4201,20 +4216,34 @@ definitions:
           $ref: "#/definitions/User"
       email:
         type: "string"
+        position: 6
         description: "This is the email of the git organization"
       defaultVersion:
         type: "string"
+        position: 7
         description: "This is the default version of the entry"
+      is_published:
+        type: "boolean"
+        position: 8
+        description: "Implementation specific visibility in this web service"
+      last_modified:
+        type: "integer"
+        format: "int32"
+        position: 9
+        description: "Implementation specific timestamp for last modified"
       lastUpdated:
         type: "string"
         format: "date-time"
+        position: 10
         description: "Implementation specific timestamp for last updated on webservice"
       gitUrl:
         type: "string"
+        position: 11
         description: "This is a link to the associated repo with a descriptor, required\
           \ GA4GH"
       mode:
         type: "string"
+        position: 12
         description: "This indicates what mode this is in which informs how we do\
           \ things like refresh, dockstore specific"
         enum:
@@ -4223,9 +4252,45 @@ definitions:
         - "MANUAL_IMAGE_PATH"
       name:
         type: "string"
+        position: 13
         description: "This is the name of the container, required: GA4GH"
+      default_dockerfile_path:
+        type: "string"
+        position: 14
+        description: "This indicates for the associated git repository, the default\
+          \ path to the Dockerfile, required: GA4GH"
+      default_cwl_path:
+        type: "string"
+        position: 15
+        description: "This indicates for the associated git repository, the default\
+          \ path to the CWL document, required: GA4GH"
+      default_wdl_path:
+        type: "string"
+        position: 16
+        description: "This indicates for the associated git repository, the default\
+          \ path to the WDL document"
+      defaultCWLTestParameterFile:
+        type: "string"
+        position: 17
+        description: "This indicates for the associated git repository, the default\
+          \ path to the CWL test parameter file"
+      defaultWDLTestParameterFile:
+        type: "string"
+        position: 18
+        description: "This indicates for the associated git repository, the default\
+          \ path to the WDL test parameter file"
+      tool_maintainer_email:
+        type: "string"
+        position: 19
+        description: "The email address of the tool maintainer. Required for private\
+          \ repositories"
+      private_access:
+        type: "boolean"
+        position: 20
+        description: "Is the docker image private or not."
       toolname:
         type: "string"
+        position: 21
         description: "This is the tool name of the container, when not-present this\
           \ will function just like 0.1 dockstorewhen present, this can be used to\
           \ distinguish between two containers based on the same image, but associated\
@@ -4236,9 +4301,11 @@ definitions:
           \ the same image, required: GA4GH"
       namespace:
         type: "string"
+        position: 22
         description: "This is a docker namespace for the container, required: GA4GH"
       registry:
         type: "string"
+        position: 23
         description: "This is a specific docker provider like quay.io or dockerhub\
           \ or n/a?, required: GA4GH"
         enum:
@@ -4249,61 +4316,20 @@ definitions:
       lastBuild:
         type: "string"
         format: "date-time"
+        position: 24
         description: "Implementation specific timestamp for last built"
+      custom_docker_registry_path:
+        type: "string"
+        position: 25
+        description: "Only used for docker registries that allow for custom paths"
       tags:
         type: "array"
+        position: 26
         description: "Implementation specific tracking of valid build tags for the\
           \ docker container"
         uniqueItems: true
         items:
           $ref: "#/definitions/Tag"
-      descriptorType:
-        type: "array"
-        readOnly: true
-        items:
-          type: "string"
-      path:
-        type: "string"
-      is_published:
-        type: "boolean"
-        description: "Implementation specific visibility in this web service"
-      last_modified:
-        type: "integer"
-        format: "int32"
-        description: "Implementation specific timestamp for last modified"
-      default_dockerfile_path:
-        type: "string"
-        description: "This indicates for the associated git repository, the default\
-          \ path to the Dockerfile, required: GA4GH"
-      default_cwl_path:
-        type: "string"
-        description: "This indicates for the associated git repository, the default\
-          \ path to the CWL document, required: GA4GH"
-      default_wdl_path:
-        type: "string"
-        description: "This indicates for the associated git repository, the default\
-          \ path to the WDL document"
-      defaultCWLTestParameterFile:
-        type: "string"
-        description: "This indicates for the associated git repository, the default\
-          \ path to the CWL test parameter file"
-      defaultWDLTestParameterFile:
-        type: "string"
-        description: "This indicates for the associated git repository, the default\
-          \ path to the WDL test parameter file"
-      tool_maintainer_email:
-        type: "string"
-        description: "The email address of the tool maintainer. Required for private\
-          \ repositories"
-      private_access:
-        type: "boolean"
-        description: "Is the docker image private or not."
-      custom_docker_registry_path:
-        type: "string"
-        description: "Only used for docker registries that allow for custom paths"
-      tool_path:
-        type: "string"
-        readOnly: true
     description: "This describes one entry in the dockstore. Logically, this currently\
       \ means one tuple of registry (either quay or docker hub), organization, image\
       \ name, and toolname which can be\n * associated with CWL and Dockerfile documents"
@@ -4318,13 +4344,16 @@ definitions:
         description: "Implementation specific ID for the container in this web service"
       author:
         type: "string"
+        position: 1
         description: "This is the name of the author stated in the Dockstore.cwl"
       description:
         type: "string"
+        position: 2
         description: "This is a human-readable description of this container and what\
           \ it is trying to accomplish, required GA4GH"
       labels:
         type: "array"
+        position: 3
         description: "Labels (i.e. meta tags) for describing the purpose and contents\
           \ of containers"
         uniqueItems: true
@@ -4332,6 +4361,7 @@ definitions:
           $ref: "#/definitions/Label"
       users:
         type: "array"
+        position: 4
         description: "This indicates the users that have control over this entry,\
           \ dockstore specific"
         uniqueItems: true
@@ -4339,6 +4369,7 @@ definitions:
           $ref: "#/definitions/User"
       starredUsers:
         type: "array"
+        position: 5
         description: "This indicates the users that have starred this entry, dockstore\
           \ specific"
         uniqueItems: true
@@ -4346,25 +4377,31 @@ definitions:
           $ref: "#/definitions/User"
       email:
         type: "string"
+        position: 6
         description: "This is the email of the git organization"
       defaultVersion:
         type: "string"
+        position: 7
         description: "This is the default version of the entry"
-      lastUpdated:
-        type: "string"
-        format: "date-time"
-        description: "Implementation specific timestamp for last updated on webservice"
-      gitUrl:
-        type: "string"
-        description: "This is a link to the associated repo with a descriptor, required\
-          \ GA4GH"
       is_published:
         type: "boolean"
+        position: 8
         description: "Implementation specific visibility in this web service"
       last_modified:
         type: "integer"
         format: "int32"
+        position: 9
         description: "Implementation specific timestamp for last modified"
+      lastUpdated:
+        type: "string"
+        format: "date-time"
+        position: 10
+        description: "Implementation specific timestamp for last updated on webservice"
+      gitUrl:
+        type: "string"
+        position: 11
+        description: "This is a link to the associated repo with a descriptor, required\
+          \ GA4GH"
   GitHubComAuthenticationResource:
     type: "object"
     properties:
@@ -4421,6 +4458,7 @@ definitions:
         readOnly: true
       value:
         type: "string"
+        position: 1
         description: "String representation of the tag"
     description: "This describes a descriptive label that can be placed on an entry\
       \ in the dockstore"
@@ -4520,6 +4558,7 @@ definitions:
         description: "Implementation specific ID for the source file in this web service"
       type:
         type: "string"
+        position: 1
         description: "Enumerates the type of file"
         enum:
         - "DOCKSTORE_CWL"
@@ -4532,9 +4571,11 @@ definitions:
         - "NEXTFLOW_TEST_PARAMS"
       content:
         type: "string"
+        position: 2
         description: "Cache for the contents of the target file"
       path:
         type: "string"
+        position: 3
         description: "Path to source file in git repo"
   StarRequest:
     type: "object"
@@ -4554,11 +4595,20 @@ definitions:
         format: "int64"
         description: "Implementation specific ID for the tag in this web service"
         readOnly: true
+      workingDirectory:
+        type: "string"
+      last_modified:
+        type: "string"
+        format: "date-time"
+        position: 1
+        description: "The last time this image was modified in the image registry"
       reference:
         type: "string"
+        position: 2
         description: "git commit/tag/branch"
       sourceFiles:
         type: "array"
+        position: 3
         description: "Cached files for each version. Includes Dockerfile and Descriptor\
           \ files"
         uniqueItems: true
@@ -4566,61 +4616,69 @@ definitions:
           $ref: "#/definitions/SourceFile"
       hidden:
         type: "boolean"
+        position: 4
         description: "Implementation specific, whether this row is visible to other\
           \ users aside from the owner"
       valid:
         type: "boolean"
+        position: 5
         description: "Implementation specific, whether this tag has valid files from\
           \ source code repo"
       name:
         type: "string"
+        position: 6
         description: "Implementation specific, can be a quay.io or docker hub tag\
           \ name"
       dirtyBit:
         type: "boolean"
+        position: 7
         description: "True if user has altered the tag"
       verified:
         type: "boolean"
+        position: 8
         description: "Whether this version has been verified or not"
       verifiedSource:
         type: "string"
+        position: 9
         description: "Verified source for the version"
       doiURL:
         type: "string"
+        position: 10
         description: "This is a URL for the DOI for the version of the entry"
       doiStatus:
         type: "string"
+        position: 11
         description: "This indicates the DOI status"
         enum:
         - "NOT_REQUESTED"
         - "REQUESTED"
         - "CREATED"
+      image_id:
+        type: "string"
+        position: 12
+        description: "Tag for this image in quay.ui/docker hub"
       size:
         type: "integer"
         format: "int64"
+        position: 13
         description: "Size of the image"
-      automated:
-        type: "boolean"
-        description: "Implementation specific, indicates whether this is an automated\
-          \ build on quay.io"
-      workingDirectory:
-        type: "string"
-      last_modified:
-        type: "string"
-        format: "date-time"
-        description: "The last time this image was modified in the image registry"
-      image_id:
-        type: "string"
-        description: "Tag for this image in quay.ui/docker hub"
       dockerfile_path:
         type: "string"
+        position: 14
         description: "Path for the Dockerfile"
       cwl_path:
         type: "string"
+        position: 15
         description: "Path for the CWL document"
       wdl_path:
         type: "string"
+        position: 16
         description: "Path for the WDL document"
+      automated:
+        type: "boolean"
+        position: 17
+        description: "Implementation specific, indicates whether this is an automated\
+          \ build on quay.io"
     description: "This describes one tag associated with a container."
   Token:
     type: "object"
@@ -4630,23 +4688,28 @@ definitions:
         format: "int64"
         description: "Implementation specific ID for the token in this web service"
         readOnly: true
+      userId:
+        type: "integer"
+        format: "int64"
       tokenSource:
         type: "string"
+        position: 1
         description: "Source website for this token"
       content:
         type: "string"
+        position: 2
         description: "Contents of the access token"
       username:
         type: "string"
+        position: 3
         description: "When an integrated service is not aware of the username, we\
           \ store it"
       refreshToken:
         type: "string"
-      userId:
-        type: "integer"
-        format: "int64"
+        position: 4
       token:
         type: "string"
+        position: 5
         description: "Contents of the access token"
         readOnly: true
     description: "Access tokens for this web service and integrated services like\
@@ -4994,29 +5057,36 @@ definitions:
         format: "int64"
         description: "Implementation specific ID for the container in this web service"
         readOnly: true
+      name:
+        type: "string"
       username:
         type: "string"
+        position: 1
         description: "Username on dockstore"
       isAdmin:
         type: "boolean"
+        position: 2
         description: "Indicates whether this user is an admin"
       company:
         type: "string"
+        position: 3
         description: "Company of user"
       bio:
         type: "string"
+        position: 4
         description: "Bio of user"
       location:
         type: "string"
+        position: 5
         description: "Location of user"
       email:
         type: "string"
+        position: 6
         description: "Email of user"
       avatarUrl:
         type: "string"
+        position: 7
         description: "URL of user avatar on Github."
-      name:
-        type: "string"
     description: "End users for the dockstore"
   VerifyRequest:
     type: "object"
@@ -5043,15 +5113,23 @@ definitions:
         type: "integer"
         format: "int64"
         description: "Implementation specific ID for the container in this web service"
+      path:
+        type: "string"
+      full_workflow_path:
+        type: "string"
+        readOnly: true
       author:
         type: "string"
+        position: 1
         description: "This is the name of the author stated in the Dockstore.cwl"
       description:
         type: "string"
+        position: 2
         description: "This is a human-readable description of this container and what\
           \ it is trying to accomplish, required GA4GH"
       labels:
         type: "array"
+        position: 3
         description: "Labels (i.e. meta tags) for describing the purpose and contents\
           \ of containers"
         uniqueItems: true
@@ -5059,6 +5137,7 @@ definitions:
           $ref: "#/definitions/Label"
       users:
         type: "array"
+        position: 4
         description: "This indicates the users that have control over this entry,\
           \ dockstore specific"
         uniqueItems: true
@@ -5066,6 +5145,7 @@ definitions:
           $ref: "#/definitions/User"
       starredUsers:
         type: "array"
+        position: 5
         description: "This indicates the users that have starred this entry, dockstore\
           \ specific"
         uniqueItems: true
@@ -5073,20 +5153,34 @@ definitions:
           $ref: "#/definitions/User"
       email:
         type: "string"
+        position: 6
         description: "This is the email of the git organization"
       defaultVersion:
         type: "string"
+        position: 7
         description: "This is the default version of the entry"
+      is_published:
+        type: "boolean"
+        position: 8
+        description: "Implementation specific visibility in this web service"
+      last_modified:
+        type: "integer"
+        format: "int32"
+        position: 9
+        description: "Implementation specific timestamp for last modified"
       lastUpdated:
         type: "string"
         format: "date-time"
+        position: 10
         description: "Implementation specific timestamp for last updated on webservice"
       gitUrl:
         type: "string"
+        position: 11
         description: "This is a link to the associated repo with a descriptor, required\
           \ GA4GH"
       mode:
         type: "string"
+        position: 12
         description: "This indicates what mode this is in which informs how we do\
           \ things like refresh, dockstore specific"
         enum:
@@ -5094,16 +5188,20 @@ definitions:
         - "STUB"
       workflowName:
         type: "string"
+        position: 13
         description: "This is the name of the workflow, not needed when only one workflow\
           \ in a repo"
       organization:
         type: "string"
+        position: 14
         description: "This is a git organization for the workflow"
       repository:
         type: "string"
+        position: 15
         description: "This is a git repository name"
       sourceControl:
         type: "string"
+        position: 16
         description: "This is a specific source control provider like github or bitbucket\
           \ or n/a?, required: GA4GH"
         enum:
@@ -5112,35 +5210,27 @@ definitions:
         - "GITLAB"
       descriptorType:
         type: "string"
+        position: 17
         description: "This is a descriptor type for the workflow, either CWL or WDL\
           \ (Defaults to CWL)"
+      workflow_path:
+        type: "string"
+        position: 18
+        description: "This indicates for the associated git repository, the default\
+          \ path to the CWL document"
+      defaultTestParameterFilePath:
+        type: "string"
+        position: 19
+        description: "This indicates for the associated git repository, the default\
+          \ path to the test parameter file"
       workflowVersions:
         type: "array"
+        position: 20
         description: "Implementation specific tracking of valid build workflowVersions\
           \ for the docker container"
         uniqueItems: true
         items:
           $ref: "#/definitions/WorkflowVersion"
-      path:
-        type: "string"
-      is_published:
-        type: "boolean"
-        description: "Implementation specific visibility in this web service"
-      last_modified:
-        type: "integer"
-        format: "int32"
-        description: "Implementation specific timestamp for last modified"
-      workflow_path:
-        type: "string"
-        description: "This indicates for the associated git repository, the default\
-          \ path to the CWL document"
-      defaultTestParameterFilePath:
-        type: "string"
-        description: "This indicates for the associated git repository, the default\
-          \ path to the test parameter file"
-      full_workflow_path:
-        type: "string"
-        readOnly: true
     description: "This describes one workflow in the dockstore"
   WorkflowVersion:
     type: "object"
@@ -5153,11 +5243,20 @@ definitions:
         format: "int64"
         description: "Implementation specific ID for the tag in this web service"
         readOnly: true
+      workingDirectory:
+        type: "string"
+      last_modified:
+        type: "string"
+        format: "date-time"
+        position: 1
+        description: "The last time this image was modified in the image registry"
       reference:
         type: "string"
+        position: 2
         description: "git commit/tag/branch"
       sourceFiles:
         type: "array"
+        position: 3
         description: "Cached files for each version. Includes Dockerfile and Descriptor\
           \ files"
         uniqueItems: true
@@ -5165,42 +5264,45 @@ definitions:
           $ref: "#/definitions/SourceFile"
       hidden:
         type: "boolean"
+        position: 4
         description: "Implementation specific, whether this row is visible to other\
           \ users aside from the owner"
       valid:
         type: "boolean"
+        position: 5
         description: "Implementation specific, whether this tag has valid files from\
           \ source code repo"
       name:
         type: "string"
+        position: 6
         description: "Implementation specific, can be a quay.io or docker hub tag\
           \ name"
       dirtyBit:
         type: "boolean"
+        position: 7
         description: "True if user has altered the tag"
       verified:
         type: "boolean"
+        position: 8
         description: "Whether this version has been verified or not"
       verifiedSource:
         type: "string"
+        position: 9
         description: "Verified source for the version"
       doiURL:
         type: "string"
+        position: 10
         description: "This is a URL for the DOI for the version of the entry"
       doiStatus:
         type: "string"
+        position: 11
         description: "This indicates the DOI status"
         enum:
         - "NOT_REQUESTED"
         - "REQUESTED"
         - "CREATED"
-      workingDirectory:
-        type: "string"
-      last_modified:
-        type: "string"
-        format: "date-time"
-        description: "The last time this image was modified in the image registry"
       workflow_path:
         type: "string"
+        position: 12
         description: "Path for the workflow"
     description: "This describes one workflow version associated with a workflow."

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4171,37 +4171,15 @@ definitions:
         type: "integer"
         format: "int64"
         description: "Implementation specific ID for the container in this web service"
-      mode:
-        type: "string"
-        description: "This indicates what mode this is in which informs how we do\
-          \ things like refresh, dockstore specific"
-        enum:
-        - "AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS"
-        - "AUTO_DETECT_QUAY_TAGS_WITH_MIXED"
-        - "MANUAL_IMAGE_PATH"
-      descriptorType:
-        type: "array"
-        readOnly: true
-        items:
-          type: "string"
       author:
         type: "string"
         position: 1
         description: "This is the name of the author stated in the Dockstore.cwl"
-      name:
-        type: "string"
-        position: 1
-        description: "This is the name of the container, required: GA4GH"
       description:
         type: "string"
         position: 2
         description: "This is a human-readable description of this container and what\
           \ it is trying to accomplish, required GA4GH"
-      default_dockerfile_path:
-        type: "string"
-        position: 2
-        description: "This indicates for the associated git repository, the default\
-          \ path to the Dockerfile, required: GA4GH"
       labels:
         type: "array"
         position: 3
@@ -4210,11 +4188,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/Label"
-      default_cwl_path:
-        type: "string"
-        position: 3
-        description: "This indicates for the associated git repository, the default\
-          \ path to the CWL document, required: GA4GH"
       users:
         type: "array"
         position: 4
@@ -4223,11 +4196,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/User"
-      default_wdl_path:
-        type: "string"
-        position: 4
-        description: "This indicates for the associated git repository, the default\
-          \ path to the WDL document"
       starredUsers:
         type: "array"
         position: 5
@@ -4236,48 +4204,18 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/User"
-      defaultCWLTestParameterFile:
-        type: "string"
-        position: 5
-        description: "This indicates for the associated git repository, the default\
-          \ path to the CWL test parameter file"
       email:
         type: "string"
         position: 6
         description: "This is the email of the git organization"
-      defaultWDLTestParameterFile:
-        type: "string"
-        position: 6
-        description: "This indicates for the associated git repository, the default\
-          \ path to the WDL test parameter file"
       defaultVersion:
         type: "string"
         position: 7
         description: "This is the default version of the entry"
-      tool_maintainer_email:
-        type: "string"
-        position: 7
-        description: "The email address of the tool maintainer. Required for private\
-          \ repositories"
       is_published:
         type: "boolean"
         position: 8
         description: "Implementation specific visibility in this web service"
-      private_access:
-        type: "boolean"
-        position: 8
-        description: "Is the docker image private or not."
-      toolname:
-        type: "string"
-        position: 9
-        description: "This is the tool name of the container, when not-present this\
-          \ will function just like 0.1 dockstorewhen present, this can be used to\
-          \ distinguish between two containers based on the same image, but associated\
-          \ with different CWL and Dockerfile documents. i.e. two containers with\
-          \ the same registry+namespace+name but different toolnames will be two different\
-          \ entries in the dockstore registry/namespace/name/tool, different options\
-          \ to edit tags, and only the same insofar as they would \"docker pull\"\
-          \ the same image, required: GA4GH"
       last_modified:
         type: "integer"
         format: "int32"
@@ -4288,21 +4226,76 @@ definitions:
         format: "date-time"
         position: 10
         description: "Implementation specific timestamp for last updated on webservice"
-      namespace:
-        type: "string"
-        position: 10
-        description: "This is a docker namespace for the container, required: GA4GH"
-      path:
-        type: "string"
-        position: 10
       gitUrl:
         type: "string"
         position: 11
         description: "This is a link to the associated repo with a descriptor, required\
           \ GA4GH"
+      mode:
+        type: "string"
+        position: 12
+        description: "This indicates what mode this is in which informs how we do\
+          \ things like refresh, dockstore specific"
+        enum:
+        - "AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS"
+        - "AUTO_DETECT_QUAY_TAGS_WITH_MIXED"
+        - "MANUAL_IMAGE_PATH"
+      name:
+        type: "string"
+        position: 13
+        description: "This is the name of the container, required: GA4GH"
+      default_dockerfile_path:
+        type: "string"
+        position: 14
+        description: "This indicates for the associated git repository, the default\
+          \ path to the Dockerfile, required: GA4GH"
+      default_cwl_path:
+        type: "string"
+        position: 15
+        description: "This indicates for the associated git repository, the default\
+          \ path to the CWL document, required: GA4GH"
+      default_wdl_path:
+        type: "string"
+        position: 16
+        description: "This indicates for the associated git repository, the default\
+          \ path to the WDL document"
+      defaultCWLTestParameterFile:
+        type: "string"
+        position: 17
+        description: "This indicates for the associated git repository, the default\
+          \ path to the CWL test parameter file"
+      defaultWDLTestParameterFile:
+        type: "string"
+        position: 18
+        description: "This indicates for the associated git repository, the default\
+          \ path to the WDL test parameter file"
+      tool_maintainer_email:
+        type: "string"
+        position: 19
+        description: "The email address of the tool maintainer. Required for private\
+          \ repositories"
+      private_access:
+        type: "boolean"
+        position: 20
+        description: "Is the docker image private or not."
+      toolname:
+        type: "string"
+        position: 21
+        description: "This is the tool name of the container, when not-present this\
+          \ will function just like 0.1 dockstorewhen present, this can be used to\
+          \ distinguish between two containers based on the same image, but associated\
+          \ with different CWL and Dockerfile documents. i.e. two containers with\
+          \ the same registry+namespace+name but different toolnames will be two different\
+          \ entries in the dockstore registry/namespace/name/tool, different options\
+          \ to edit tags, and only the same insofar as they would \"docker pull\"\
+          \ the same image, required: GA4GH"
+      namespace:
+        type: "string"
+        position: 22
+        description: "This is a docker namespace for the container, required: GA4GH"
       registry:
         type: "string"
-        position: 11
+        position: 23
         description: "This is a specific docker provider like quay.io or dockerhub\
           \ or n/a?, required: GA4GH"
         enum:
@@ -4310,27 +4303,36 @@ definitions:
         - "DOCKER_HUB"
         - "GITLAB"
         - "AMAZON_ECR"
-      tool_path:
-        type: "string"
-        position: 11
-        readOnly: true
       lastBuild:
         type: "string"
         format: "date-time"
-        position: 12
+        position: 24
         description: "Implementation specific timestamp for last built"
       custom_docker_registry_path:
         type: "string"
-        position: 13
+        position: 25
         description: "Only used for docker registries that allow for custom paths"
       tags:
         type: "array"
-        position: 14
+        position: 26
         description: "Implementation specific tracking of valid build tags for the\
           \ docker container"
         uniqueItems: true
         items:
           $ref: "#/definitions/Tag"
+      path:
+        type: "string"
+        position: 27
+      descriptorType:
+        type: "array"
+        position: 28
+        readOnly: true
+        items:
+          type: "string"
+      tool_path:
+        type: "string"
+        position: 29
+        readOnly: true
     description: "This describes one entry in the dockstore. Logically, this currently\
       \ means one tuple of registry (either quay or docker hub), organization, image\
       \ name, and toolname which can be\n * associated with CWL and Dockerfile documents"
@@ -4587,7 +4589,6 @@ definitions:
   Tag:
     type: "object"
     required:
-    - "image_id"
     - "name"
     - "reference"
     properties:
@@ -4596,16 +4597,6 @@ definitions:
         format: "int64"
         description: "Implementation specific ID for the tag in this web service"
         readOnly: true
-      workingDirectory:
-        type: "string"
-      image_id:
-        type: "string"
-        description: "Tag for this image in quay.ui/docker hub"
-      size:
-        type: "integer"
-        format: "int64"
-        position: 1
-        description: "Size of the image"
       last_modified:
         type: "string"
         format: "date-time"
@@ -4615,10 +4606,6 @@ definitions:
         type: "string"
         position: 2
         description: "git commit/tag/branch"
-      dockerfile_path:
-        type: "string"
-        position: 2
-        description: "Path for the Dockerfile"
       sourceFiles:
         type: "array"
         position: 3
@@ -4627,29 +4614,16 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/SourceFile"
-      cwl_path:
-        type: "string"
-        position: 3
-        description: "Path for the CWL document"
       hidden:
         type: "boolean"
         position: 4
         description: "Implementation specific, whether this row is visible to other\
           \ users aside from the owner"
-      wdl_path:
-        type: "string"
-        position: 4
-        description: "Path for the WDL document"
       valid:
         type: "boolean"
         position: 5
         description: "Implementation specific, whether this tag has valid files from\
           \ source code repo"
-      automated:
-        type: "boolean"
-        position: 5
-        description: "Implementation specific, indicates whether this is an automated\
-          \ build on quay.io"
       name:
         type: "string"
         position: 6
@@ -4679,6 +4653,34 @@ definitions:
         - "NOT_REQUESTED"
         - "REQUESTED"
         - "CREATED"
+      size:
+        type: "integer"
+        format: "int64"
+        position: 13
+        description: "Size of the image"
+      dockerfile_path:
+        type: "string"
+        position: 14
+        description: "Path for the Dockerfile"
+      cwl_path:
+        type: "string"
+        position: 15
+        description: "Path for the CWL document"
+      wdl_path:
+        type: "string"
+        position: 16
+        description: "Path for the WDL document"
+      automated:
+        type: "boolean"
+        position: 17
+        description: "Implementation specific, indicates whether this is an automated\
+          \ build on quay.io"
+      workingDirectory:
+        type: "string"
+        position: 18
+      image_id:
+        type: "string"
+        position: 19
     description: "This describes one tag associated with a container."
   Token:
     type: "object"
@@ -4688,9 +4690,6 @@ definitions:
         format: "int64"
         description: "Implementation specific ID for the token in this web service"
         readOnly: true
-      userId:
-        type: "integer"
-        format: "int64"
       tokenSource:
         type: "string"
         position: 1
@@ -4707,9 +4706,13 @@ definitions:
       refreshToken:
         type: "string"
         position: 4
+      userId:
+        type: "integer"
+        format: "int64"
+        position: 5
       token:
         type: "string"
-        position: 5
+        position: 6
         description: "Contents of the access token"
         readOnly: true
     description: "Access tokens for this web service and integrated services like\
@@ -5057,8 +5060,6 @@ definitions:
         format: "int64"
         description: "Implementation specific ID for the container in this web service"
         readOnly: true
-      name:
-        type: "string"
       username:
         type: "string"
         position: 1
@@ -5087,6 +5088,9 @@ definitions:
         type: "string"
         position: 7
         description: "URL of user avatar on Github."
+      name:
+        type: "string"
+        position: 8
     description: "End users for the dockstore"
   VerifyRequest:
     type: "object"
@@ -5113,31 +5117,15 @@ definitions:
         type: "integer"
         format: "int64"
         description: "Implementation specific ID for the container in this web service"
-      mode:
-        type: "string"
-        description: "This indicates what mode this is in which informs how we do\
-          \ things like refresh, dockstore specific"
-        enum:
-        - "FULL"
-        - "STUB"
       author:
         type: "string"
         position: 1
         description: "This is the name of the author stated in the Dockstore.cwl"
-      workflowName:
-        type: "string"
-        position: 1
-        description: "This is the name of the workflow, not needed when only one workflow\
-          \ in a repo"
       description:
         type: "string"
         position: 2
         description: "This is a human-readable description of this container and what\
           \ it is trying to accomplish, required GA4GH"
-      organization:
-        type: "string"
-        position: 2
-        description: "This is a git organization for the workflow"
       labels:
         type: "array"
         position: 3
@@ -5146,10 +5134,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/Label"
-      repository:
-        type: "string"
-        position: 3
-        description: "This is a git repository name"
       users:
         type: "array"
         position: 4
@@ -5158,15 +5142,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/User"
-      sourceControl:
-        type: "string"
-        position: 4
-        description: "This is a specific source control provider like github or bitbucket\
-          \ or n/a?, required: GA4GH"
-        enum:
-        - "GITHUB"
-        - "BITBUCKET"
-        - "GITLAB"
       starredUsers:
         type: "array"
         position: 5
@@ -5175,37 +5150,14 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/User"
-      descriptorType:
-        type: "string"
-        position: 5
-        description: "This is a descriptor type for the workflow, either CWL or WDL\
-          \ (Defaults to CWL)"
       email:
         type: "string"
         position: 6
         description: "This is the email of the git organization"
-      workflow_path:
-        type: "string"
-        position: 6
-        description: "This indicates for the associated git repository, the default\
-          \ path to the CWL document"
       defaultVersion:
         type: "string"
         position: 7
         description: "This is the default version of the entry"
-      defaultTestParameterFilePath:
-        type: "string"
-        position: 7
-        description: "This indicates for the associated git repository, the default\
-          \ path to the test parameter file"
-      workflowVersions:
-        type: "array"
-        position: 8
-        description: "Implementation specific tracking of valid build workflowVersions\
-          \ for the docker container"
-        uniqueItems: true
-        items:
-          $ref: "#/definitions/WorkflowVersion"
       is_published:
         type: "boolean"
         position: 8
@@ -5220,18 +5172,71 @@ definitions:
         format: "date-time"
         position: 10
         description: "Implementation specific timestamp for last updated on webservice"
-      full_workflow_path:
-        type: "string"
-        position: 10
-        readOnly: true
       gitUrl:
         type: "string"
         position: 11
         description: "This is a link to the associated repo with a descriptor, required\
           \ GA4GH"
+      mode:
+        type: "string"
+        position: 12
+        description: "This indicates what mode this is in which informs how we do\
+          \ things like refresh, dockstore specific"
+        enum:
+        - "FULL"
+        - "STUB"
+      workflowName:
+        type: "string"
+        position: 13
+        description: "This is the name of the workflow, not needed when only one workflow\
+          \ in a repo"
+      organization:
+        type: "string"
+        position: 14
+        description: "This is a git organization for the workflow"
+      repository:
+        type: "string"
+        position: 15
+        description: "This is a git repository name"
+      sourceControl:
+        type: "string"
+        position: 16
+        description: "This is a specific source control provider like github or bitbucket\
+          \ or n/a?, required: GA4GH"
+        enum:
+        - "GITHUB"
+        - "BITBUCKET"
+        - "GITLAB"
+      descriptorType:
+        type: "string"
+        position: 17
+        description: "This is a descriptor type for the workflow, either CWL or WDL\
+          \ (Defaults to CWL)"
+      workflow_path:
+        type: "string"
+        position: 18
+        description: "This indicates for the associated git repository, the default\
+          \ path to the CWL document"
+      defaultTestParameterFilePath:
+        type: "string"
+        position: 19
+        description: "This indicates for the associated git repository, the default\
+          \ path to the test parameter file"
+      workflowVersions:
+        type: "array"
+        position: 20
+        description: "Implementation specific tracking of valid build workflowVersions\
+          \ for the docker container"
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/WorkflowVersion"
+      full_workflow_path:
+        type: "string"
+        position: 21
+        readOnly: true
       path:
         type: "string"
-        position: 11
+        position: 22
     description: "This describes one workflow in the dockstore"
   WorkflowVersion:
     type: "object"
@@ -5246,9 +5251,6 @@ definitions:
         readOnly: true
       workingDirectory:
         type: "string"
-      workflow_path:
-        type: "string"
-        description: "Path for the workflow"
       last_modified:
         type: "string"
         format: "date-time"
@@ -5305,4 +5307,8 @@ definitions:
         - "NOT_REQUESTED"
         - "REQUESTED"
         - "CREATED"
+      workflow_path:
+        type: "string"
+        position: 12
+        description: "Path for the workflow"
     description: "This describes one workflow version associated with a workflow."

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4171,13 +4171,21 @@ definitions:
         type: "integer"
         format: "int64"
         description: "Implementation specific ID for the container in this web service"
+      mode:
+        type: "string"
+        description: "This indicates what mode this is in which informs how we do\
+          \ things like refresh, dockstore specific"
+        enum:
+        - "AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS"
+        - "AUTO_DETECT_QUAY_TAGS_WITH_MIXED"
+        - "MANUAL_IMAGE_PATH"
+      path:
+        type: "string"
       descriptorType:
         type: "array"
         readOnly: true
         items:
           type: "string"
-      path:
-        type: "string"
       tool_path:
         type: "string"
         readOnly: true
@@ -4185,11 +4193,20 @@ definitions:
         type: "string"
         position: 1
         description: "This is the name of the author stated in the Dockstore.cwl"
+      name:
+        type: "string"
+        position: 1
+        description: "This is the name of the container, required: GA4GH"
       description:
         type: "string"
         position: 2
         description: "This is a human-readable description of this container and what\
           \ it is trying to accomplish, required GA4GH"
+      default_dockerfile_path:
+        type: "string"
+        position: 2
+        description: "This indicates for the associated git repository, the default\
+          \ path to the Dockerfile, required: GA4GH"
       labels:
         type: "array"
         position: 3
@@ -4198,6 +4215,11 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/Label"
+      default_cwl_path:
+        type: "string"
+        position: 3
+        description: "This indicates for the associated git repository, the default\
+          \ path to the CWL document, required: GA4GH"
       users:
         type: "array"
         position: 4
@@ -4206,6 +4228,11 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/User"
+      default_wdl_path:
+        type: "string"
+        position: 4
+        description: "This indicates for the associated git repository, the default\
+          \ path to the WDL document"
       starredUsers:
         type: "array"
         position: 5
@@ -4214,18 +4241,48 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/User"
+      defaultCWLTestParameterFile:
+        type: "string"
+        position: 5
+        description: "This indicates for the associated git repository, the default\
+          \ path to the CWL test parameter file"
       email:
         type: "string"
         position: 6
         description: "This is the email of the git organization"
+      defaultWDLTestParameterFile:
+        type: "string"
+        position: 6
+        description: "This indicates for the associated git repository, the default\
+          \ path to the WDL test parameter file"
       defaultVersion:
         type: "string"
         position: 7
         description: "This is the default version of the entry"
+      tool_maintainer_email:
+        type: "string"
+        position: 7
+        description: "The email address of the tool maintainer. Required for private\
+          \ repositories"
       is_published:
         type: "boolean"
         position: 8
         description: "Implementation specific visibility in this web service"
+      private_access:
+        type: "boolean"
+        position: 8
+        description: "Is the docker image private or not."
+      toolname:
+        type: "string"
+        position: 9
+        description: "This is the tool name of the container, when not-present this\
+          \ will function just like 0.1 dockstorewhen present, this can be used to\
+          \ distinguish between two containers based on the same image, but associated\
+          \ with different CWL and Dockerfile documents. i.e. two containers with\
+          \ the same registry+namespace+name but different toolnames will be two different\
+          \ entries in the dockstore registry/namespace/name/tool, different options\
+          \ to edit tags, and only the same insofar as they would \"docker pull\"\
+          \ the same image, required: GA4GH"
       last_modified:
         type: "integer"
         format: "int32"
@@ -4236,76 +4293,18 @@ definitions:
         format: "date-time"
         position: 10
         description: "Implementation specific timestamp for last updated on webservice"
+      namespace:
+        type: "string"
+        position: 10
+        description: "This is a docker namespace for the container, required: GA4GH"
       gitUrl:
         type: "string"
         position: 11
         description: "This is a link to the associated repo with a descriptor, required\
           \ GA4GH"
-      mode:
-        type: "string"
-        position: 12
-        description: "This indicates what mode this is in which informs how we do\
-          \ things like refresh, dockstore specific"
-        enum:
-        - "AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS"
-        - "AUTO_DETECT_QUAY_TAGS_WITH_MIXED"
-        - "MANUAL_IMAGE_PATH"
-      name:
-        type: "string"
-        position: 13
-        description: "This is the name of the container, required: GA4GH"
-      default_dockerfile_path:
-        type: "string"
-        position: 14
-        description: "This indicates for the associated git repository, the default\
-          \ path to the Dockerfile, required: GA4GH"
-      default_cwl_path:
-        type: "string"
-        position: 15
-        description: "This indicates for the associated git repository, the default\
-          \ path to the CWL document, required: GA4GH"
-      default_wdl_path:
-        type: "string"
-        position: 16
-        description: "This indicates for the associated git repository, the default\
-          \ path to the WDL document"
-      defaultCWLTestParameterFile:
-        type: "string"
-        position: 17
-        description: "This indicates for the associated git repository, the default\
-          \ path to the CWL test parameter file"
-      defaultWDLTestParameterFile:
-        type: "string"
-        position: 18
-        description: "This indicates for the associated git repository, the default\
-          \ path to the WDL test parameter file"
-      tool_maintainer_email:
-        type: "string"
-        position: 19
-        description: "The email address of the tool maintainer. Required for private\
-          \ repositories"
-      private_access:
-        type: "boolean"
-        position: 20
-        description: "Is the docker image private or not."
-      toolname:
-        type: "string"
-        position: 21
-        description: "This is the tool name of the container, when not-present this\
-          \ will function just like 0.1 dockstorewhen present, this can be used to\
-          \ distinguish between two containers based on the same image, but associated\
-          \ with different CWL and Dockerfile documents. i.e. two containers with\
-          \ the same registry+namespace+name but different toolnames will be two different\
-          \ entries in the dockstore registry/namespace/name/tool, different options\
-          \ to edit tags, and only the same insofar as they would \"docker pull\"\
-          \ the same image, required: GA4GH"
-      namespace:
-        type: "string"
-        position: 22
-        description: "This is a docker namespace for the container, required: GA4GH"
       registry:
         type: "string"
-        position: 23
+        position: 11
         description: "This is a specific docker provider like quay.io or dockerhub\
           \ or n/a?, required: GA4GH"
         enum:
@@ -4316,15 +4315,15 @@ definitions:
       lastBuild:
         type: "string"
         format: "date-time"
-        position: 24
+        position: 12
         description: "Implementation specific timestamp for last built"
       custom_docker_registry_path:
         type: "string"
-        position: 25
+        position: 13
         description: "Only used for docker registries that allow for custom paths"
       tags:
         type: "array"
-        position: 26
+        position: 14
         description: "Implementation specific tracking of valid build tags for the\
           \ docker container"
         uniqueItems: true
@@ -4597,6 +4596,14 @@ definitions:
         readOnly: true
       workingDirectory:
         type: "string"
+      image_id:
+        type: "string"
+        description: "Tag for this image in quay.ui/docker hub"
+      size:
+        type: "integer"
+        format: "int64"
+        position: 1
+        description: "Size of the image"
       last_modified:
         type: "string"
         format: "date-time"
@@ -4606,6 +4613,10 @@ definitions:
         type: "string"
         position: 2
         description: "git commit/tag/branch"
+      dockerfile_path:
+        type: "string"
+        position: 2
+        description: "Path for the Dockerfile"
       sourceFiles:
         type: "array"
         position: 3
@@ -4614,16 +4625,29 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/SourceFile"
+      cwl_path:
+        type: "string"
+        position: 3
+        description: "Path for the CWL document"
       hidden:
         type: "boolean"
         position: 4
         description: "Implementation specific, whether this row is visible to other\
           \ users aside from the owner"
+      wdl_path:
+        type: "string"
+        position: 4
+        description: "Path for the WDL document"
       valid:
         type: "boolean"
         position: 5
         description: "Implementation specific, whether this tag has valid files from\
           \ source code repo"
+      automated:
+        type: "boolean"
+        position: 5
+        description: "Implementation specific, indicates whether this is an automated\
+          \ build on quay.io"
       name:
         type: "string"
         position: 6
@@ -4653,32 +4677,6 @@ definitions:
         - "NOT_REQUESTED"
         - "REQUESTED"
         - "CREATED"
-      image_id:
-        type: "string"
-        position: 12
-        description: "Tag for this image in quay.ui/docker hub"
-      size:
-        type: "integer"
-        format: "int64"
-        position: 13
-        description: "Size of the image"
-      dockerfile_path:
-        type: "string"
-        position: 14
-        description: "Path for the Dockerfile"
-      cwl_path:
-        type: "string"
-        position: 15
-        description: "Path for the CWL document"
-      wdl_path:
-        type: "string"
-        position: 16
-        description: "Path for the WDL document"
-      automated:
-        type: "boolean"
-        position: 17
-        description: "Implementation specific, indicates whether this is an automated\
-          \ build on quay.io"
     description: "This describes one tag associated with a container."
   Token:
     type: "object"
@@ -5113,6 +5111,13 @@ definitions:
         type: "integer"
         format: "int64"
         description: "Implementation specific ID for the container in this web service"
+      mode:
+        type: "string"
+        description: "This indicates what mode this is in which informs how we do\
+          \ things like refresh, dockstore specific"
+        enum:
+        - "FULL"
+        - "STUB"
       path:
         type: "string"
       full_workflow_path:
@@ -5122,11 +5127,20 @@ definitions:
         type: "string"
         position: 1
         description: "This is the name of the author stated in the Dockstore.cwl"
+      workflowName:
+        type: "string"
+        position: 1
+        description: "This is the name of the workflow, not needed when only one workflow\
+          \ in a repo"
       description:
         type: "string"
         position: 2
         description: "This is a human-readable description of this container and what\
           \ it is trying to accomplish, required GA4GH"
+      organization:
+        type: "string"
+        position: 2
+        description: "This is a git organization for the workflow"
       labels:
         type: "array"
         position: 3
@@ -5135,6 +5149,10 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/Label"
+      repository:
+        type: "string"
+        position: 3
+        description: "This is a git repository name"
       users:
         type: "array"
         position: 4
@@ -5143,6 +5161,15 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/User"
+      sourceControl:
+        type: "string"
+        position: 4
+        description: "This is a specific source control provider like github or bitbucket\
+          \ or n/a?, required: GA4GH"
+        enum:
+        - "GITHUB"
+        - "BITBUCKET"
+        - "GITLAB"
       starredUsers:
         type: "array"
         position: 5
@@ -5151,14 +5178,37 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/User"
+      descriptorType:
+        type: "string"
+        position: 5
+        description: "This is a descriptor type for the workflow, either CWL or WDL\
+          \ (Defaults to CWL)"
       email:
         type: "string"
         position: 6
         description: "This is the email of the git organization"
+      workflow_path:
+        type: "string"
+        position: 6
+        description: "This indicates for the associated git repository, the default\
+          \ path to the CWL document"
       defaultVersion:
         type: "string"
         position: 7
         description: "This is the default version of the entry"
+      defaultTestParameterFilePath:
+        type: "string"
+        position: 7
+        description: "This indicates for the associated git repository, the default\
+          \ path to the test parameter file"
+      workflowVersions:
+        type: "array"
+        position: 8
+        description: "Implementation specific tracking of valid build workflowVersions\
+          \ for the docker container"
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/WorkflowVersion"
       is_published:
         type: "boolean"
         position: 8
@@ -5178,59 +5228,6 @@ definitions:
         position: 11
         description: "This is a link to the associated repo with a descriptor, required\
           \ GA4GH"
-      mode:
-        type: "string"
-        position: 12
-        description: "This indicates what mode this is in which informs how we do\
-          \ things like refresh, dockstore specific"
-        enum:
-        - "FULL"
-        - "STUB"
-      workflowName:
-        type: "string"
-        position: 13
-        description: "This is the name of the workflow, not needed when only one workflow\
-          \ in a repo"
-      organization:
-        type: "string"
-        position: 14
-        description: "This is a git organization for the workflow"
-      repository:
-        type: "string"
-        position: 15
-        description: "This is a git repository name"
-      sourceControl:
-        type: "string"
-        position: 16
-        description: "This is a specific source control provider like github or bitbucket\
-          \ or n/a?, required: GA4GH"
-        enum:
-        - "GITHUB"
-        - "BITBUCKET"
-        - "GITLAB"
-      descriptorType:
-        type: "string"
-        position: 17
-        description: "This is a descriptor type for the workflow, either CWL or WDL\
-          \ (Defaults to CWL)"
-      workflow_path:
-        type: "string"
-        position: 18
-        description: "This indicates for the associated git repository, the default\
-          \ path to the CWL document"
-      defaultTestParameterFilePath:
-        type: "string"
-        position: 19
-        description: "This indicates for the associated git repository, the default\
-          \ path to the test parameter file"
-      workflowVersions:
-        type: "array"
-        position: 20
-        description: "Implementation specific tracking of valid build workflowVersions\
-          \ for the docker container"
-        uniqueItems: true
-        items:
-          $ref: "#/definitions/WorkflowVersion"
     description: "This describes one workflow in the dockstore"
   WorkflowVersion:
     type: "object"
@@ -5245,6 +5242,9 @@ definitions:
         readOnly: true
       workingDirectory:
         type: "string"
+      workflow_path:
+        type: "string"
+        description: "Path for the workflow"
       last_modified:
         type: "string"
         format: "date-time"
@@ -5301,8 +5301,4 @@ definitions:
         - "NOT_REQUESTED"
         - "REQUESTED"
         - "CREATED"
-      workflow_path:
-        type: "string"
-        position: 12
-        description: "Path for the workflow"
     description: "This describes one workflow version associated with a workflow."

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4179,16 +4179,11 @@ definitions:
         - "AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS"
         - "AUTO_DETECT_QUAY_TAGS_WITH_MIXED"
         - "MANUAL_IMAGE_PATH"
-      path:
-        type: "string"
       descriptorType:
         type: "array"
         readOnly: true
         items:
           type: "string"
-      tool_path:
-        type: "string"
-        readOnly: true
       author:
         type: "string"
         position: 1
@@ -4297,6 +4292,9 @@ definitions:
         type: "string"
         position: 10
         description: "This is a docker namespace for the container, required: GA4GH"
+      path:
+        type: "string"
+        position: 10
       gitUrl:
         type: "string"
         position: 11
@@ -4312,6 +4310,10 @@ definitions:
         - "DOCKER_HUB"
         - "GITLAB"
         - "AMAZON_ECR"
+      tool_path:
+        type: "string"
+        position: 11
+        readOnly: true
       lastBuild:
         type: "string"
         format: "date-time"
@@ -5118,11 +5120,6 @@ definitions:
         enum:
         - "FULL"
         - "STUB"
-      path:
-        type: "string"
-      full_workflow_path:
-        type: "string"
-        readOnly: true
       author:
         type: "string"
         position: 1
@@ -5223,11 +5220,18 @@ definitions:
         format: "date-time"
         position: 10
         description: "Implementation specific timestamp for last updated on webservice"
+      full_workflow_path:
+        type: "string"
+        position: 10
+        readOnly: true
       gitUrl:
         type: "string"
         position: 11
         description: "This is a link to the associated repo with a descriptor, required\
           \ GA4GH"
+      path:
+        type: "string"
+        position: 11
     description: "This describes one workflow in the dockstore"
   WorkflowVersion:
     type: "object"


### PR DESCRIPTION
This forces order for properties of a swagger doc, at least for the main classes like tool, workflow, etc. 

Unfortunately if we add a property to entry for example, we have to update all positions in the Tool and Workflow classes. Still better than the constant failing though.

I suppressed checkstyle warnings for magic number, as I don't see the need for creating a constant for each position.