### PR TITLE
commit ids

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -161,6 +161,10 @@ public class WorkflowIT extends BaseIT {
         assertEquals("should find 4 valid versions for bitbucket workflow, found : " + refreshBitbucket.getWorkflowVersions().stream()
                 .filter(WorkflowVersion::isValid).count(), 4,
             refreshBitbucket.getWorkflowVersions().stream().filter(WorkflowVersion::isValid).count());
+
+        // check on commit ids for github
+        boolean allHaveCommitIds = refreshGithub.getWorkflowVersions().stream().noneMatch(version -> version.getCommitID().isEmpty());
+        assertTrue("not all workflows seem to have commit ids", allHaveCommitIds);
     }
 
     @Test
@@ -499,6 +503,10 @@ public class WorkflowIT extends BaseIT {
         assertEquals("did not import symbolic links to folders properly", 5,
             registeredTool.getTags().stream().filter(tag -> Objects.equals(tag.getName(), "symbolic.v1")).findFirst().get().getSourceFiles()
                 .size());
+        // check that commit ids look properly recorded
+        // check on commit ids for github
+        boolean allHaveCommitIds = registeredTool.getTags().stream().noneMatch(version -> version.getCommitID().isEmpty());
+        assertTrue("not all tools seem to have commit ids", allHaveCommitIds);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/FileFormat.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/FileFormat.java
@@ -46,7 +46,7 @@ public class FileFormat implements Comparable<FileFormat> {
     @ApiModelProperty(value = "Implementation specific ID for file format in this web service", position = 0)
     private long id;
 
-    @Column(unique = true)
+    @Column(unique = true, columnDefinition = "text")
     @ApiModelProperty(value = "String representation of the file format", required = true, position = 1)
     private String value;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -37,8 +37,8 @@ import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.OneToMany;
-import javax.persistence.OrderBy;
 import javax.persistence.OneToOne;
+import javax.persistence.OrderBy;
 import javax.persistence.SequenceGenerator;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -77,12 +77,16 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @ApiModelProperty(value = "Implementation specific, can be a quay.io or docker hub tag name", required = true, position = 6)
     protected String name;
 
+    @Column(columnDefinition = "text")
+    @ApiModelProperty(value = "This is the commit id for the source control that the files belong to", position = 22)
+    String commitID;
+
     @Column
     @JsonProperty("last_modified")
     @ApiModelProperty(value = "The last time this image was modified in the image registry", position = 1)
     Date lastModified;
 
-    @Column(columnDefinition = "text", nullable = false)
+    @Column(columnDefinition = "text default 'UNSET'", nullable = false)
     @Enumerated(EnumType.STRING)
     @ApiModelProperty(value = "This indicates the type of git (or other source control) reference")
     private ReferenceType referenceType = ReferenceType.UNSET;
@@ -108,6 +112,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @Column(columnDefinition =  "boolean default false")
     @ApiModelProperty(value = "Whether this version has been verified or not", position = 8)
     private boolean verified;
+
     @Column
     @ApiModelProperty(value = "Verified source for the version", position = 9)
     private String verifiedSource;
@@ -309,13 +314,21 @@ public abstract class Version<T extends Version> implements Comparable<T> {
         this.versionEditor = versionEditor;
     }
 
+    public String getCommitID() {
+        return commitID;
+    }
+
+    public void setCommitID(String commitID) {
+        this.commitID = commitID;
+    }
+
     public enum DOIStatus { NOT_REQUESTED, REQUESTED, CREATED }
 
     public enum ReferenceType { COMMIT, TAG, BRANCH, NOT_APPLICABLE, UNSET }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, lastModified, reference, hidden, valid, name);
+        return Objects.hash(id, lastModified, reference, hidden, valid, name, commitID);
     }
 
     @Override
@@ -328,8 +341,8 @@ public abstract class Version<T extends Version> implements Comparable<T> {
         }
         final Version other = (Version)obj;
         return Objects.equals(this.id, other.id) && Objects.equals(this.lastModified, other.lastModified) && Objects
-            .equals(this.reference, other.reference) && Objects.equals(this.hidden, other.hidden) && Objects
-            .equals(this.valid, other.valid) && Objects.equals(this.name, other.name);
+            .equals(this.reference, other.reference) && Objects.equals(this.hidden, other.hidden) && Objects.equals(this.valid, other.valid)
+            && Objects.equals(this.name, other.name) && Objects.equals(this.commitID, other.commitID);
     }
 
     @Override
@@ -337,6 +350,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
         return ComparisonChain.start().compare(this.id, that.id, Ordering.natural().nullsLast())
             .compare(this.lastModified, that.lastModified, Ordering.natural().nullsLast())
             .compare(this.reference, that.reference, Ordering.natural().nullsLast())
-            .compare(this.name, that.name, Ordering.natural().nullsLast()).result();
+            .compare(this.name, that.name, Ordering.natural().nullsLast())
+            .compare(this.commitID, that.commitID, Ordering.natural().nullsLast()).result();
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -93,7 +93,7 @@ public class Workflow extends Entry<Workflow, WorkflowVersion> {
     @ApiModelProperty(value = "This is a git repository name", required = true, position = 16)
     private String repository;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "text")
     @ApiModelProperty(value = "This is a specific source control provider like github or bitbucket or n/a?, required: GA4GH", required = true, position = 17, dataType = "string")
     @Convert(converter = SourceControlConverter.class)
     private SourceControl sourceControl;
