### PR TITLE
Travis-testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,17 @@ jobs:
     - stage: coverage
       env:
         - EXTRA_MAVEN_VAR="cobertura:cobertura-integration-test coveralls:report" TESTING_PROFILE="integration-tests"
+    - stage: deploy
+      deploy:
+        provider: releases
+        api_key:
+          secure: UaVSOFWwDx2gQIZVSS6jxgs6/Q8cK6qKhg+sDG5aBE5qYJdFSZvBpphZQqSJ176L3dZ0+dxR10RMvrQpocW+bI5NLOj4R1j8dHxxv7Od6pyIYkdhFVsu9KB8F67DVbsIzVGRj7MZgbq4+UUpEif4oTrTI8LVg9AzlBnXhQ0Md4k=
+        file:
+          - dockstore-client/target/dockstore
+          - dockstore-client/target/dockstore-client-*-shaded.jar
+        skip_cleanup: true
+        on:
+          tags: true
 
 # build lifecycle is before_install, install, before_script, script, after_script
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,20 +31,17 @@ jobs:
         - EXTRA_MAVEN_VAR="" TESTING_PROFILE="integration-tests"
     - stage: integration-tests
       env:
-        - EXTRA_MAVEN_VAR="cobertura:cobertura-integration-test coveralls:report" TESTING_PROFILE="toil-integration-tests"
-    - stage: integration-tests
-      env:
-        - EXTRA_MAVEN_VAR="cobertura:cobertura-integration-test coveralls:report" TESTING_PROFILE="regression-integration-tests"
-    - stage: integration-tests
-      env:
-        - EXTRA_MAVEN_VAR="cobertura:cobertura-integration-test coveralls:report" TESTING_PROFILE="toil-integration-tests"
+        - EXTRA_MAVEN_VAR="" TESTING_PROFILE="toil-integration-tests"
 
     - stage: coverage
+      if: branch IN (master, develop)
       env:
         - EXTRA_MAVEN_VAR="cobertura:cobertura coveralls:report" TESTING_PROFILE="unit-tests"
     - stage: coverage
+      if: branch IN (master, develop)
       env:
         - EXTRA_MAVEN_VAR="cobertura:cobertura-integration-test coveralls:report" TESTING_PROFILE="integration-tests"
+
     - stage: deploy
       deploy:
         provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,21 @@ jobs:
     - stage: integration-tests # no point in running integration tests if we don't pass unit tests
       env:
         - EXTRA_MAVEN_VAR="" TESTING_PROFILE="integration-tests"
+    - stage: integration-tests
+      env:
         - EXTRA_MAVEN_VAR="cobertura:cobertura-integration-test coveralls:report" TESTING_PROFILE="toil-integration-tests"
+    - stage: integration-tests
+      env:
         - EXTRA_MAVEN_VAR="cobertura:cobertura-integration-test coveralls:report" TESTING_PROFILE="regression-integration-tests"
+    - stage: integration-tests
+      env:
         - EXTRA_MAVEN_VAR="cobertura:cobertura-integration-test coveralls:report" TESTING_PROFILE="toil-integration-tests"
 
-    - stage: coverage # no point in running coverage if we don't pass integration tests
+    - stage: coverage
       env:
         - EXTRA_MAVEN_VAR="cobertura:cobertura coveralls:report" TESTING_PROFILE="unit-tests"
+    - stage: coverage
+      env:
         - EXTRA_MAVEN_VAR="cobertura:cobertura-integration-test coveralls:report" TESTING_PROFILE="integration-tests"
 
 # build lifecycle is before_install, install, before_script, script, after_script

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
       env:
         - EXTRA_MAVEN_VAR="" TESTING_PROFILE="toil-integration-tests"
 
-    - stage: coverage
+    - stage: coverage # no point in running coverage if we don't pass integration tests
       if: branch IN (master, develop)
       env:
         - EXTRA_MAVEN_VAR="cobertura:cobertura coveralls:report" TESTING_PROFILE="unit-tests"
