### PR TITLE
Fix containerfile endpoint return type and also add dummy self_link h…

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2IT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2IT.java
@@ -117,7 +117,8 @@ public class GA4GHV2IT extends GA4GHIT {
     @Override
     public void toolsIdVersionsVersionIdTypeDockerfile() throws Exception {
         Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/containerfile");
-        ToolContainerfile responseObject = response.readEntity(ToolContainerfile.class);
+        List<ToolContainerfile> responseObject = response.readEntity(new GenericType<List<ToolContainerfile>>() {
+        });
         assertThat(MAPPER.writeValueAsString(responseObject).contains("containerfile"));
     }
 

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ApiVersionConverter.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ApiVersionConverter.java
@@ -45,13 +45,17 @@ public final class ApiVersionConverter {
             for (Object innerObject : arrayList) {
                 if (innerObject instanceof Tool) {
                     Tool tool = (Tool)innerObject;
-                    newArrayList.add( new ToolV1(tool));
+                    newArrayList.add(new ToolV1(tool));
                 } else {
                     if (innerObject instanceof ToolVersion) {
                         ToolVersion toolVersion = (ToolVersion)innerObject;
                         newArrayList.add(new ToolVersionV1(toolVersion));
                     } else {
-                        return getResponse(object, response.getHeaders());
+                        if (innerObject instanceof ToolContainerfile) {
+                            return getResponse(new ToolDockerfile((ToolContainerfile)innerObject), response.getHeaders());
+                        } else {
+                            return getResponse(object, response.getHeaders());
+                        }
                     }
                 }
             }

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
@@ -329,8 +329,7 @@ public class ToolsApiServiceImpl extends ToolsApiService {
         final Response.ResponseBuilder responseBuilder = Response.ok(results);
         responseBuilder.header("current_offset", offset);
         responseBuilder.header("current_limit", limit);
-        // Placeholder for now until actual known value is used
-        responseBuilder.header("self_link", "");
+        responseBuilder.header("self_link", value.getUriInfo().getRequestUri().toString());
         // construct links to other pages
         try {
             List<String> filters = new ArrayList<>();

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
@@ -329,6 +329,8 @@ public class ToolsApiServiceImpl extends ToolsApiService {
         final Response.ResponseBuilder responseBuilder = Response.ok(results);
         responseBuilder.header("current_offset", offset);
         responseBuilder.header("current_limit", limit);
+        // Placeholder for now until actual known value is used
+        responseBuilder.header("self_link", "");
         // construct links to other pages
         try {
             List<String> filters = new ArrayList<>();
@@ -442,8 +444,10 @@ public class ToolsApiServiceImpl extends ToolsApiService {
                         : toolTestsList).build();
             case DOCKERFILE:
                 final ToolContainerfile dockerfile = (ToolContainerfile)table.get(toolVersionName, SourceFile.FileType.DOCKERFILE);
+                List<ToolContainerfile> containerfilesList = new ArrayList<>();
+                containerfilesList.add(dockerfile);
                 return Response.status(Response.Status.OK).type(unwrap ? MediaType.TEXT_PLAIN : MediaType.APPLICATION_JSON)
-                    .entity(unwrap ? dockerfile.getContainerfile() : dockerfile).build();
+                    .entity(unwrap ? dockerfile.getContainerfile() : containerfilesList).build();
             default:
                 if (relativePath == null) {
                     if ((type == DOCKSTORE_WDL) && (


### PR DESCRIPTION
This passes the TRSV.  Fixes the /containerfile endpoint to return an array of a single containerfile because only one containerfile is attained.  When the response content type is text/plain, it still returns that containerfile's content in text.  In the future, it should support multiple containerfiles (and still somehow figure out what to return for text/plain).

self_link header returns the link that was used to hit the endpoint