### PR TITLE
block updating of descriptor type for a workflow if not a stub

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -536,10 +536,16 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
 
     // Used to update workflow manually (not refresh)
     private void updateInfo(Workflow oldWorkflow, Workflow newWorkflow) {
+        // If workflow is FULL and descriptor type is being changed throw an error
+        if (Objects.equals(oldWorkflow.getMode(), WorkflowMode.STUB) && !Objects.equals(oldWorkflow.getDescriptorType(), newWorkflow.getDescriptorType())) {
+            throw new CustomWebApplicationException("You cannot change the descriptor type of a FULL workflow.", HttpStatus.SC_BAD_REQUEST);
+        }
+
         // Only copy workflow type if old workflow is a STUB
         if (Objects.equals(oldWorkflow.getMode(), WorkflowMode.STUB)) {
             oldWorkflow.setDescriptorType(newWorkflow.getDescriptorType());
         }
+
         oldWorkflow.setDefaultWorkflowPath(newWorkflow.getDefaultWorkflowPath());
         oldWorkflow.setDefaultTestParameterFilePath(newWorkflow.getDefaultTestParameterFilePath());
         if (newWorkflow.getDefaultVersion() != null) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -536,7 +536,10 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
 
     // Used to update workflow manually (not refresh)
     private void updateInfo(Workflow oldWorkflow, Workflow newWorkflow) {
-        oldWorkflow.setDescriptorType(newWorkflow.getDescriptorType());
+        // Only copy workflow type if old workflow is a STUB
+        if (Objects.equals(oldWorkflow.getMode(), WorkflowMode.STUB)) {
+            oldWorkflow.setDescriptorType(newWorkflow.getDescriptorType());
+        }
         oldWorkflow.setDefaultWorkflowPath(newWorkflow.getDefaultWorkflowPath());
         oldWorkflow.setDefaultTestParameterFilePath(newWorkflow.getDefaultTestParameterFilePath());
         if (newWorkflow.getDefaultVersion() != null) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -537,7 +537,7 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     // Used to update workflow manually (not refresh)
     private void updateInfo(Workflow oldWorkflow, Workflow newWorkflow) {
         // If workflow is FULL and descriptor type is being changed throw an error
-        if (Objects.equals(oldWorkflow.getMode(), WorkflowMode.STUB) && !Objects.equals(oldWorkflow.getDescriptorType(), newWorkflow.getDescriptorType())) {
+        if (Objects.equals(oldWorkflow.getMode(), WorkflowMode.FULL) && !Objects.equals(oldWorkflow.getDescriptorType(), newWorkflow.getDescriptorType())) {
             throw new CustomWebApplicationException("You cannot change the descriptor type of a FULL workflow.", HttpStatus.SC_BAD_REQUEST);
         }
 


### PR DESCRIPTION
Block updating workflow descriptor type if FULL. Currently this is block in the UI and CLI, but not the backend.