@@ -42,7 +42,7 @@ jobs:
       env:
         - EXTRA_MAVEN_VAR="cobertura:cobertura-integration-test coveralls:report" TESTING_PROFILE="integration-tests"
 
-    - stage: deploy
+    - stage: deploy # experiment with deploy from travis
       env:
         - EXTRA_MAVEN_VAR="" TESTING_PROFILE="unit-tests"
       deploy:
@@ -62,9 +62,6 @@ before_install:
 - npm install -g swagger2openapi@2.11.16
 # pre-build to check dependencies and look for out-of-sync swagger
 - mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -V
-# start local stack in the background
-- pip install --user localstack
-- localstack start &
 - ./scripts/check-swagger.sh
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,22 @@ language: java
 jdk:
 - oraclejdk8
 
-env:
-   - EXTRA_MAVEN_VAR="" TESTING_PROFILE="unit-tests"
-   - EXTRA_MAVEN_VAR="" TESTING_PROFILE="integration-tests"
-   - EXTRA_MAVEN_VAR="cobertura:cobertura coveralls:report" TESTING_PROFILE="unit-tests"
-   - EXTRA_MAVEN_VAR="cobertura:cobertura-integration-test coveralls:report" TESTING_PROFILE="integration-tests"
-   - EXTRA_MAVEN_VAR="cobertura:cobertura-integration-test coveralls:report" TESTING_PROFILE="toil-integration-tests"
-   - EXTRA_MAVEN_VAR="cobertura:cobertura-integration-test coveralls:report" TESTING_PROFILE="regression-integration-tests"
+jobs:
+  include:
+    - stage: unit-tests 
+      env:
+        - EXTRA_MAVEN_VAR="" TESTING_PROFILE="unit-tests"
+    - stage: integration-tests # no point in running integration tests if we don't pass unit tests
+      env:
+        - EXTRA_MAVEN_VAR="" TESTING_PROFILE="integration-tests"
+        - EXTRA_MAVEN_VAR="cobertura:cobertura-integration-test coveralls:report" TESTING_PROFILE="toil-integration-tests"
+        - EXTRA_MAVEN_VAR="cobertura:cobertura-integration-test coveralls:report" TESTING_PROFILE="regression-integration-tests"
+        - EXTRA_MAVEN_VAR="cobertura:cobertura-integration-test coveralls:report" TESTING_PROFILE="toil-integration-tests"
+
+    - stage: coverage # no point in running coverage if we don't pass integration tests
+      env:
+        - EXTRA_MAVEN_VAR="cobertura:cobertura coveralls:report" TESTING_PROFILE="unit-tests"
+        - EXTRA_MAVEN_VAR="cobertura:cobertura-integration-test coveralls:report" TESTING_PROFILE="integration-tests"
 
 # build lifecycle is before_install, install, before_script, script, after_script
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ jobs:
         - EXTRA_MAVEN_VAR="cobertura:cobertura-integration-test coveralls:report" TESTING_PROFILE="integration-tests"
 
     - stage: deploy
+      env:
+        - EXTRA_MAVEN_VAR="" TESTING_PROFILE="unit-tests"
       deploy:
         provider: releases
         api_key:

--- a/dockstore-client/src/test/java/io/github/collaboratory/cwl/SecondaryFilesUtilityIT.java
+++ b/dockstore-client/src/test/java/io/github/collaboratory/cwl/SecondaryFilesUtilityIT.java
@@ -25,13 +25,13 @@ import io.cwl.avro.Workflow;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author gluu
  * @since 18/09/17
  */
