### PR TITLE
1419/metadata issue

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -51,6 +51,7 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
 import static io.dockstore.common.CommonTestUtilities.getTestingPostgres;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -104,8 +105,8 @@ public class GeneralIT extends BaseIT {
         c.setToolname("test5");
         c.setPath("quay.io/dockstoretestuser2/dockstore-tool-imports");
         Tag tag = new Tag();
-        tag.setName("master");
-        tag.setReference("refs/heads/master");
+        tag.setName("1.0");
+        tag.setReference("master");
         tag.setValid(true);
         tag.setImageId("123456");
         // construct source files
@@ -572,6 +573,25 @@ public class GeneralIT extends BaseIT {
         //check if the tag's dockerfile path have the same cwl path or not in the database
         final String path = getPathfromDB("cwlpath");
         assertTrue("the cwl path should be changed to /test1.cwl", path.equals("/test1.cwl"));
+    }
+
+    /**
+     * Tests that if a tool has a tag with mismatching tag name and tag reference, and it is set as the default tag
+     * then the author metadata is properly grabbed.
+     */
+    @Test
+    public void testParseMetadataFromToolWithTagNameAndReferenceMismatch() {
+        // Setup webservice and get tool api
+        ContainersApi toolsApi = setupWebService();
+
+        // Create tool with mismatching tag name and tag reference
+        DockstoreTool tool = getContainer();
+        tool.setDefaultVersion("1.0");
+        DockstoreTool toolTest = toolsApi.registerManual(tool);
+        toolsApi.refresh(toolTest.getId());
+
+        DockstoreTool refreshedTool = toolsApi.getContainer(toolTest.getId());
+        assertTrue("Author should be set, even if tag name and tag reference are mismatched.", refreshedTool.getAuthor() != null);
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -52,6 +52,7 @@ import org.junit.runner.Description;
 
 import static io.dockstore.common.CommonTestUtilities.getTestingPostgres;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -591,7 +592,7 @@ public class GeneralIT extends BaseIT {
         toolsApi.refresh(toolTest.getId());
 
         DockstoreTool refreshedTool = toolsApi.getContainer(toolTest.getId());
-        assertTrue("Author should be set, even if tag name and tag reference are mismatched.", refreshedTool.getAuthor() != null);
+        assertNotNull("Author should be set, even if tag name and tag reference are mismatched.", refreshedTool.getAuthor());
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
@@ -292,7 +292,7 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
 
         // Is default version set?
         if (entry.getDefaultVersion() != null) {
-            branch = entry.getDefaultVersion();
+            branch = getBranchNameFromDefaultVersion(entry);
         } else {
             // If default version is not set, need to find the main branch
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -412,6 +412,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
                 // Determine the default branch on Github
                 mainBranch = repository.getDefaultBranch();
             } catch (IOException e) {
+                LOG.error("Unable to retrieve default branch for repository " + repositoryId);
                 return null;
             }
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -419,7 +419,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
         // Determine which branch to use for tool info
         if (entry.getDefaultVersion() != null) {
-            mainBranch = entry.getDefaultVersion();
+            mainBranch = getBranchNameFromDefaultVersion(entry);
         }
 
         return mainBranch;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
@@ -232,7 +232,7 @@ public class GitLabSourceCodeRepo extends SourceCodeRepoInterface {
     @Override
     public String getMainBranch(Entry entry, String repositoryId) {
         if (entry.getDefaultVersion() != null) {
-            return entry.getDefaultVersion();
+            return getBranchNameFromDefaultVersion(entry);
         } else {
             String projectsUrl = GITLAB_API_URL + "projects";
             // I think I have to pass tokens with ?private_token=...

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -229,8 +229,8 @@ public abstract class SourceCodeRepoInterface {
 
             // Find filepath to parse
             for (Tag tag : ((Tool)entry).getVersions()) {
-                if ((entry.getDefaultVersion() == null && tag.getReference() != null && tag.getReference().equals(branch)) ||
-                        (entry.getDefaultVersion() != null && tag.getName() != null && tag.getName().equals(branch))) {
+                if ((entry.getDefaultVersion() == null && tag.getReference() != null && tag.getReference().equals(branch))
+                        || (entry.getDefaultVersion() != null && tag.getName() != null && tag.getName().equals(branch))) {
                     sourceFiles = tag.getSourceFiles();
                     if (type == AbstractEntryClient.Type.CWL) {
                         filePath = tag.getCwlPath();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -208,7 +209,6 @@ public abstract class SourceCodeRepoInterface {
             return entry;
         }
 
-        // for tools if a default version is set, this actually returns the tag name and not the tag repository
         String branch = getMainBranch(entry, repositoryId);
 
         if (branch == null) {
@@ -229,8 +229,7 @@ public abstract class SourceCodeRepoInterface {
 
             // Find filepath to parse
             for (Tag tag : ((Tool)entry).getVersions()) {
-                if ((entry.getDefaultVersion() == null && tag.getReference() != null && tag.getReference().equals(branch))
-                        || (entry.getDefaultVersion() != null && tag.getName() != null && tag.getName().equals(branch))) {
+                if (tag.getReference() != null && tag.getReference().equals(branch)) {
                     sourceFiles = tag.getSourceFiles();
                     if (type == AbstractEntryClient.Type.CWL) {
                         filePath = tag.getCwlPath();
@@ -305,6 +304,29 @@ public abstract class SourceCodeRepoInterface {
      * @return content of a file from git host
      */
     public abstract String getFileContents(String filePath, String branch, String repositoryId);
+
+    /**
+     * Returns the branch name for the default version
+     * @param entry
+     * @return
+     */
+    public String getBranchNameFromDefaultVersion(Entry entry) {
+        String defaultVersion = entry.getDefaultVersion();
+        if (entry instanceof Tool) {
+            for (Tag tag : ((Tool)entry).getVersions()) {
+                if (Objects.equals(tag.getName(), defaultVersion)) {
+                    return tag.getReference();
+                }
+            }
+        } else if (entry instanceof Workflow) {
+            for (WorkflowVersion workflowVersion : ((Workflow)entry).getVersions()) {
+                if (Objects.equals(workflowVersion.getName(), defaultVersion)) {
+                    return workflowVersion.getReference();
+                }
+            }
+        }
+        return null;
+    }
 
     /**
      * Initializes workflow version for given branch

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -208,6 +208,7 @@ public abstract class SourceCodeRepoInterface {
             return entry;
         }
 
+        // for tools if a default version is set, this actually returns the tag name and not the tag repository
         String branch = getMainBranch(entry, repositoryId);
 
         if (branch == null) {
@@ -228,7 +229,8 @@ public abstract class SourceCodeRepoInterface {
 
             // Find filepath to parse
             for (Tag tag : ((Tool)entry).getVersions()) {
-                if (tag.getReference() != null && tag.getReference().equals(branch)) {
+                if ((entry.getDefaultVersion() == null && tag.getReference() != null && tag.getReference().equals(branch)) ||
+                        (entry.getDefaultVersion() != null && tag.getName() != null && tag.getName().equals(branch))) {
                     sourceFiles = tag.getSourceFiles();
                     if (type == AbstractEntryClient.Type.CWL) {
                         filePath = tag.getCwlPath();


### PR DESCRIPTION
Fixes the issue where if a default version is set for a tool, and has mismatched name and git reference, then the authorship and docs metadata will not be parsed.

#1419 