### PR TITLE
Date everything with database-managed dates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_script:
 
 script: ./scripts/run-tests.sh
 
-after_script:
+before_cache:
 - rm -rf /home/travis/.m2/repository/io/dockstore
 
 notifications:

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -16,6 +16,7 @@
 
 package io.dockstore.webservice.core;
 
+import java.sql.Timestamp;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Objects;
@@ -44,6 +45,8 @@ import io.dockstore.common.Registry;
 import io.dockstore.common.SourceControl;
 import io.dockstore.webservice.helpers.EntryStarredSerializer;
 import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 /**
  * Base class for all entries in the dockstore
@@ -98,15 +101,26 @@ public abstract class Entry<S extends Entry, T extends Version> {
     @JsonProperty("is_published")
     @ApiModelProperty(value = "Implementation specific visibility in this web service", position = 8)
     private boolean isPublished;
+
     @Column
     @ApiModelProperty(value = "Implementation specific timestamp for last modified", position = 9)
-    private Integer lastModified;
+    private Date lastModified;
     @Column
     @ApiModelProperty(value = "Implementation specific timestamp for last updated on webservice", position = 10)
     private Date lastUpdated;
     @Column
     @ApiModelProperty(value = "This is a link to the associated repo with a descriptor, required GA4GH", required = true, position = 11)
     private String gitUrl;
+
+    // database timestamps
+    @Column(updatable = false)
+    @CreationTimestamp
+    private Timestamp dbCreateDate;
+
+    @Column()
+    @UpdateTimestamp
+    private Timestamp dbUpdateDate;
+
 
     public Entry() {
         users = new HashSet<>(0);
@@ -200,7 +214,7 @@ public abstract class Entry<S extends Entry, T extends Version> {
     /**
      * @param lastModified the lastModified to set
      */
