### PR TITLE
Custom http user agent for CLI

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -760,6 +760,8 @@ public class Client {
         String serverUrl = config.getString("server-url", "https://www.dockstore.org:8443");
         ApiClient defaultApiClient;
         defaultApiClient = Configuration.getDefaultApiClient();
+        String cliVersion = Client.class.getPackage().getImplementationVersion();
+        defaultApiClient.setUserAgent("Dockstore-CLI/" + cliVersion + "/java");
 
         ApiKeyAuth bearer = (ApiKeyAuth)defaultApiClient.getAuthentication("BEARER");
         bearer.setApiKeyPrefix("BEARER");


### PR DESCRIPTION
Simple change to add custom http user agent for CLI so that the webservice will be able to figure out which version of Dockstore that the HTTP requests came from.

Partial fix for ga4gh/dockstore#1176