### PR TITLE
Sort endpoints in swagger-ui

### DIFF
--- a/dockstore-webservice/src/main/resources/assets/swagger-ui/index.html
+++ b/dockstore-webservice/src/main/resources/assets/swagger-ui/index.html
@@ -109,6 +109,17 @@
       requestInterceptor: requestInterceptor,
       showMutatedRequest: true,
       filter: true,
+      operationsSorter: (a, b) => {
+          var methodsOrder = ["get", "post", "put", "delete", "patch", "options", "trace"];
+          var result = result = a.get("path").localeCompare(b.get("path"));
+          // Or if you want to sort the methods alphabetically (delete, get, head, options, ...):
+          // var result = a.get("method").localeCompare(b.get("method"));
+
+          if (result === 0) {
+            result = methodsOrder.indexOf( a.get("method") ) - methodsOrder.indexOf( b.get("method") );
+          }
+          return result;
+      },
       presets: [
         SwaggerUIBundle.presets.apis,
         SwaggerUIStandalonePreset


### PR DESCRIPTION
Simply sorting the swagger endpoints into alphabetical order by path and then by request method ("get", "post", "put", "delete", "patch", "options", "trace") because creating a regex for each endpoint without sorting is a pain.