### PR TITLE
Feature/1295/ga4 gh invalid id handling

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
@@ -29,8 +29,11 @@ import io.dropwizard.jackson.Jackson;
 import io.dropwizard.testing.DropwizardTestSupport;
 import io.swagger.client.model.ToolDescriptor;
 import io.swagger.client.model.ToolTests;
+import io.swagger.model.Error;
+import org.apache.http.HttpStatus;
 import org.glassfish.jersey.client.ClientProperties;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -186,5 +189,19 @@ public abstract class GA4GHIT {
         Response response = client.target(path).request().get();
         assertThat(response.getStatus()).isEqualTo(200);
         return response;
+    }
+
+    /**
+     * This tests that a 400 response returns an Error response object similar to the 404 response defined in the
+     * GA4GH swagger.yaml
+     * @throws Exception
+     */
+    @Test
+    public void testInvalidToolId() throws Exception {
+        Response response = client.target(basePath + "tools/potato").request().get();
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+        Error error = response.readEntity(Error.class);
+        Assert.assertTrue(error.getMessage().contains("Tool ID should"));
+        assertThat(error.getCode()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
     }
 }

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
@@ -57,6 +57,7 @@ import io.dockstore.webservice.jdbi.WorkflowDAO;
 import io.swagger.api.NotFoundException;
 import io.swagger.api.ToolsApiService;
 import io.swagger.model.DescriptorType;
+import io.swagger.model.Error;
 import io.swagger.model.ToolContainerfile;
 import io.swagger.model.ToolDescriptor;
 import io.swagger.model.ToolFile;
@@ -656,10 +657,27 @@ public class ToolsApiServiceImpl extends ToolsApiService {
                 list.remove(0); // Remove #workflow from ArrayList to make parsing similar to tool
                 tool = false;
             }
+            checkToolId(list);
             registry = list.get(0);
             organization = list.get(1);
             name = list.get(2);
             toolName = list.size() > SEGMENTS_IN_ID ? list.get(SEGMENTS_IN_ID) : "";
+        }
+
+        /**
+         * This checks if the GA4GH toolId string segments provided by the user is of proper length
+         * If it is not the proper length, returns an Error response object similar to what's defined for the
+         * 404 response in the GA4GH swagger.yaml
+         * @param toolIdStringSegments    The toolId provided by the user which was split into string segments
+         */
+        private void checkToolId(List<String> toolIdStringSegments) {
+            if (toolIdStringSegments.size() < SEGMENTS_IN_ID) {
+                Error error = new Error();
+                error.setCode(HttpStatus.SC_BAD_REQUEST);
+                error.setMessage("Tool ID should have at least 3 separate segments, seperated by /");
+                Response errorResponse = Response.status(HttpStatus.SC_BAD_REQUEST).entity(error).type(MediaType.APPLICATION_JSON).build();
+                throw new WebApplicationException(errorResponse);
+            }
         }
 
         public String getRegistry() {


### PR DESCRIPTION
For issue #1295 

For the tools/{id} endpoint and probably various others, return the GA4GH Error response object with BAD_REQUEST whenever the tool ID is of improper length (less than 3 string segments separated by /).  DockstoreTool always have at least registry/organization/repository.  Workflows always have at least source_code_repo/namespace/repository.