### PR TITLE
Feature/no toolname workflowname update

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
@@ -886,13 +886,9 @@ public class ToolClient extends AbstractEntryClient {
                 final String dockerfilePath = optVal(args, "--dockerfile-path", tool.getDefaultDockerfilePath());
                 final String testCwlPath = optVal(args, "--test-cwl-path", tool.getDefaultCWLTestParameterFile());
                 final String testWdlPath = optVal(args, "--test-wdl-path", tool.getDefaultWDLTestParameterFile());
-                final String toolname = optVal(args, "--toolname", tool.getToolname());
                 final String gitUrl = optVal(args, "--git-url", tool.getGitUrl());
                 final String defaultTag = optVal(args, "--default-version", tool.getDefaultVersion());
 
-                if (toolname != null && toolname.startsWith("_")) {
-                    errorMessage("Tool names cannot start with an underscore.", Client.CLIENT_ERROR);
-                }
 
                 // Check that user did not use manual only attributes for an auto tool
                 if (tool.getMode() != DockstoreTool.ModeEnum.MANUAL_IMAGE_PATH && (args.contains("--private") || args
@@ -922,7 +918,6 @@ public class ToolClient extends AbstractEntryClient {
                 tool.setDefaultDockerfilePath(dockerfilePath);
                 tool.setDefaultCWLTestParameterFile(testCwlPath);
                 tool.setDefaultWDLTestParameterFile(testWdlPath);
-                tool.setToolname(toolname);
                 tool.setGitUrl(gitUrl);
 
                 // The following is only for manual tools as only they can be private tools
@@ -1109,7 +1104,6 @@ public class ToolClient extends AbstractEntryClient {
         out("  --test-cwl-path <test-cwl-path>                              Path to default test cwl location");
         out("  --test-wdl-path <test-wdl-path>                              Path to default test wdl location");
         out("  --dockerfile-path <dockerfile-path>                          Path to default dockerfile location");
-        out("  --toolname <toolname>                                        Toolname for the given tool");
         out("  --git-url <git-url>                                          Git url");
         out("  --default-version <default-version>                          Default branch name");
         out("  --tool-maintainer-email <tool-maintainer-email>              Email of tool maintainer (Used for private tools). Manual tools only.");

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -158,7 +158,6 @@ public class WorkflowClient extends AbstractEntryClient {
         out("  --entry <entry>                                              Complete workflow path in the Dockstore (ex. github.com/collaboratory/seqware-bwa-workflow)");
         out("");
         out("Optional Parameters");
-        out("  --workflow-name <workflow-name>                              Name for the given workflow");
         out("  --descriptor-type <descriptor-type>                          Descriptor type of the given workflow.  Can only be altered if workflow is a STUB.");
         out("  --workflow-path <workflow-path>                              Path to default workflow descriptor location");
         out("  --default-version <default-version>                          Default branch name");
@@ -851,15 +850,10 @@ public class WorkflowClient extends AbstractEntryClient {
                 Workflow workflow = workflowsApi.getWorkflowByPath(entry);
                 long workflowId = workflow.getId();
 
-                String workflowName = optVal(args, "--workflow-name", workflow.getWorkflowName());
                 String descriptorType = optVal(args, "--descriptor-type", workflow.getDescriptorType());
                 String workflowDescriptorPath = optVal(args, "--workflow-path", workflow.getWorkflowPath());
                 String defaultVersion = optVal(args, "--default-version", workflow.getDefaultVersion());
                 String defaultTestJsonPath = optVal(args, "--default-test-parameter-path", workflow.getDefaultTestParameterFilePath());
-
-                if (workflowName != null && workflowName.startsWith("_")) {
-                    errorMessage("Workflow names cannot start with an underscore.", Client.CLIENT_ERROR);
-                }
 
                 if (workflow.getMode() == io.swagger.client.model.Workflow.ModeEnum.STUB) {
 
@@ -875,11 +869,6 @@ public class WorkflowClient extends AbstractEntryClient {
                             Client.CLIENT_ERROR);
                 }
 
-                if (workflowName != null && "".equals(workflowName)) {
-                    workflowName = null;
-                }
-
-                workflow.setWorkflowName(workflowName);
                 workflow.setWorkflowPath(workflowDescriptorPath);
                 workflow.setDefaultTestParameterFilePath(defaultTestJsonPath);
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -465,36 +465,6 @@ public class GeneralIT extends BaseIT {
     }
 
     /**
-     * Change toolname of a container
-     */
-    @Test
-    public void testChangeToolname() {
-        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "tool", "manual_publish", "--registry", Registry.QUAY_IO.name(), "--namespace", "dockstoretestuser2", "--name", "quayandgithubalternate", "--git-url",
-                "git@github.com:dockstoretestuser2/quayandgithubalternate.git", "--git-reference", "master", "--toolname", "alternate",
-                "--cwl-path", "/testDir/Dockstore.cwl", "--dockerfile-path", "/testDir/Dockerfile", "--script" });
-
-        Client.main(
-                new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "tool", ToolClient.UPDATE_TOOL, "--entry",
-                        "quay.io/dockstoretestuser2/quayandgithubalternate/alternate", "--toolname", "alternate", "--script" });
-
-        final CommonTestUtilities.TestingPostgres testingPostgres = getTestingPostgres();
-        final long count = testingPostgres.runSelectStatement(
-                "select count(*) from tool where registry = '"+ Registry.QUAY_IO.toString() +"' and namespace = 'dockstoretestuser2' and name = 'quayandgithubalternate' and toolname = 'alternate'",
-                new ScalarHandler<>());
-        assertTrue("there should only be one instance of the container with the toolname set to alternate", count == 1);
-
-        Client.main(
-                new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "tool", ToolClient.UPDATE_TOOL, "--entry",
-                        "quay.io/dockstoretestuser2/quayandgithubalternate", "--toolname", "toolnameTest", "--script" });
-
-        final long count2 = testingPostgres.runSelectStatement(
-                "select count(*) from tool where registry = '"+ Registry.QUAY_IO.toString() +"' and namespace = 'dockstoretestuser2' and name = 'quayandgithubalternate' and toolname = 'toolnameTest'",
-                new ScalarHandler<>());
-        assertTrue("there should only be one instance of the container with the toolname set to toolnameTest", count2 == 1);
-
-    }
-
-    /**
      * Tests that a user can only add Quay containers that they own directly or through an organization
      */
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -245,27 +245,6 @@ public class GeneralWorkflowIT extends BaseIT {
     }
 
     /**
-     * This tests that a workflow can be updated to have a new workflow name
-     */
-    @Test
-    public void testUpdateWorkflowNameAndPath() {
-        // Set up DB
-        final CommonTestUtilities.TestingPostgres testingPostgres = getTestingPostgres();
-
-        // Update workflow
-        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "manual_publish",
-                "--repository", "hello-dockstore-workflow", "--organization", "DockstoreTestUser2", "--git-version-control", "github",
-                "--workflow-name", "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", "wdl", "--script" });
-        Client.main(
-                new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "update_workflow", "--entry",
-                        SourceControl.GITHUB.toString() + "/DockstoreTestUser2/hello-dockstore-workflow/testname", "--workflow-name", "newname", "--script" });
-
-        final long count = testingPostgres
-                .runSelectStatement("select count(*) from workflow where workflowname = 'newname'", new ScalarHandler<>());
-        Assert.assertTrue("there should be 1 matching workflow, there is " + count, count == 1);
-    }
-
-    /**
      * This tests that a user can update a workflow version
      */
     @Test
