### PR TITLE
Feature/convert manual to auto

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -663,4 +663,59 @@ public class GeneralIT extends BaseIT {
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "tool", "launch", "--entry",
                 "imnotreal.wdl", "--json", "imnotreal-job.json", "--descriptor", "wdl", "--script" });
     }
+
+    /**
+     * Creates a basic Manual Tool with Quay
+     * @param gitUrl
+     * @return
+     */
+    private DockstoreTool getQuayContainer(String gitUrl) {
+        DockstoreTool tool = new DockstoreTool();
+        tool.setMode(DockstoreTool.ModeEnum.MANUAL_IMAGE_PATH);
+        tool.setName("my-md5sum");
+        tool.setGitUrl(gitUrl);
+        tool.setDefaultDockerfilePath("/md5sum/Dockerfile");
+        tool.setDefaultCwlPath("/md5sum/md5sum-tool.cwl");
+        tool.setRegistryString(Registry.QUAY_IO.toString());
+        tool.setNamespace("dockstoretestuser2");
+        tool.setToolname("altname");
+        tool.setPrivateAccess(false);
+        tool.setDefaultCWLTestParameterFile("/testcwl.json");
+        return tool;
+    }
+
+    /**
+     * Tests that manually adding a tool that should become auto is properly converted
+     */
+    @Test
+    public void testManualToAuto() {
+        String gitUrl = "git@github.com:DockstoreTestUser2/md5sum-checker.git";
+        ContainersApi toolsApi = setupWebService();
+        DockstoreTool tool = getQuayContainer(gitUrl);
+        DockstoreTool toolTest = toolsApi.registerManual(tool);
+        toolsApi.refresh(toolTest.getId());
+
+        final CommonTestUtilities.TestingPostgres testingPostgres = getTestingPostgres();
+        final long count = testingPostgres
+                .runSelectStatement("select count(*) from tool where mode = '" + DockstoreTool.ModeEnum.AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS + "' and giturl = '" + gitUrl + "' and name = 'my-md5sum' and namespace = 'dockstoretestuser2' and toolname = 'altname'", new ScalarHandler<>());
+        assertTrue("The tool should be auto, there are " + count, count == 1);
+    }
+
+    /**
+     * Tests that manually adding a tool that shouldn't become auto stays manual
+     * The tool should specify a git URL that does not match any in any Quay builds
+     */
+    @Test
+    public void testManualToolStayManual() {
+        String gitUrl = "git@github.com:DockstoreTestUser2/dockstore-whalesay-imports.git";
+        ContainersApi toolsApi = setupWebService();
+        DockstoreTool tool = getQuayContainer(gitUrl);
+        DockstoreTool toolTest = toolsApi.registerManual(tool);
+        toolsApi.refresh(toolTest.getId());
+
+        final CommonTestUtilities.TestingPostgres testingPostgres = getTestingPostgres();
+        final long count = testingPostgres
+                .runSelectStatement("select count(*) from tool where mode = '" + DockstoreTool.ModeEnum.MANUAL_IMAGE_PATH + "' and giturl = '" + gitUrl + "' and name = 'my-md5sum' and namespace = 'dockstoretestuser2' and toolname = 'altname'", new ScalarHandler<>());
+        assertTrue("The tool should be manual, there are " + count, count == 1);
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -244,7 +244,7 @@ public abstract class AbstractImageRegistry {
         // Get all existing tags
         List<Tag> existingTags = new ArrayList<>(tool.getTags());
 
-        if (tool.getMode() != ToolMode.MANUAL_IMAGE_PATH) {
+        if (tool.getMode() != ToolMode.MANUAL_IMAGE_PATH || (tool.getRegistry().equals(Registry.QUAY_IO.toString()) && existingTags.isEmpty())) {
 
             if (newTags == null) {
                 LOG.info(githubToken.getUsername() + " : Tags for tool {} did not get updated because new tags were not found",

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -86,6 +86,13 @@ public abstract class AbstractImageRegistry {
     public abstract Registry getRegistry();
 
     /**
+     * Returns true if a tool can be converted to auto, false otherwise
+     * @param tool
+     * @return
+     */
+    public abstract boolean convertToAuto(Tool tool);
+
+    /**
      * Updates/Adds/Deletes tools and their associated tags
      *
      * @param userId         The ID of the user
@@ -176,6 +183,13 @@ public abstract class AbstractImageRegistry {
         if (tool.getMode() == ToolMode.MANUAL_IMAGE_PATH && duplicatePath != null && tool.getRegistry()
                 .equals(Registry.QUAY_IO.toString()) && duplicatePath.getGitUrl().equals(tool.getGitUrl())) {
             tool.setMode(duplicatePath.getMode());
+        }
+
+        // Check if manual Quay repository can be changed to automatic
+        if (tool.getMode() == ToolMode.MANUAL_IMAGE_PATH && tool.getRegistry().equals(Registry.QUAY_IO.toString())) {
+            if (convertToAuto(tool)) {
+                tool.setMode(ToolMode.AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS);
+            }
         }
 
         // Get tool information from API (if not manual) and remove from api list all tools besides the tool of interest

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -90,7 +90,7 @@ public abstract class AbstractImageRegistry {
      * @param tool
      * @return
      */
-    public abstract boolean convertToAuto(Tool tool);
+    public abstract boolean canConvertToAuto(Tool tool);
 
     /**
      * Updates/Adds/Deletes tools and their associated tags
@@ -187,7 +187,7 @@ public abstract class AbstractImageRegistry {
 
         // Check if manual Quay repository can be changed to automatic
         if (tool.getMode() == ToolMode.MANUAL_IMAGE_PATH && tool.getRegistry().equals(Registry.QUAY_IO.toString())) {
-            if (convertToAuto(tool)) {
+            if (canConvertToAuto(tool)) {
                 tool.setMode(ToolMode.AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS);
             }
         }
@@ -244,7 +244,7 @@ public abstract class AbstractImageRegistry {
         // Get all existing tags
         List<Tag> existingTags = new ArrayList<>(tool.getTags());
 
-        if (tool.getMode() != ToolMode.MANUAL_IMAGE_PATH || (tool.getRegistry().equals(Registry.QUAY_IO.toString()) && existingTags.isEmpty())) {
+        if (tool.getMode() != ToolMode.MANUAL_IMAGE_PATH) {
 
             if (newTags == null) {
                 LOG.info(githubToken.getUsername() + " : Tags for tool {} did not get updated because new tags were not found",

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/DockerHubRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/DockerHubRegistry.java
@@ -58,4 +58,8 @@ public class DockerHubRegistry extends AbstractImageRegistry {
         return Registry.DOCKER_HUB;
     }
 
+    @Override
+    public boolean convertToAuto(Tool tool) {
+        return false;
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/DockerHubRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/DockerHubRegistry.java
@@ -59,7 +59,7 @@ public class DockerHubRegistry extends AbstractImageRegistry {
     }
 
     @Override
-    public boolean convertToAuto(Tool tool) {
+    public boolean canConvertToAuto(Tool tool) {
         return false;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ManualRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ManualRegistry.java
@@ -56,4 +56,9 @@ public class ManualRegistry extends AbstractImageRegistry {
     public Registry getRegistry() {
         return registry;
     }
+
+    @Override
+    public boolean convertToAuto(Tool tool) {
+        return false;
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ManualRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ManualRegistry.java
@@ -58,7 +58,7 @@ public class ManualRegistry extends AbstractImageRegistry {
     }
 
     @Override
-    public boolean convertToAuto(Tool tool) {
+    public boolean canConvertToAuto(Tool tool) {
         return false;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
@@ -356,7 +356,7 @@ public class QuayImageRegistry extends AbstractImageRegistry {
     }
 
     @Override
-    public boolean convertToAuto(Tool tool) {
+    public boolean canConvertToAuto(Tool tool) {
         final String repo = tool.getNamespace() + '/' + tool.getName();
         final Gson gson = new Gson();
 


### PR DESCRIPTION
Improves conversion of manual to auto tools so that an existing matching auto tool doesn't need to exist.

Instead we will check on individual refresh if the quay repo has a build with the build trigger matching the manual tool's git url.

https://github.com/ga4gh/dockstore/issues/1254

Note that this does not include any changes from the discussion this morning, that will come in another PR with a lot of new tests for the different refresh cases.