@@ -126,7 +126,7 @@ public class Workflow extends Entry<Workflow, WorkflowVersion> {
     @ApiModelProperty(value = "The parent ID of a checker workflow. Null if not a checker workflow. Required for checker workflows.", position = 22)
     private Entry parentEntry;
 
-    @Column(columnDefinition = "boolean")
+    @Column(columnDefinition = "boolean default false")
     @JsonProperty("is_checker")
     @ApiModelProperty(position = 23)
     private boolean isChecker = false;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -151,7 +152,10 @@ public abstract class AbstractImageRegistry {
         // Get tags and update for each tool
         for (Tool tool : newDBTools) {
             List<Tag> toolTags = getTags(tool);
-            updateTags(toolTags, tool, githubToken, bitbucketToken, gitlabToken, tagDAO, fileDAO, toolDAO, fileFormatDAO, client);
+            final SourceCodeRepoInterface sourceCodeRepo = SourceCodeRepoFactory
+                .createSourceCodeRepo(tool.getGitUrl(), client, bitbucketToken == null ? null : bitbucketToken.getContent(),
+                    gitlabToken == null ? null : gitlabToken.getContent(), githubToken.getContent());
+            updateTags(toolTags, tool, sourceCodeRepo, tagDAO, fileDAO, toolDAO, fileFormatDAO);
         }
 
         return newDBTools;
@@ -164,7 +168,7 @@ public abstract class AbstractImageRegistry {
      */
     @SuppressWarnings("checkstyle:parameternumber")
     public Tool refreshTool(final long toolId, final Long userId, final UserDAO userDAO, final ToolDAO toolDAO, final TagDAO tagDAO,
-            final FileDAO fileDAO, final FileFormatDAO fileFormatDAO, final HttpClient client, final Token githubToken, final Token bitbucketToken, final Token gitlabToken) {
+            final FileDAO fileDAO, final FileFormatDAO fileFormatDAO, SourceCodeRepoInterface sourceCodeRepoInterface) {
 
         // Find tool of interest and store in a List (Allows for reuse of code)
         Tool tool = toolDAO.findById(toolId);
@@ -223,7 +227,7 @@ public abstract class AbstractImageRegistry {
 
         // Get tags and update for each tool
         List<Tag> toolTags = getTags(tool);
-        updateTags(toolTags, tool, githubToken, bitbucketToken, gitlabToken, tagDAO, fileDAO, toolDAO, fileFormatDAO, client);
+        updateTags(toolTags, tool, sourceCodeRepoInterface, tagDAO, fileDAO, toolDAO, fileFormatDAO);
 
         // Return the updated tool
         return newDBTools.get(0);
@@ -234,23 +238,19 @@ public abstract class AbstractImageRegistry {
      *
      * @param newTags
      * @param tool
-     * @param githubToken
-     * @param bitbucketToken
      * @param tagDAO
      * @param fileDAO
      * @param toolDAO
-     * @param client
      */
-    @SuppressWarnings("checkstyle:parameternumber")
-    private void updateTags(List<Tag> newTags, Tool tool, Token githubToken, Token bitbucketToken, Token gitlabToken, final TagDAO tagDAO,
-        final FileDAO fileDAO, final ToolDAO toolDAO, final FileFormatDAO fileFormatDAO, final HttpClient client) {
+    private void updateTags(List<Tag> newTags, Tool tool, SourceCodeRepoInterface sourceCodeRepoInterface, final TagDAO tagDAO,
+        final FileDAO fileDAO, final ToolDAO toolDAO, final FileFormatDAO fileFormatDAO) {
         // Get all existing tags
         List<Tag> existingTags = new ArrayList<>(tool.getTags());
 
         if (tool.getMode() != ToolMode.MANUAL_IMAGE_PATH || (tool.getRegistry().equals(Registry.QUAY_IO.toString()) && existingTags.isEmpty())) {
 
             if (newTags == null) {
-                LOG.info(githubToken.getUsername() + " : Tags for tool {} did not get updated because new tags were not found",
+                LOG.info(sourceCodeRepoInterface.gitUsername + " : Tags for tool {} did not get updated because new tags were not found",
                         tool.getPath());
                 return;
             }
@@ -318,7 +318,7 @@ public abstract class AbstractImageRegistry {
             for (Tag tag : existingTags) {
                 // create and add a tag if it does not already exist
                 if (!tool.getTags().contains(tag)) {
-                    LOG.info(githubToken.getUsername() + " : Updating tag {}", tag.getName());
+                    LOG.info(sourceCodeRepoInterface.gitUsername + " : Updating tag {}", tag.getName());
 
                     long id = tagDAO.create(tag);
                     tag = tagDAO.findById(id);
@@ -333,7 +333,7 @@ public abstract class AbstractImageRegistry {
 
             // delete tool if it has no users
             for (Tag t : toDelete) {
-                LOG.info(githubToken.getUsername() + " : DELETING tag: {}", t.getName());
+                LOG.info(sourceCodeRepoInterface.gitUsername + " : DELETING tag: {}", t.getName());
                 t.getSourceFiles().clear();
                 // tagDAO.delete(t);
                 tool.getTags().remove(t);
@@ -351,27 +351,34 @@ public abstract class AbstractImageRegistry {
 
 
         // Now grab default/main tag to grab general information (defaults to github/bitbucket "main branch")
-        final SourceCodeRepoInterface sourceCodeRepo = SourceCodeRepoFactory
-                .createSourceCodeRepo(tool.getGitUrl(), client, bitbucketToken == null ? null : bitbucketToken.getContent(),
-                        gitlabToken == null ? null : gitlabToken.getContent(), githubToken.getContent());
-        if (sourceCodeRepo != null) {
+        if (sourceCodeRepoInterface != null) {
             // Grab files for each version/tag and check if valid
-            updateFiles(tool, fileDAO, sourceCodeRepo, githubToken.getUsername());
-            // Grab and parse files to get tool information
-            // Add for new descriptor types
+            Set<Tag> tags = tool.getTags();
+            String repositoryId = sourceCodeRepoInterface.getRepositoryId(tool);
+            for (Tag tag : tags) {
+                // check to see whether the commit id has changed
+                // determine commit id to find out whether it is different, can skip refresh if it has not changed
+                String commitID = sourceCodeRepoInterface.getCommitID(repositoryId, tag);
+                if (commitID != null && Objects.equals(tag.getCommitID(), commitID)) {
+                    continue;
+                }
+                updateFiles(tool, tag, fileDAO, sourceCodeRepoInterface, sourceCodeRepoInterface.gitUsername);
+                // Grab and parse files to get tool information
+                // Add for new descriptor types
 
-            //Check if default version is set
-            // If not set or invalid, set tag of interest to tag stored in main tag
-            // If set and valid, set tag of interest to tag stored in default version
+                //Check if default version is set
+                // If not set or invalid, set tag of interest to tag stored in main tag
+                // If set and valid, set tag of interest to tag stored in default version
 
-            if (tool.getDefaultCwlPath() != null) {
-                LOG.info(githubToken.getUsername() + " : Parsing CWL...");
-                sourceCodeRepo.updateEntryMetadata(tool, LanguageType.CWL);
-            }
+                if (tool.getDefaultCwlPath() != null) {
+                    LOG.info(sourceCodeRepoInterface.gitUsername + " : Parsing CWL...");
+                    sourceCodeRepoInterface.updateEntryMetadata(tool, LanguageType.CWL);
+                }
 
-            if (tool.getDefaultWdlPath() != null) {
-                LOG.info(githubToken.getUsername() + " : Parsing WDL...");
-                sourceCodeRepo.updateEntryMetadata(tool, LanguageType.WDL);
+                if (tool.getDefaultWdlPath() != null) {
+                    LOG.info(sourceCodeRepoInterface.gitUsername + " : Parsing WDL...");
+                    sourceCodeRepoInterface.updateEntryMetadata(tool, LanguageType.WDL);
+                }
             }
         }
         FileFormatHelper.updateFileFormats(tool.getTags(), fileFormatDAO);
@@ -379,50 +386,46 @@ public abstract class AbstractImageRegistry {
 
     }
 
-    private static void updateFiles(Tool tool, final FileDAO fileDAO, SourceCodeRepoInterface sourceCodeRepo, String username) {
-        Set<Tag> tags = tool.getTags();
-
+    private void updateFiles(Tool tool, Tag tag, final FileDAO fileDAO, SourceCodeRepoInterface sourceCodeRepo, String username) {
         // For each tag, will download files to db and determine if the tag is valid
-        for (Tag tag : tags) {
-            LOG.info(username + " : Updating files for tag {}", tag.getName());
+        LOG.info(username + " : Updating files for tag {}", tag.getName());
 
-            // Get all of the required sourcefiles for the given tag
-            List<SourceFile> newFiles = loadFiles(sourceCodeRepo, tool, tag);
+        // Get all of the required sourcefiles for the given tag
+        List<SourceFile> newFiles = loadFiles(sourceCodeRepo, tool, tag);
 
-            // Remove all existing sourcefiles
-            tag.getSourceFiles().clear();
+        // Remove all existing sourcefiles
+        tag.getSourceFiles().clear();
 
+        // Add for new descriptor types
+        boolean hasCwl = false;
+        boolean hasWdl = false;
+        boolean hasDockerfile = false;
+
+        for (SourceFile newFile : newFiles) {
+            long id = fileDAO.create(newFile);
+            SourceFile file = fileDAO.findById(id);
+            tag.addSourceFile(file);
+
+            if (file.getType() == SourceFile.FileType.DOCKERFILE) {
+                hasDockerfile = true;
+                LOG.info(username + " : HAS Dockerfile");
+            }
             // Add for new descriptor types
-            boolean hasCwl = false;
-            boolean hasWdl = false;
-            boolean hasDockerfile = false;
-
-            for (SourceFile newFile : newFiles) {
-                long id = fileDAO.create(newFile);
-                SourceFile file = fileDAO.findById(id);
-                tag.addSourceFile(file);
-
-                if (file.getType() == SourceFile.FileType.DOCKERFILE) {
-                    hasDockerfile = true;
-                    LOG.info(username + " : HAS Dockerfile");
-                }
-                // Add for new descriptor types
-                if (file.getType() == SourceFile.FileType.DOCKSTORE_CWL) {
-                    hasCwl = true;
-                    LOG.info(username + " : HAS Dockstore.cwl");
-                }
-                if (file.getType() == SourceFile.FileType.DOCKSTORE_WDL) {
-                    hasWdl = true;
-                    LOG.info(username + " : HAS Dockstore.wdl");
-                }
+            if (file.getType() == SourceFile.FileType.DOCKSTORE_CWL) {
+                hasCwl = true;
+                LOG.info(username + " : HAS Dockstore.cwl");
             }
-
-            // Private tools don't require a dockerfile
-            if (tool.isPrivateAccess()) {
-                tag.setValid((hasCwl || hasWdl));
-            } else {
-                tag.setValid((hasCwl || hasWdl) && hasDockerfile);
+            if (file.getType() == SourceFile.FileType.DOCKSTORE_WDL) {
+                hasWdl = true;
+                LOG.info(username + " : HAS Dockstore.wdl");
             }
+        }
+
+        // Private tools don't require a dockerfile
+        if (tool.isPrivateAccess()) {
+            tag.setValid((hasCwl || hasWdl));
+        } else {
+            tag.setValid((hasCwl || hasWdl) && hasDockerfile);
         }
     }
 
@@ -433,13 +436,14 @@ public abstract class AbstractImageRegistry {
      * @param tag
      * @return list of SourceFiles containing cwl and dockerfile.
      */
-    private static List<SourceFile> loadFiles(SourceCodeRepoInterface sourceCodeRepo, Tool c,
-        Tag tag) {
+    private List<SourceFile> loadFiles(SourceCodeRepoInterface sourceCodeRepo, Tool c, Tag tag) {
         List<SourceFile> files = new ArrayList<>();
 
         String repositoryId = sourceCodeRepo.getRepositoryId(c);
+        String commitID = sourceCodeRepo.getCommitID(repositoryId, tag);
         // determine type of git reference for tag
         sourceCodeRepo.updateReferenceType(repositoryId, tag);
+        tag.setCommitID(commitID);
 
         // Add for new descriptor types
         for (SourceFile.FileType f : SourceFile.FileType.values()) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -347,8 +347,6 @@ public abstract class AbstractImageRegistry {
             }
         }
 
-
-
         // Now grab default/main tag to grab general information (defaults to github/bitbucket "main branch")
         if (sourceCodeRepoInterface != null) {
             // Grab files for each version/tag and check if valid
@@ -358,21 +356,22 @@ public abstract class AbstractImageRegistry {
                 updateFiles(tool, tag, fileDAO, sourceCodeRepoInterface, sourceCodeRepoInterface.gitUsername);
                 // Grab and parse files to get tool information
                 // Add for new descriptor types
-
-                //Check if default version is set
-                // If not set or invalid, set tag of interest to tag stored in main tag
-                // If set and valid, set tag of interest to tag stored in default version
-
-                if (tool.getDefaultCwlPath() != null) {
-                    LOG.info(sourceCodeRepoInterface.gitUsername + " : Parsing CWL...");
-                    sourceCodeRepoInterface.updateEntryMetadata(tool, LanguageType.CWL);
-                }
-
-                if (tool.getDefaultWdlPath() != null) {
-                    LOG.info(sourceCodeRepoInterface.gitUsername + " : Parsing WDL...");
-                    sourceCodeRepoInterface.updateEntryMetadata(tool, LanguageType.WDL);
-                }
             }
+
+            //Check if default version is set
+            // If not set or invalid, set tag of interest to tag stored in main tag
+            // If set and valid, set tag of interest to tag stored in default version
+
+            if (tool.getDefaultCwlPath() != null) {
+                LOG.info(sourceCodeRepoInterface.gitUsername + " : Parsing CWL...");
+                sourceCodeRepoInterface.updateEntryMetadata(tool, LanguageType.CWL);
+            }
+
+            if (tool.getDefaultWdlPath() != null) {
+                LOG.info(sourceCodeRepoInterface.gitUsername + " : Parsing WDL...");
+                sourceCodeRepoInterface.updateEntryMetadata(tool, LanguageType.WDL);
+            }
+
         }
         FileFormatHelper.updateFileFormats(tool.getTags(), fileFormatDAO);
         toolDAO.create(tool);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -22,7 +22,6 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -354,14 +353,8 @@ public abstract class AbstractImageRegistry {
         if (sourceCodeRepoInterface != null) {
             // Grab files for each version/tag and check if valid
             Set<Tag> tags = tool.getTags();
-            String repositoryId = sourceCodeRepoInterface.getRepositoryId(tool);
             for (Tag tag : tags) {
                 // check to see whether the commit id has changed
-                // determine commit id to find out whether it is different, can skip refresh if it has not changed
-                String commitID = sourceCodeRepoInterface.getCommitID(repositoryId, tag);
-                if (commitID != null && Objects.equals(tag.getCommitID(), commitID)) {
-                    continue;
-                }
                 updateFiles(tool, tag, fileDAO, sourceCodeRepoInterface, sourceCodeRepoInterface.gitUsername);
                 // Grab and parse files to get tool information
                 // Add for new descriptor types

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -348,14 +348,15 @@ public abstract class AbstractImageRegistry {
             }
         }
 
-        // Grab files for each version/tag and check if valid
-        updateFiles(tool, client, fileDAO, githubToken, bitbucketToken, gitlabToken);
+
 
         // Now grab default/main tag to grab general information (defaults to github/bitbucket "main branch")
         final SourceCodeRepoInterface sourceCodeRepo = SourceCodeRepoFactory
                 .createSourceCodeRepo(tool.getGitUrl(), client, bitbucketToken == null ? null : bitbucketToken.getContent(),
                         gitlabToken == null ? null : gitlabToken.getContent(), githubToken.getContent());
         if (sourceCodeRepo != null) {
+            // Grab files for each version/tag and check if valid
+            updateFiles(tool, fileDAO, sourceCodeRepo, githubToken.getUsername());
             // Grab and parse files to get tool information
             // Add for new descriptor types
 
@@ -378,16 +379,15 @@ public abstract class AbstractImageRegistry {
 
     }
 
-    private static void updateFiles(Tool tool, final HttpClient client, final FileDAO fileDAO, final Token githubToken,
-        final Token bitbucketToken, final Token gitlabToken) {
+    private static void updateFiles(Tool tool, final FileDAO fileDAO, SourceCodeRepoInterface sourceCodeRepo, String username) {
         Set<Tag> tags = tool.getTags();
 
         // For each tag, will download files to db and determine if the tag is valid
         for (Tag tag : tags) {
-            LOG.info(githubToken.getUsername() + " : Updating files for tag {}", tag.getName());
+            LOG.info(username + " : Updating files for tag {}", tag.getName());
 
             // Get all of the required sourcefiles for the given tag
-            List<SourceFile> newFiles = loadFiles(client, bitbucketToken, githubToken, gitlabToken, tool, tag);
+            List<SourceFile> newFiles = loadFiles(sourceCodeRepo, tool, tag);
 
             // Remove all existing sourcefiles
             tag.getSourceFiles().clear();
@@ -404,16 +404,16 @@ public abstract class AbstractImageRegistry {
 
                 if (file.getType() == SourceFile.FileType.DOCKERFILE) {
                     hasDockerfile = true;
-                    LOG.info(githubToken.getUsername() + " : HAS Dockerfile");
+                    LOG.info(username + " : HAS Dockerfile");
                 }
                 // Add for new descriptor types
                 if (file.getType() == SourceFile.FileType.DOCKSTORE_CWL) {
                     hasCwl = true;
-                    LOG.info(githubToken.getUsername() + " : HAS Dockstore.cwl");
+                    LOG.info(username + " : HAS Dockstore.cwl");
                 }
                 if (file.getType() == SourceFile.FileType.DOCKSTORE_WDL) {
                     hasWdl = true;
-                    LOG.info(githubToken.getUsername() + " : HAS Dockstore.wdl");
+                    LOG.info(username + " : HAS Dockstore.wdl");
                 }
             }
 
@@ -429,25 +429,13 @@ public abstract class AbstractImageRegistry {
     /**
      * Given a container and tags, load up required files from git repository
      *
-     * @param client
-     * @param bitbucketToken
-     * @param githubToken
      * @param c
      * @param tag
      * @return list of SourceFiles containing cwl and dockerfile.
      */
-    private static List<SourceFile> loadFiles(HttpClient client, Token bitbucketToken, Token githubToken, Token gitlabToken, Tool c,
+    private static List<SourceFile> loadFiles(SourceCodeRepoInterface sourceCodeRepo, Tool c,
         Tag tag) {
         List<SourceFile> files = new ArrayList<>();
-
-        final String bitbucketTokenContent = bitbucketToken == null ? null : bitbucketToken.getContent();
-        final String gitlabTokenContent = gitlabToken == null ? null : gitlabToken.getContent();
-        final String githubTokenContent = githubToken == null ? null : githubToken.getContent();
-        final SourceCodeRepoInterface sourceCodeRepo = SourceCodeRepoFactory
-            .createSourceCodeRepo(c.getGitUrl(), client, bitbucketTokenContent, gitlabTokenContent, githubTokenContent);
-        if (sourceCodeRepo == null) {
-            return files;
-        }
 
         String repositoryId = sourceCodeRepo.getRepositoryId(c);
         // determine type of git reference for tag

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
@@ -215,6 +215,12 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
     }
 
     @Override
+    String getCommitID(String repositoryId, Version version) {
+        //TODO: optimize here for bitbucket by returning actual sha1
+        return null;
+    }
+
+    @Override
     public Workflow initializeWorkflow(String repositoryId) {
         Workflow workflow = new Workflow();
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -467,6 +467,26 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         }
     }
 
+    @Override
+    String getCommitID(String repositoryId, Version version) {
+        GHRepository repo;
+        try {
+            repo = github.getRepository(repositoryId);
+            GHRef[] refs = repo.getRefs();
+
+            for (GHRef ref : refs) {
+                String reference = StringUtils.removePattern(ref.getRef(), "refs/.+?/");
+                if (reference.equals(version.getReference())) {
+                    return ref.getObject().getSha();
+                }
+            }
+        } catch (IOException e) {
+            LOG.error(gitUsername + ": IOException on readFile " + e.getMessage());
+            // this is not so critical to warrant a http error code
+        }
+        return null;
+    }
+
     /**
      * Updates a user object with metadata from GitHub
      * @param user the user to be updated

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -48,6 +48,7 @@ import okhttp3.OkUrlFactory;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.http.HttpStatus;
 import org.kohsuke.github.AbuseLimitHandler;
 import org.kohsuke.github.GHBranch;
@@ -261,7 +262,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         GHRateLimit startRateLimit = getGhRateLimitQuietly();
 
         // when getting a full workflow, look for versions and check each version for valid workflows
-        List<Pair<String, Date>> references = new ArrayList<>();
+        List<Triple<String, Date, String>> references = new ArrayList<>();
         try {
             repository = github.getRepository(repositoryId);
             final Date epochStart = new Date(0);
@@ -269,6 +270,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             for (GHRef ref : refs) {
                 Date branchDate = new Date(0);
                 String refName = ref.getRef();
+                String sha = null;
                 if (refName.startsWith("refs/heads/")) {
                     refName = StringUtils.removeStart(refName, "refs/heads/");
                 } else if (refName.startsWith("refs/tags/")) {
@@ -278,7 +280,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
                     continue;
                 }
                 try {
-                    String sha = ref.getObject().getSha();
+                    sha = ref.getObject().getSha();
                     if (ref.getObject().getType().equals("tag")) {
                         GHTagObject tagObject = repository.getTagObject(sha);
                         sha = tagObject.getObject().getSha();
@@ -295,13 +297,13 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
                 } catch (IOException e) {
                     LOG.info("unable to retrieve commit date for branch " + refName);
                 }
-                references.add(Pair.of(refName, branchDate));
+                references.add(Triple.of(refName, branchDate, sha));
             }
         } catch (IOException e) {
             LOG.info(gitUsername + ": Cannot get branches or tags for workflow {}");
             throw new CustomWebApplicationException("Could not reach GitHub, please try again later", HttpStatus.SC_SERVICE_UNAVAILABLE);
         }
-        Optional<Date> max = references.stream().map(Pair::getRight).max(Comparator.naturalOrder());
+        Optional<Date> max = references.stream().map(Triple::getMiddle).max(Comparator.naturalOrder());
         // TODO: this conversion is lossy
         max.ifPresent(date -> {
             long time = max.get().getTime();
@@ -309,11 +311,12 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         });
 
         // For each branch (reference) found, create a workflow version and find the associated descriptor files
-        for (Pair<String, Date> ref : references) {
+        for (Triple<String, Date, String> ref : references) {
             LOG.info(gitUsername + ": Looking at reference: " + ref.toString());
             // Initialize the workflow version
-            WorkflowVersion version = initializeWorkflowVersion(ref.getKey(), existingWorkflow, existingDefaults);
-            version.setLastModified(ref.getRight());
+            WorkflowVersion version = initializeWorkflowVersion(ref.getLeft(), existingWorkflow, existingDefaults);
+            version.setLastModified(ref.getMiddle());
+            version.setCommitID(ref.getRight());
             String calculatedPath = version.getWorkflowPath();
 
             SourceFile.FileType identifiedType = workflow.getFileType();
@@ -321,7 +324,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             // Grab workflow file from github
             try {
                 // Get contents of descriptor file and store
-                String decodedContent = this.readFileFromRepo(calculatedPath, ref.getKey(), repository);
+                String decodedContent = this.readFileFromRepo(calculatedPath, ref.getLeft(), repository);
                 if (decodedContent != null) {
                     boolean validWorkflow = LanguageHandlerFactory.getInterface(identifiedType).isValidWorkflow(decodedContent);
                     // if we have a valid workflow document
@@ -336,7 +339,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
                     // Use default test parameter file if either new version or existing version that hasn't been edited
                     // TODO: why is this here? Does this code not have a counterpart in BitBucket and GitLab?
                     if (!version.isDirtyBit() && workflow.getDefaultTestParameterFilePath() != null) {
-                        String testJsonContent = this.readFileFromRepo(workflow.getDefaultTestParameterFilePath(), ref.getKey(), repository);
+                        String testJsonContent = this.readFileFromRepo(workflow.getDefaultTestParameterFilePath(), ref.getLeft(), repository);
                         if (testJsonContent != null) {
                             SourceFile testJson = new SourceFile();
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
@@ -163,6 +163,11 @@ public class GitLabSourceCodeRepo extends SourceCodeRepoInterface {
         /* no-op handled earlier since the library handles it in a more trivial way than the github library */
     }
 
+    @Override
+    String getCommitID(String repositoryId, Version version) {
+        //TODO: optimize here for gitlab by returning actual sha1
+        return null;
+    }
 
     @Override
     public String getRepositoryId(Entry entry) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -455,4 +455,11 @@ public abstract class SourceCodeRepoInterface {
      * @param version
      */
     abstract void updateReferenceType(String repositoryId, Version version);
+
+    /**
+     * Given a version of a tool or workflow, return the corresponding current commit id
+     * @param repositoryId
+     * @param version
+     */
+    abstract String getCommitID(String repositoryId, Version version);
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -116,7 +116,7 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
     @UnitOfWork
     public T editHosted(@ApiParam(hidden = true) @Auth User user,
         @ApiParam(value = "Entry to modify.", required = true) @PathParam("entryId") Long entryId,
-        @ApiParam(value = "Set of updated sourcefiles, add files by adding new files with unknown paths, delete files by including them with emptied content", required = true, type = "SourceFile") Set<SourceFile> sourceFiles) {
+        @ApiParam(value = "Set of updated sourcefiles, add files by adding new files with unknown paths, delete files by including them with emptied content", required = true) Set<SourceFile> sourceFiles) {
         T entry = getEntryDAO().findById(entryId);
         checkEntry(entry);
         checkUser(user, entry);

--- a/dockstore-webservice/src/main/resources/migrations.1.5.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.5.0.xml
@@ -81,4 +81,15 @@
         <addForeignKeyConstraint baseColumnNames="versioneditor_id" baseTableName="workflowversion" constraintName="versionEditorForWorkflows" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="enduser"/>
         <addForeignKeyConstraint baseColumnNames="versioneditor_id" baseTableName="tag" constraintName="versionEditorForTools" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="enduser"/>
     </changeSet>
+
+    <!-- add commit id -->
+    <changeSet author="dyuen (generated)" id="add commit ids to versions">
+        <addColumn tableName="tag">
+            <column name="commitid" type="text"/>
+        </addColumn>
+        <addColumn tableName="workflowversion">
+            <column name="commitid" type="text"/>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -5421,6 +5421,12 @@ components:
           uniqueItems: true
           items:
             $ref: '#/components/schemas/FileFormat'
+        commitID:
+          type: string
+          position: 22
+          description: >-
+            This is the commit id for the source control that the files belong
+            to
       description: This describes one tag associated with a container.
     Token:
       type: object
@@ -6120,4 +6126,10 @@ components:
           uniqueItems: true
           items:
             $ref: '#/components/schemas/FileFormat'
+        commitID:
+          type: string
+          position: 22
+          description: >-
+            This is the commit id for the source control that the files belong
+            to
       description: This describes one workflow version associated with a workflow.

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5000,6 +5000,11 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
+      commitID:
+        type: "string"
+        position: 22
+        description: "This is the commit id for the source control that the files\
+          \ belong to"
     description: "This describes one tag associated with a container."
   Token:
     type: "object"
@@ -5651,4 +5656,9 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
+      commitID:
+        type: "string"
+        position: 22
+        description: "This is the commit id for the source control that the files\
+          \ belong to"
     description: "This describes one workflow version associated with a workflow."

--- a/dockstore-webservice/src/test/java/core/WDLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/WDLParseTest.java
@@ -51,4 +51,14 @@ public class WDLParseTest {
         Assert.assertTrue("incorrect author", entry.getAuthor().split(",").length >= 2);
         Assert.assertTrue("incorrect email", entry.getEmail().isEmpty());
     }
+
+    @Test
+    public void testWDLMetadataExampleWithWorkflowMeta() throws IOException {
+        String filePath = ResourceHelpers.resourceFilePath("metadata_example2.wdl");
+        LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(SourceFile.FileType.DOCKSTORE_WDL);
+        Entry entry = sInterface
+            .parseWorkflowContent(new Tool(), FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+        Assert.assertTrue("incorrect author", entry.getAuthor().split(",").length >= 2);
+        Assert.assertTrue("incorrect email", entry.getDescription().equals("This is a cool workflow"));
+    }
 }

--- a/dockstore-webservice/src/test/resources/metadata_example2.wdl
+++ b/dockstore-webservice/src/test/resources/metadata_example2.wdl
@@ -1,0 +1,199 @@
+task combine_signif_pairs {
+
+    Array[File] signifpairs
+    String prefix
+
+    Int memory
+    Int disk_space
+    Int num_threads
+    Int num_preempt
+
+    command {
+        set -euo pipefail
+        /src/combine_signif_pairs.py ${write_lines(signifpairs)} ${prefix}
+    }
+
+    runtime {
+        docker: "gcr.io/broad-cga-francois-gtex/gtex_eqtl:V8"
+        memory: "${memory}GB"
+        disks: "local-disk ${disk_space} HDD"
+        cpu: "${num_threads}"
+        preemptible: "${num_preempt}"
+    }
+
+    output {
+        File combined_signifpairs="${prefix}.combined_signifpairs.txt.gz"
+    }
+}
+
+
+task extract_pairs {
+
+    File input_pairs
+    File extract_pairs
+    String prefix
+
+    Int memory
+    Int disk_space
+    Int num_threads
+    Int num_preempt
+
+    command {
+        set -euo pipefail
+        /src/extract_pairs.py ${input_pairs} ${extract_pairs} ${prefix} --feather
+    }
+
+    runtime {
+        docker: "gcr.io/broad-cga-francois-gtex/gtex_eqtl:V8"
+        memory: "${memory}GB"
+        disks: "local-disk ${disk_space} HDD"
+        cpu: "${num_threads}"
+        preemptible: "${num_preempt}"
+    }
+
+    output {
+        File extracted_pairs="${prefix}.extracted_pairs.ft"
+    }
+
+    meta {
+        author: "Francois Aguet"
+    }
+}
+
+
+task metasoft_prepare_input {
+
+    Array[File] pair_files
+    String prefix
+    Int? chunks
+
+    Int memory
+    Int disk_space
+    Int num_threads
+    Int num_preempt
+
+    command {
+        set -euo pipefail
+        /src/metasoft_prepare_input.py ${write_lines(pair_files)} ${prefix} ${"--chunks " + chunks} --write_full
+    }
+
+    runtime {
+        docker: "gcr.io/broad-cga-francois-gtex/gtex_eqtl:V8"
+        memory: "${memory}GB"
+        disks: "local-disk ${disk_space} HDD"
+        cpu: "${num_threads}"
+        preemptible: "${num_preempt}"
+    }
+
+    output {
+        File metasoft_input = "${prefix}.metasoft_input.txt.gz"
+        Array[File] metasoft_input_chunks = glob("${prefix}.metasoft_input.chunk*.txt.gz")
+    }
+
+    meta {
+        author: "Francois Aguet"
+    }
+}
+
+
+
+task metasoft_scatter {
+
+    File metasoft_input
+    String prefix
+
+    Int memory
+    Int disk_space
+    Int num_threads
+    Int num_preempt
+
+    command {
+        set -euo pipefail
+        /src/run_metasoft.py /opt/metasoft/Metasoft.jar ${metasoft_input} ${prefix}
+    }
+
+    runtime {
+        docker: "gcr.io/broad-cga-francois-gtex/gtex_eqtl:V8"
+        memory: "${memory}GB"
+        disks: "local-disk ${disk_space} HDD"
+        cpu: "${num_threads}"
+        preemptible: "${num_preempt}"
+    }
+
+    output {
+        File metasoft_output="${prefix}.metasoft.txt.gz"
+        File metasoft_log="${prefix}.metasoft.log"
+    }
+
+    meta {
+        author: "Francois Aguet"
+    }
+}
+
+
+task metasoft_postprocess {
+
+    Array[File] metasoft_chunks
+    Array[File] pair_files
+    String prefix
+
+    Int memory
+    Int disk_space
+    Int num_threads
+    Int num_preempt
+
+    command {
+        set -euo pipefail
+        /src/metasoft_postprocess.py ${write_lines(metasoft_chunks)} ${write_lines(pair_files)} ${prefix}
+    }
+
+    runtime {
+        docker: "gcr.io/broad-cga-francois-gtex/gtex_eqtl:V8"
+        memory: "${memory}GB"
+        disks: "local-disk ${disk_space} HDD"
+        cpu: "${num_threads}"
+        preemptible: "${num_preempt}"
+    }
+
+    output {
+        File metasoft_output="${prefix}.metasoft.txt.gz"
+    }
+
+    meta {
+        author: "Kinda like Francois Aguet but not"
+    }
+}
+
+
+workflow metasoft_workflow {
+
+    Array[File] signifpairs
+    Array[File] allpairs
+    Array[String] sample_ids
+    String prefix
+
+    call combine_signif_pairs { input: signifpairs=signifpairs, prefix=prefix }
+
+    # for each sample set, extract same set of pairs
+    scatter(i in range(length(allpairs))) {
+        call extract_pairs { input: input_pairs=allpairs[i], extract_pairs=combine_signif_pairs.combined_signifpairs, prefix=sample_ids[i]}
+    }
+
+    call metasoft_prepare_input { input: pair_files=extract_pairs.extracted_pairs, prefix=prefix}
+
+    scatter(chunk in metasoft_prepare_input.metasoft_input_chunks) {
+        call metasoft_scatter {
+            input: metasoft_input=chunk, prefix=prefix
+        }
+    }
+
+    call metasoft_postprocess {
+        input: metasoft_chunks=metasoft_scatter.metasoft_output, pair_files=extract_pairs.extracted_pairs, prefix=prefix
+    }
+
+    meta {
+        author : "Mr. Foo"
+        email : "foo@foo.com"
+        description: "This is a cool workflow"
+    }
+}


### PR DESCRIPTION
* partial implementation of #1412 
  * keeping track of commit ids for tags and branches so it is more clear where content is coming from in the case of branches where it can float
* reduce false positives when proposing migrations