@@ -781,49 +760,44 @@ public class GeneralWorkflowIT extends BaseIT {
                 .runSelectStatement("select count(*) from workflowversion where valid='t'", new ScalarHandler<>());
         Assert.assertTrue("there should be 2 valid version, there are " + count2, count2 == 2);
 
-        // Give nickname
-        Client.main(
-                new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "update_workflow", "--entry",
-                        SourceControl.GITLAB.toString() + "/dockstore.test.user2/dockstore-workflow-example", "--workflow-name", "newname", "--script" });
-
         final long count3 = testingPostgres.runSelectStatement(
-                "select count(*) from workflow where mode='FULL' and sourcecontrol = '" + SourceControl.GITLAB.toString() + "' and organization = 'dockstore.test.user2' and repository = 'dockstore-workflow-example' and workflowname = 'newname'",
+                "select count(*) from workflow where mode='FULL' and sourcecontrol = '" + SourceControl.GITLAB.toString() + "' and organization = 'dockstore.test.user2' and repository = 'dockstore-workflow-example'",
                 new ScalarHandler<>());
         Assert.assertTrue("there should be 1 workflow, there are " + count3, count3 == 1);
 
         // publish
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish", "--entry",
-                SourceControl.GITLAB.toString() + "/dockstore.test.user2/dockstore-workflow-example/newname", "--script" });
+                SourceControl.GITLAB.toString() + "/dockstore.test.user2/dockstore-workflow-example", "--script" });
         final long count4 = testingPostgres.runSelectStatement(
-                "select count(*) from workflow where mode='FULL' and sourcecontrol = '" + SourceControl.GITLAB.toString() + "' and organization = 'dockstore.test.user2' and repository = 'dockstore-workflow-example' and workflowname = 'newname' and ispublished='t'",
+                "select count(*) from workflow where mode='FULL' and sourcecontrol = '" + SourceControl.GITLAB.toString() + "' and organization = 'dockstore.test.user2' and repository = 'dockstore-workflow-example' and ispublished='t'",
                 new ScalarHandler<>());
         Assert.assertTrue("there should be 1 published workflow, there are " + count4, count4 == 1);
 
         // Should be able to get info since it is published
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "info", "--entry",
-                SourceControl.GITLAB.toString() + "/dockstore.test.user2/dockstore-workflow-example/newname", "--script" });
+                SourceControl.GITLAB.toString() + "/dockstore.test.user2/dockstore-workflow-example", "--script" });
 
         // Should be able to grab descriptor
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "cwl", "--entry",
-                SourceControl.GITLAB.toString() + "/dockstore.test.user2/dockstore-workflow-example/newname:master", "--script" });
+                SourceControl.GITLAB.toString() + "/dockstore.test.user2/dockstore-workflow-example:master", "--script" });
 
         // unpublish
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish", "--entry",
-                SourceControl.GITLAB.toString() + "/dockstore.test.user2/dockstore-workflow-example/newname", "--unpub", "--script" });
+                SourceControl.GITLAB.toString() + "/dockstore.test.user2/dockstore-workflow-example", "--unpub", "--script" });
         final long count5 = testingPostgres.runSelectStatement(
-                "select count(*) from workflow where mode='FULL' and sourcecontrol = '" + SourceControl.GITLAB.toString() + "' and organization = 'dockstore.test.user2' and repository = 'dockstore-workflow-example' and workflowname = 'newname' and ispublished='t'",
+                "select count(*) from workflow where mode='FULL' and sourcecontrol = '" + SourceControl.GITLAB.toString() + "' and organization = 'dockstore.test.user2' and repository = 'dockstore-workflow-example' and ispublished='t'",
                 new ScalarHandler<>());
         Assert.assertTrue("there should be 0 published workflows, there are " + count5, count5 == 0);
 
         // change default branch
         final long count6 = testingPostgres.runSelectStatement(
-                "select count(*) from workflow where sourcecontrol = '" + SourceControl.GITLAB.toString() + "' and organization = 'dockstore.test.user2' and repository = 'dockstore-workflow-example' and workflowname = 'newname' and author is null and email is null and description is null",
+                "select count(*) from workflow where sourcecontrol = '" + SourceControl.GITLAB.toString() + "' and organization = 'dockstore.test.user2' and repository = 'dockstore-workflow-example' and author is null and email is null and description is null",
                 new ScalarHandler<>());
         Assert.assertTrue("The given workflow shouldn't have any contact info", count6 == 1);
 
         Client.main(
                 new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "update_workflow", "--entry",
-                        SourceControl.GITLAB.toString() + "/dockstore.test.user2/dockstore-workflow-example/newname", "--default-version", "test", "--script" });
+                        SourceControl.GITLAB.toString() + "/dockstore.test.user2/dockstore-workflow-example", "--default-version", "test", "--script" });
 
         final long count7 = testingPostgres.runSelectStatement(
                 "select count(*) from workflow where defaultversion = 'test' and author is null and email is null and description is null",
@@ -832,16 +806,16 @@ public class GeneralWorkflowIT extends BaseIT {
 
         // restub
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "restub", "--entry",
-                SourceControl.GITLAB.toString() + "/dockstore.test.user2/dockstore-workflow-example/newname", "--script" });
+                SourceControl.GITLAB.toString() + "/dockstore.test.user2/dockstore-workflow-example", "--script" });
         final long count8 = testingPostgres.runSelectStatement(
-                "select count(*) from workflow where mode='STUB' and sourcecontrol = '" + SourceControl.GITLAB.toString() + "' and organization = 'dockstore.test.user2' and repository = 'dockstore-workflow-example' and workflowname = 'newname'",
+                "select count(*) from workflow where mode='STUB' and sourcecontrol = '" + SourceControl.GITLAB.toString() + "' and organization = 'dockstore.test.user2' and repository = 'dockstore-workflow-example'",
                 new ScalarHandler<>());
         Assert.assertTrue("The workflow should now be a stub", count8 == 1);
 
         // Convert to WDL workflow
         Client.main(
                 new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "update_workflow", "--entry",
-                        SourceControl.GITLAB.toString() + "/dockstore.test.user2/dockstore-workflow-example/newname", "--descriptor-type", "wdl", "--script" });
+                        SourceControl.GITLAB.toString() + "/dockstore.test.user2/dockstore-workflow-example", "--descriptor-type", "wdl", "--script" });
 
         // Should now be a WDL workflow
         final long count9 = testingPostgres

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -283,7 +283,6 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
             }
         }
 
-        originalTool.setToolname(newTool.getToolname());
         originalTool.setGitUrl(newTool.getGitUrl());
 
         if (originalTool.getMode() == ToolMode.MANUAL_IMAGE_PATH) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -536,7 +536,6 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
 
     // Used to update workflow manually (not refresh)
     private void updateInfo(Workflow oldWorkflow, Workflow newWorkflow) {
-        oldWorkflow.setWorkflowName(newWorkflow.getWorkflowName());
         oldWorkflow.setDescriptorType(newWorkflow.getDescriptorType());
         oldWorkflow.setDefaultWorkflowPath(newWorkflow.getDefaultWorkflowPath());
         oldWorkflow.setDefaultTestParameterFilePath(newWorkflow.getDefaultTestParameterFilePath());


### PR DESCRIPTION
Can no longer update toolnames and workflownames on the CLI/backend. This would change the unique path which complicates some things.