### PR TITLE
Ignore commonwl, enable more error codes, circumvent ssl error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: ruby
 rvm:
   - 2.2
-
+addons:
+  apt:
+    packages:
+    - libcurl4-openssl-dev
 branches:
   only:
   - gh-pages
@@ -12,6 +15,6 @@ install:
 
 script:
   - bundle exec jekyll build
-  # Ignore external certificate and SSL connect errors, ignore '#' and '#top'
-  - htmlproofer --http-status-ignore=0,301 --allow-hash-href --url-ignore='#top' _site/
+  # Ignore external certificate errors from https://ci.commonwl.org, ignore '#' and '#top'
+  - htmlproofer --allow-hash-href --url-ignore="#top,/https://ci.commonwl.org/" _site/
 


### PR DESCRIPTION
Several changes
- Stop ignoring 0 and 301 errors
- Fix many of the 0 and 301 errors by install libcurl4-openssl-dev
- https://ci.commonwl.org still returns a 0 error due to `Peer certificate cannot be authenticated with given CA certificates` but current have no solution so ignoring it.  see https://www.sslshopper.com/ssl-checker.html#hostname=https://ci.commonwl.org/ for another source that think there's a problem.
See https://travis-ci.org/garyluu/dockstore/builds/366237958 for failing with incorrect URL.