-    public void setLastModified(Integer lastModified) {
+    public void setLastModified(Date lastModified) {
         this.lastModified = lastModified;
     }
 
@@ -214,6 +228,12 @@ public abstract class Entry<S extends Entry, T extends Version> {
 
     @JsonProperty("last_modified")
     public Integer getLastModified() {
+        // this is lossy, but needed for backwards compatibility
+        return (int)lastModified.getTime();
+    }
+
+    @JsonProperty("last_modified_date")
+    public Date getLastModifiedDate() {
         return lastModified;
     }
 
@@ -257,7 +277,7 @@ public abstract class Entry<S extends Entry, T extends Version> {
         this.setDescription(entry.getDescription());
         // this causes an issue when newly refreshed tools that are not published overwrite publish settings for existing containers
         // isPublished = entry.getIsPublished();
-        lastModified = entry.getLastModified();
+        lastModified = entry.getLastModifiedDate();
         this.setAuthor(entry.getAuthor());
         this.setEmail(entry.getEmail());
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -229,7 +229,7 @@ public abstract class Entry<S extends Entry, T extends Version> {
     @JsonProperty("last_modified")
     public Integer getLastModified() {
         // this is lossy, but needed for backwards compatibility
-        return (int)lastModified.getTime();
+        return lastModified == null ? null : (int)lastModified.getTime();
     }
 
     @JsonProperty("last_modified_date")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Group.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Group.java
@@ -16,6 +16,7 @@
 
 package io.dockstore.webservice.core;
 
+import java.sql.Timestamp;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -35,6 +36,8 @@ import javax.persistence.Table;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 /**
  * This describes a grouping of end-users for the purposes of managing sharing.
@@ -57,6 +60,15 @@ public class Group {
     @ManyToMany(fetch = FetchType.LAZY, cascade = { CascadeType.PERSIST, CascadeType.MERGE })
     @JoinTable(name = "endusergroup", inverseJoinColumns = @JoinColumn(name = "userid", nullable = false, updatable = false, referencedColumnName = "id"), joinColumns = @JoinColumn(name = "groupid", nullable = false, updatable = false, referencedColumnName = "id"))
     private final Set<User> users;
+
+    // database timestamps
+    @Column(updatable = false)
+    @CreationTimestamp
+    private Timestamp dbCreateDate;
+
+    @Column()
+    @UpdateTimestamp
+    private Timestamp dbUpdateDate;
 
     public Group() {
         users = new HashSet<>(0);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Label.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Label.java
@@ -16,6 +16,8 @@
 
 package io.dockstore.webservice.core;
 
+import java.sql.Timestamp;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -28,6 +30,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 /**
  * This describes a descriptive label that can be placed on an entry in the dockstore, implementation specific.
@@ -49,6 +53,15 @@ public class Label implements Comparable<Label> {
     @Column(unique = true)
     @ApiModelProperty(value = "String representation of the tag", required = true, position = 1)
     private String value;
+
+    // database timestamps
+    @Column(updatable = false)
+    @CreationTimestamp
+    private Timestamp dbCreateDate;
+
+    @Column()
+    @UpdateTimestamp
+    private Timestamp dbUpdateDate;
 
     @JsonProperty
     public long getId() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -16,6 +16,7 @@
 
 package io.dockstore.webservice.core;
 
+import java.sql.Timestamp;
 import java.util.Objects;
 
 import javax.persistence.Column;
@@ -29,6 +30,8 @@ import javax.persistence.Table;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 /**
  * This describes a cached copy of a remotely accessible file. Implementation specific.
@@ -65,6 +68,15 @@ public class SourceFile {
     @Column(nullable = false)
     @ApiModelProperty(value = "Path to source file in git repo", required = true, position = 3)
     private String path;
+
+    // database timestamps
+    @Column(updatable = false)
+    @CreationTimestamp
+    private Timestamp dbCreateDate;
+
+    @Column()
+    @UpdateTimestamp
+    private Timestamp dbUpdateDate;
 
     public long getId() {
         return id;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
@@ -16,6 +16,7 @@
 
 package io.dockstore.webservice.core;
 
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Objects;
 
@@ -31,6 +32,8 @@ import javax.persistence.Table;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 /**
  * Access tokens for this web service and integrated services like quay.io and github.
@@ -77,6 +80,15 @@ public class Token {
     @Column
     @ApiModelProperty(position = 5)
     private long userId;
+
+    // database timestamps
+    @Column(updatable = false)
+    @CreationTimestamp
+    private Timestamp dbCreateDate;
+
+    @Column()
+    @UpdateTimestamp
+    private Timestamp dbUpdateDate;
 
     public Token() {
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -17,6 +17,7 @@
 package io.dockstore.webservice.core;
 
 import java.security.Principal;
+import java.sql.Timestamp;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -46,6 +47,8 @@ import io.dockstore.webservice.jdbi.TokenDAO;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.apache.http.HttpStatus;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 /**
  * Stores end user information
@@ -92,6 +95,15 @@ public class User implements Principal {
     @Column
     @ApiModelProperty(value = "URL of user avatar on Github.", position = 7)
     private String avatarUrl;
+
+    // database timestamps
+    @Column(updatable = false)
+    @CreationTimestamp
+    private Timestamp dbCreateDate;
+
+    @Column()
+    @UpdateTimestamp
+    private Timestamp dbUpdateDate;
 
     @ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinTable(name = "endusergroup", joinColumns = @JoinColumn(name = "userid", nullable = false, updatable = false, referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "groupid", nullable = false, updatable = false, referencedColumnName = "id"))

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -16,6 +16,7 @@
 
 package io.dockstore.webservice.core;
 
+import java.sql.Timestamp;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Objects;
@@ -42,6 +43,8 @@ import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Ordering;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 /**
  * This describes one version of either a workflow or a tool.
@@ -107,6 +110,15 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @Enumerated(EnumType.STRING)
     @ApiModelProperty(value = "This indicates the DOI status", position = 11)
     private DOIStatus doiStatus;
+
+    // database timestamps
+    @Column(updatable = false)
+    @CreationTimestamp
+    private Timestamp dbCreateDate;
+
+    @Column()
+    @UpdateTimestamp
+    private Timestamp dbUpdateDate;
 
     public Version() {
         sourceFiles = new HashSet<>(0);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -155,7 +155,7 @@ public class Workflow extends Entry<Workflow, WorkflowVersion> {
         targetWorkflow.setAuthor(getAuthor());
         targetWorkflow.setEmail(getEmail());
         targetWorkflow.setDescription(getDescription());
-        targetWorkflow.setLastModified(getLastModified());
+        targetWorkflow.setLastModified(getLastModifiedDate());
         targetWorkflow.setOrganization(getOrganization());
         targetWorkflow.setRepository(getRepository());
         targetWorkflow.setGitUrl(getGitUrl());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -249,7 +249,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             LOG.info(gitUsername + ": Looking at reference: " + ref.toString());
             // Initialize the workflow version
             WorkflowVersion version = initializeWorkflowVersion(ref.getKey(), existingWorkflow, existingDefaults);
-//            version.setLastModified(ref.getRight());
+            version.setLastModified(ref.getRight());
             String calculatedPath = version.getWorkflowPath();
 
             SourceFile.FileType identifiedType = workflow.getFileType();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -205,23 +205,29 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         List<Pair<String, Date>> references = new ArrayList<>();
         try {
             GHRepository repository = github.getRepository(repositoryId);
-
+            final Date epochStart = new Date(0);
             service.getBranches(id).forEach(branch -> {
-                Date branchDate = new Date(Long.MIN_VALUE);
+                Date branchDate = new Date(0);
                 try {
                     GHBranch githubBranch = repository.getBranch(branch.getName());
                     GHCommit commit = repository.getCommit(githubBranch.getSHA1());
                     branchDate = commit.getCommitDate();
+                    if (branchDate.before(epochStart)) {
+                        branchDate = epochStart;
+                    }
                 } catch (IOException e) {
                     LOG.info("unable to retrieve commit date for branch " + branch.getName());
                 }
                 references.add(Pair.of(branch.getName(), branchDate));
             });
             service.getTags(id).forEach(tag -> {
-                Date branchDate = new Date(Long.MIN_VALUE);
+                Date branchDate = new Date(0);
                 try {
                     GHCommit commit = repository.getCommit(tag.getCommit().getSha());
                     branchDate = commit.getCommitDate();
+                    if (branchDate.before(epochStart)) {
+                        branchDate = epochStart;
+                    }
                 } catch (IOException e) {
                     LOG.info("unable to retrieve commit date for tag " + tag.getName());
                 }
@@ -233,14 +239,17 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         }
         Optional<Date> max = references.stream().map(Pair::getRight).max(Comparator.naturalOrder());
         // TODO: this conversion is lossy
-        max.ifPresent(date -> workflow.setLastModified((int)max.get().getTime()));
+        max.ifPresent(date -> {
+            long time = max.get().getTime();
+            workflow.setLastModified(new Date(Math.max(time, 0L)));
+        });
 
         // For each branch (reference) found, create a workflow version and find the associated descriptor files
         for (Pair<String, Date> ref : references) {
             LOG.info(gitUsername + ": Looking at reference: " + ref.toString());
             // Initialize the workflow version
             WorkflowVersion version = initializeWorkflowVersion(ref.getKey(), existingWorkflow, existingDefaults);
-            version.setLastModified(ref.getRight());
+//            version.setLastModified(ref.getRight());
             String calculatedPath = version.getWorkflowPath();
 
             SourceFile.FileType identifiedType = workflow.getFileType();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.DELETE;
@@ -143,14 +145,17 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @ApiOperation(value = "Refresh all workflows", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Updates some metadata. ADMIN ONLY", response = Workflow.class, responseContainer = "List")
     public List<Workflow> refreshAll(@ApiParam(hidden = true) @Auth User authUser) {
         List<User> users = userDAO.findAll();
+        LOG.info("# users to process: " + users.size());
+        Set<Long> alreadyProcessedWorkflows = new HashSet<>();
+        AtomicInteger integer = new AtomicInteger();
         users.forEach(user -> {
             try {
-                LOG.info("refreshing user: " + user.getUsername());
+                LOG.info("refreshing user " + integer.getAndAdd(1) + ": " + user.getUsername());
                 // why does a specific user have an issue?
                 if (user.getUsername().equals("chapmanb")) {
                     return;
                 }
-                refreshStubWorkflowsForUser(user, null);
+                refreshStubWorkflowsForUser(user, null, alreadyProcessedWorkflows);
             } catch (Exception e) {
                 // continue past users that have issues
                 LOG.debug("could not refresh user: " + user.getUsername(), e);
@@ -206,12 +211,17 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
 
     }
 
+    void refreshStubWorkflowsForUser(User user, String organization) {
+        refreshStubWorkflowsForUser(user, organization, new HashSet<>());
+    }
+
     /**
      * For each valid token for a git hosting service, refresh all workflows
      *
      * @param user a user to refresh workflows for
+     * @param organization limit the refresh to particular organizations if given
      */
-    void refreshStubWorkflowsForUser(User user, String organization) {
+    private void refreshStubWorkflowsForUser(User user, String organization, Set<Long> alreadyProcessed) {
 
         List<Token> tokens = checkOnBitbucketToken(user);
         // Check if tokens for git hosting services are valid and refresh corresponding workflows
@@ -250,17 +260,17 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
         try {
             if (hasBitbucketToken) {
                 // get workflows from bitbucket for a user and updates db
-                refreshHelper(bitBucketSourceCodeRepo, user, organization);
+                refreshHelper(bitBucketSourceCodeRepo, user, organization, alreadyProcessed);
             }
             // Update github workflows if token exists
             if (hasGitHubToken) {
                 // get workflows from github for a user and updates db
-                refreshHelper(gitHubSourceCodeRepo, user, organization);
+                refreshHelper(gitHubSourceCodeRepo, user, organization, alreadyProcessed);
             }
             // Update gitlab workflows if token exists
             if (hasGitLabToken) {
                 // get workflows from gitlab for a user and updates db
-                refreshHelper(gitLabSourceCodeRepo, user, organization);
+                refreshHelper(gitLabSourceCodeRepo, user, organization, alreadyProcessed);
             }
             // when 3) no data is found for a workflow in the db, we may want to create a warning, note, or label
         } catch (WebApplicationException ex) {
@@ -275,9 +285,15 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
      * @param user the user that made the request to refresh
      * @param organization            if specified, only refresh if workflow belongs to the organization
      */
-    private void refreshHelper(final SourceCodeRepoInterface sourceCodeRepoInterface, User user, String organization) {
+    private void refreshHelper(final SourceCodeRepoInterface sourceCodeRepoInterface, User user, String organization, Set<Long> alreadyProcessed) {
         // Mapping of git url to repository name (owner/repo)
-        final Map<String, String> workflowGitUrl2Name = sourceCodeRepoInterface.getWorkflowGitUrl2RepositoryId();
+        List<Workflow> workflows = userDAO.findById(user.getId()).getEntries().stream().filter(entry -> entry instanceof Workflow).map(obj -> (Workflow)obj).collect(Collectors.toList());
+        Map<String, String> workflowGitUrl2Name = new HashMap<>();
+        for (Workflow workflow : workflows) {
+            workflowGitUrl2Name.put(workflow.getGitUrl(), workflow.getOrganization() + "/" + workflow.getRepository());
+        }
+
+        // final Map<String, String> oldWorkflowGitUrl2Name = sourceCodeRepoInterface.getWorkflowGitUrl2RepositoryId();
         LOG.info("found giturl to workflow name map" + Arrays.toString(workflowGitUrl2Name.entrySet().toArray()));
         if (organization != null) {
             workflowGitUrl2Name.entrySet().removeIf(thing -> !(thing.getValue().split("/"))[0].equals(organization));
@@ -293,6 +309,11 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
             if (byGitUrl.size() > 0) {
                 // Workflows exist with the given git url
                 for (Workflow workflow : byGitUrl) {
+                    // check whitelist for already processed workflows
+                    if (alreadyProcessed.contains(workflow.getId())) {
+                        continue;
+                    }
+
                     // Update existing workflows with new information from the repository
                     // Note we pass the existing workflow as a base for the updated version of the workflow
                     final Workflow newWorkflow = sourceCodeRepoInterface.getWorkflow(entry.getValue(), Optional.of(workflow));
@@ -302,6 +323,7 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
 
                     // Update the existing matching workflows based off of the new information
                     updateDBWorkflowWithSourceControlWorkflow(workflow, newWorkflow);
+                    alreadyProcessed.add(workflow.getId());
                 }
             } else {
                 // Workflows are not registered for the given git url, add one
@@ -317,6 +339,7 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
 
                     // Update newly created template workflow (workflowFromDB) with found data from the repository
                     updateDBWorkflowWithSourceControlWorkflow(workflowFromDB, newWorkflow);
+                    alreadyProcessed.add(workflowFromDB.getId());
                 }
             }
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -286,14 +286,20 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
      * @param organization            if specified, only refresh if workflow belongs to the organization
      */
     private void refreshHelper(final SourceCodeRepoInterface sourceCodeRepoInterface, User user, String organization, Set<Long> alreadyProcessed) {
-        // Mapping of git url to repository name (owner/repo)
-        List<Workflow> workflows = userDAO.findById(user.getId()).getEntries().stream().filter(entry -> entry instanceof Workflow).map(obj -> (Workflow)obj).collect(Collectors.toList());
-        Map<String, String> workflowGitUrl2Name = new HashMap<>();
-        for (Workflow workflow : workflows) {
-            workflowGitUrl2Name.put(workflow.getGitUrl(), workflow.getOrganization() + "/" + workflow.getRepository());
+        /** helpful code for testing, this was used to refresh a users existing workflows
+         *  with a fixed github token for all users
+         */
+        boolean statsCollection = false;
+        if (statsCollection) {
+            List<Workflow> workflows = userDAO.findById(user.getId()).getEntries().stream().filter(entry -> entry instanceof Workflow).map(obj -> (Workflow)obj).collect(Collectors.toList());
+            Map<String, String> workflowGitUrl2Name = new HashMap<>();
+            for (Workflow workflow : workflows) {
+                workflowGitUrl2Name.put(workflow.getGitUrl(), workflow.getOrganization() + "/" + workflow.getRepository());
+            }
         }
 
-        // final Map<String, String> oldWorkflowGitUrl2Name = sourceCodeRepoInterface.getWorkflowGitUrl2RepositoryId();
+        // Mapping of git url to repository name (owner/repo)
+        final Map<String, String> workflowGitUrl2Name = sourceCodeRepoInterface.getWorkflowGitUrl2RepositoryId();
         LOG.info("found giturl to workflow name map" + Arrays.toString(workflowGitUrl2Name.entrySet().toArray()));
         if (organization != null) {
             workflowGitUrl2Name.entrySet().removeIf(thing -> !(thing.getValue().split("/"))[0].equals(organization));

--- a/dockstore-webservice/src/main/resources/migrations.1.4.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.4.0.xml
@@ -138,4 +138,64 @@
         <addNotNullConstraint columnDataType="clob" columnName="doistatus" tableName="workflowversion"/>
     </changeSet>
 
+    <changeSet author="dyuen (generated)" id="workflow-jpa-dbcreate">
+        <addColumn tableName="workflow">
+            <column name="dbcreatedate" type="timestamp without time zone"/>
+        </addColumn>
+    </changeSet>
+    <changeSet author="dyuen (generated)" id="workflow-jpa-dbupdate">
+        <addColumn tableName="workflow">
+            <column name="dbupdatedate" type="timestamp without time zone"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="dyuen (generated)" id="tool-jpa-dbcreate">
+        <addColumn tableName="tool">
+            <column name="dbcreatedate" type="timestamp without time zone"/>
+        </addColumn>
+    </changeSet>
+    <changeSet author="dyuen (generated)" id="tool-jpa-dbupdate">
+        <addColumn tableName="tool">
+            <column name="dbupdatedate" type="timestamp without time zone"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="dyuen (generated)" id="more-dates">
+        <addColumn tableName="usergroup">
+            <column name="dbcreatedate" type="timestamp without time zone"/>
+            <column name="dbupdatedate" type="timestamp without time zone"/>
+        </addColumn>
+        <addColumn tableName="label">
+            <column name="dbcreatedate" type="timestamp without time zone"/>
+            <column name="dbupdatedate" type="timestamp without time zone"/>
+        </addColumn>
+        <addColumn tableName="sourcefile">
+            <column name="dbcreatedate" type="timestamp without time zone"/>
+            <column name="dbupdatedate" type="timestamp without time zone"/>
+        </addColumn>
+        <addColumn tableName="token">
+            <column name="dbcreatedate" type="timestamp without time zone"/>
+            <column name="dbupdatedate" type="timestamp without time zone"/>
+        </addColumn>
+        <addColumn tableName="enduser">
+            <column name="dbcreatedate" type="timestamp without time zone"/>
+            <column name="dbupdatedate" type="timestamp without time zone"/>
+        </addColumn>
+        <addColumn tableName="workflowversion">
+            <column name="dbcreatedate" type="timestamp without time zone"/>
+            <column name="dbupdatedate" type="timestamp without time zone"/>
+        </addColumn>
+        <addColumn tableName="tag">
+            <column name="dbcreatedate" type="timestamp without time zone"/>
+            <column name="dbupdatedate" type="timestamp without time zone"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="dyuen" id="mutate-tool-modified-timestamp">
+        <sql>alter table tool alter column lastModified type timestamp without time zone USING to_timestamp(lastModified/1000)</sql>
+    </changeSet>
+    <changeSet author="dyuen" id="mutate-workflow-modified-timestamp">
+        <sql>alter table workflow alter column lastModified type timestamp without time zone USING to_timestamp(lastModified/1000)</sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.test.testworkflow.xml
+++ b/dockstore-webservice/src/main/resources/migrations.test.testworkflow.xml
@@ -43,7 +43,7 @@
             <column name="email"/>
             <column name="giturl" value="git@github.com:garyluu/testWorkflow.git"/>
             <column name="ispublished" valueBoolean="true"/>
-            <column name="lastmodified" valueNumeric="-1886401784"/>
+            <column name="lastmodified"/>
             <column name="lastupdated" valueDate="2018-02-13 10:42:52.608"/>
             <column name="defaulttestparameterfilepath"/>
             <column name="defaultworkflowpath" value="/Dockstore.cwl"/>
@@ -62,7 +62,7 @@
             <column name="doistatus" value="NOT_REQUESTED"/>
             <column name="doiurl"/>
             <column name="hidden" valueBoolean="false"/>
-            <column name="lastmodified" valueDate="2018-02-13 09:27:01.0"/>
+            <column name="lastmodified"/>
             <column name="name" value="master"/>
             <column name="reference" value="master"/>
             <column name="valid" valueBoolean="true"/>

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4171,6 +4171,10 @@ definitions:
         type: "integer"
         format: "int64"
         description: "Implementation specific ID for the container in this web service"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       author:
         type: "string"
         position: 1
@@ -4345,6 +4349,10 @@ definitions:
         type: "integer"
         format: "int64"
         description: "Implementation specific ID for the container in this web service"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       author:
         type: "string"
         position: 1
@@ -5117,6 +5125,10 @@ definitions:
         type: "integer"
         format: "int64"
         description: "Implementation specific ID for the container in this web service"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       author:
         type: "string"
         position: 1


### PR DESCRIPTION
Working on #331 

Before getting dates from the underlying data sources, we can quickly date everything by database at least for future grant work. 
