### PR TITLE
fix for issue, also fix for another issue

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -70,7 +70,7 @@ import org.hibernate.annotations.Check;
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findPublishedByOrganization", query = "SELECT c FROM Workflow c WHERE lower(c.organization) = lower(:organization) AND c.isPublished = true"),
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.searchPattern", query = "SELECT c FROM Workflow c WHERE ((c.defaultWorkflowPath LIKE :pattern) OR (c.description LIKE :pattern) OR (CONCAT(c.sourceControl, '/', c.organization, '/', c.repository, '/', c.workflowName) LIKE :pattern)) AND c.isPublished = true") })
 @DiscriminatorValue("workflow")
-@Check(constraints = " ((ischecker IS TRUE and workflowname LIKE '\\_%') or (ischecker IS FALSE and workflowname NOT LIKE '\\_%'))")
+@Check(constraints = " ((ischecker IS TRUE) or (ischecker IS FALSE and workflowname NOT LIKE '\\_%'))")
 @SuppressWarnings("checkstyle:magicnumber")
 public class Workflow extends Entry<Workflow, WorkflowVersion> {
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -384,8 +384,9 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
         workflow.setMode(WorkflowMode.FULL);
         // look for checker workflows to associate with if applicable
         if (!workflow.isIsChecker() && workflow.getDescriptorType().equals(CWL_STRING) || workflow.getDescriptorType().equals(WDL_STRING)) {
-            String prefix = "/" + (workflow.getDescriptorType().equals(CWL_STRING) ? CWL_CHECKER : WDL_CHECKER);
-            Workflow byPath = workflowDAO.findByPath(workflow.getWorkflowPath() + prefix, false);
+            String workflowName = workflow.getWorkflowName() == null ? "" : workflow.getWorkflowName();
+            String checkerWorkflowName = "/" + workflowName + (workflow.getDescriptorType().equals(CWL_STRING) ? CWL_CHECKER : WDL_CHECKER);
+            Workflow byPath = workflowDAO.findByPath(workflow.getPath() + checkerWorkflowName, false);
             if (byPath != null && workflow.getCheckerWorkflow() == null) {
                 workflow.setCheckerWorkflow(byPath);
             }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -385,7 +385,7 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
         // look for checker workflows to associate with if applicable
         if (!workflow.isIsChecker() && workflow.getDescriptorType().equals(CWL_STRING) || workflow.getDescriptorType().equals(WDL_STRING)) {
             String prefix = "/" + (workflow.getDescriptorType().equals(CWL_STRING) ? CWL_CHECKER : WDL_CHECKER);
-            Workflow byPath = workflowDAO.findByPath(workflow.getPath() + prefix, false);
+            Workflow byPath = workflowDAO.findByPath(workflow.getWorkflowPath() + prefix, false);
             if (byPath != null && workflow.getCheckerWorkflow() == null) {
                 workflow.setCheckerWorkflow(byPath);
             }


### PR DESCRIPTION
This fixes the issue in #1268 .

It also fixes another issue where the workflow table has a constraint that if an entry is a checker it must start with _. Really it just could start with underscore, and this is only the case when you add a checker workflow to an entry with no tool/workflowname. Note this was already in the migrations 1.4.0 script, so I think this is the relic of an improper merge.