### PR TITLE
Feature/1177/missing documentation

### DIFF
--- a/_docs/getting-started-with-dockstore.md
+++ b/_docs/getting-started-with-dockstore.md
@@ -273,6 +273,65 @@ Optional parameters:
 ------------------
 ```
 
+## Additional Information on Build Modes
+
+#### [Fully-Automated](#Fully-Automated)
+
+How to create it:
+
+Create by using the "Refresh All Tools" button.  This will scan through your Quay.io repositories and automatically register the tool on Dockstore.
+
+Requirements:
+
+- Using a Quay.io registry with Quay.io linked to Dockstore.
+
+Benefits:
+
+This build mode automatically adds versions to your tool with Quay tags and Git reference using the Quay.io build trigger.
+
+Limitations:
+
+- Unable to easily deregister the tool
+- Unable to manually add versions
+- Cannot uniquely name the tool
+- Currently only works with Quay.io image registry
+
+When to use:  
+
+Recommended when you are using a Quay.io registry, want a quick and easy way to register the tool, and want to avoid manually adding new versions to the tool.  Generally recommended for most tools.
+
+#### [Manual](#Manual)
+
+How to create it:
+
+- Click Add Tool, fill in details
+
+Requirements:
+
+- Registry that has at least one tag
+- Token to the corresponding registry (if using Quay.io)
+
+Limitations:
+
+- Have to manually the tool and also manually add each version (refresh will not work)
+
+When to use:
+
+Recommended when you're not using Quay.io or if someone else has the same tool name already and you want your own tool instead.  Also if you are not using build triggers.
+
+### Converting Between Build Modes
+
+Manual -> Fully-Automated:
+
+1. Deregister the manual tool
+2. Create a new Fully-Automated one (simply click "Refresh All Tools")
+
+Fully-Automated -> Manual:
+
+1. Delete Quay.io repository
+2. "Refresh All Tools" (this will remove the tool from Dockstore)
+3. Create a new Manual tool (will have to recreate the Quay.io repository)
+
 ## Sharing the Tool
 
 This is the simple part.  Now that we've successfully registered the tool on Dockstore you can just send around a link, for example to the BAMStat tool I just registered:

--- a/_docs/getting-started-with-dockstore.md
+++ b/_docs/getting-started-with-dockstore.md
@@ -59,6 +59,26 @@ You can also click on the "Versions" tab and should notice `1.25-6` is present a
 
 Next, pick a version of your tool that you wish to present to the world by clicking on the radio selector in the Git Reference or Version column. This will determine which version of your CWL/WDL file will be used to find the author, email, and description in the case that it changes between versions. This also allows you to pre-select a version of your tool to present to users in the "Launch With" section, and the Dockerfile and Descriptor tabs.
 
+### Quick Registration of Alternate Tools
+
+Outside of this tutorial, you may wish to re-register a pre-existing tool with a new name. This can occur when you've quick registered a tool, but wish to create a new tool with a different descriptor based on the same Docker image when your Docker image supports a number of different commands.
+
+Consider the linked [repository](https://github.com/CancerCollaboratory/dockstore-tool-bamstats). If you've followed the tutorial, you will have this as a published tool. But wait, there's a `Dockstore2.cwl` in the same repo with a different command.
+
+To register this, follow the procedure below:
+
+First, make note of the GitHub repository that stores the descriptors for the tool.  
+
+![Existing tool](/assets/images/docs/alternate1.png)
+
+Second, hit the plus button under the organization and ensure that the GitHub repository and image registry match your previous tool. Note that we changed the default CWL Descriptor Path to `Dockstore2.cwl` to simulate an alternate descriptor for the same Docker image. Last but not least, change the tool name to distinguish the tool from the intial tool.
+
+![Add alternate tool](/assets/images/docs/alternate2.png)
+
+After clicking on "Add Tool" you should now see a new "Fully-Automated" tool that shared a GitHub and quay.io repo with an existing tool. Note that the description and launch-with commands should reflect the new tool and the ID will have an additional part (up from three) identifying the new alternate tool.
+
+![Newly created alternate tool](/assets/images/docs/alternate3.png)
+
 
 #### Manual Registration of Tools
 


### PR DESCRIPTION
Missing a few sections of documents
Completely missing the "For developers document" (was replaced by an identically copy of the docker-registries document)

Edit to add: making #1177 linked