### PR TITLE
Hidden docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
 script:
   - bundle exec jekyll build
   # Ignore external certificate and SSL connect errors, ignore '#' and '#top'
-  - htmlproofer --allow-hash-href --url-ignore="#top,/https://ci.commonwl.org/,/https://dockstore.org:8443/metadata/runner_dependencies/" _site/
+  - htmlproofer --allow-hash-href --file-ignore="/_site/docs/user-tutorials/language-support-backup/" --url-ignore="#top,/https://ci.commonwl.org/,/https://dockstore.org:8443/metadata/runner_dependencies/" _site/

--- a/_docs/language-support-backup.md
+++ b/_docs/language-support-backup.md
@@ -1,19 +1,8 @@
-<!--
- *     Copyright 2018 OICR
- *
- *     Licensed under the Apache License, Version 2.0 (the "License")
- *     you may not use this file except in compliance with the License
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- */
- -->
+---
+title: Language Support
+permalink: /docs/user-tutorials/language-support-backup/
+---
+
 Sample markdown table
 
 | Feature                | CWL           | WDL   |

--- a/_docs/language-support-backup.md
+++ b/_docs/language-support-backup.md
@@ -2,7 +2,6 @@
 title: Language Support
 permalink: /docs/user-tutorials/language-support-backup/
 ---
-[stuff](https://www.potatostew.com)
 
 Sample markdown table
 

--- a/_docs/language-support-backup.md
+++ b/_docs/language-support-backup.md
@@ -2,6 +2,7 @@
 title: Language Support
 permalink: /docs/user-tutorials/language-support-backup/
 ---
+[stuff](https://www.potatostew.com)
 
 Sample markdown table
 


### PR DESCRIPTION
Let Jeykll build "hidden docs"
Removed copyright to keep consistent with everything else (also it wasn't correct for markdown)
Demonstrate ignoring directories from htmlproofer