-public class SecondaryFilesUtilityTest {
+public class SecondaryFilesUtilityIT {
 
     private static final String imageDescriptorPath = FileUtils
             .getFile("src", "test", "resources", "gdc/cwl/workflows/dnaseq/transform.cwl").getAbsolutePath();
@@ -41,7 +41,7 @@ public class SecondaryFilesUtilityTest {
 
 
     @Test
-    public void modifyWorkflowToIncludeToolSecondaryFiles() throws Exception {
+    public void modifyWorkflowToIncludeToolSecondaryFiles() {
         IntStream.range(0, 5).forEach(i -> modifyWorkflow());
     }
 
@@ -56,10 +56,8 @@ public class SecondaryFilesUtilityTest {
                 inputParameters.add(secondaryFiles);
             }
         });
-        assertTrue(inputParameters.size() == 1);
+        assertEquals(1, inputParameters.size());
         ArrayList inputParameterArray = (ArrayList)inputParameters.get(0);
-        assertTrue(inputParameterArray.size() == 5);
-
-
+        assertEquals(5, inputParameterArray.size());
     }
 }

--- a/dockstore-common/src/test/java/io/dockstore/client/cli/CWLClientIT.java
+++ b/dockstore-common/src/test/java/io/dockstore/client/cli/CWLClientIT.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author dyuen
  */
-public class CWLClientTest {
+public class CWLClientIT {
 
     @Test
     public void serializeToJson() throws Exception {

--- a/scripts/check-swagger.sh
+++ b/scripts/check-swagger.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 # This script checks that the generated swagger.yaml is semantically equivalent to the checked in yaml
+# Equivalent to a integration test
 # Bash3 Boilerplate. Copyright (c) 2014, kvz.io
 
 set -o errexit
 set -o pipefail
 set -o nounset
 set -o xtrace
+
+if [ "${TESTING_PROFILE}" = "unit-tests" ]; then
+    exit 0;
+fi
 
 cp dockstore-webservice/src/main/resources/swagger.yaml generated.yaml
 git checkout dockstore-webservice/src/main/resources/swagger.yaml

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
-# Bash3 Boilerplate. Copyright (c) 2014, kvz.io
+# Installs dependencies for integration tests, not used for unit tests
+# Includes Bash3 Boilerplate. Copyright (c) 2014, kvz.io
 
 set -o errexit
 set -o pipefail
 set -o nounset
 set -o xtrace
 
+if [ "${TESTING_PROFILE}" = "unit-tests" ]; then
+    exit 0;
+fi
+
 if [ "${TESTING_PROFILE}" = "toil-integration-tests" ]; then
     pip2.7 install --user toil[cwl]==3.14.0
 else
+    pip install --user localstack
+    localstack start &
     pip2.7 install --user setuptools==36.5.0
     pip2.7 install --user cwl-runner cwltool==1.0.20170828135420 schema-salad==2.6.20170806163416 avro==1.8.1 ruamel.yaml==0.14.12 requests==2.18.4
 fi

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -11,15 +11,4 @@ if [ "${TESTING_PROFILE}" = "integration-tests" ] || [ "${TESTING_PROFILE}" = "r
     tar xvf secrets.tar
 fi
 
-if [ ${#EXTRA_MAVEN_VAR} -eq 0 ]; then
-        # always do non-coverage builds
-    echo "Non-coverage build"
-	mvn --batch-mode clean install -P${TESTING_PROFILE} ${EXTRA_MAVEN_VAR}
-else
-    mvn --batch-mode dependency:get -Dartifact=org.eluder.coveralls:coveralls-maven-plugin:4.2.0
-    # for coverage builds, we need to be more picky, let's exclude builds from branches other than develop and master
-    if [ "${TRAVIS_BRANCH}" = "master" ] || [ "${TRAVIS_BRANCH}" = "develop" ]; then
-        echo "Coverage build"
-        mvn --batch-mode clean install -P${TESTING_PROFILE} ${EXTRA_MAVEN_VAR}
-    fi
-fi
+mvn --batch-mode clean install -P${TESTING_PROFILE} ${EXTRA_MAVEN_VAR}


### PR DESCRIPTION
Attempting to clean up the build somewhat
* install dependencies only for jobs that need them
* run integration tests only when unit tests pass
* run coverage only when integration tests pass
* Also experiment with auto-deploy script and shaded jar
* make tests that depend on cwltool integration tests so unit tests can move toward having no dependencies