### PR TITLE
1422/link to test parameter file

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
@@ -144,6 +144,25 @@ public abstract class GA4GHIT {
         assertDescriptor(MAPPER.writeValueAsString(responseObject));
     }
 
+    // Use relative-paths endpoint to return of the test parameter file
+    @Test
+    public void toolsIdVersionsVersionIdTypeDescriptorRelativePathTestFile() throws Exception {
+        Response response = checkedResponse(
+            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_CWL_FILE/descriptor/%2Ftest.cwl.json");
+        String responseObject = response.readEntity(String.class);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(responseObject.equals("potato"));
+        Response response2 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_CWL_FILE/descriptor/%2Ftest.potato.json").request().get();
+        assertThat(response2.getStatus()).isEqualTo(204);
+        Response response3 = checkedResponse(
+            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_WDL_FILE/descriptor/%2Ftest.wdl.json");
+        String responseObject3 = response3.readEntity(String.class);
+        assertThat(response3.getStatus()).isEqualTo(200);
+        assertThat(responseObject3.equals("potato"));
+        Response response4 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_WDL_FILE/descriptor/%2Ftest.potato.json").request().get();
+        assertThat(response4.getStatus()).isEqualTo(204);
+    }
+
     private void toolsIdVersionsVersionIdTypeDescriptorRelativePathMissingSlash() throws Exception {
         Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/Dockstore.cwl");
         ToolDescriptor responseObject = response.readEntity(ToolDescriptor.class);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 
 import static io.dockstore.common.CommonTestUtilities.WAIT_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author gluu
@@ -196,6 +197,17 @@ public abstract class GA4GHIT {
         String responseObject3 = response3.readEntity(String.class);
         assertThat(response3.getStatus()).isEqualTo(200);
         assertThat(responseObject3.equals("potato"));
+
+        Response response4 = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/TEST_CWL_FILE/descriptor/%2Fnested%2Ftest.cwl.json");
+        ToolTests responseObject4 = response4.readEntity(ToolTests.class);
+        assertEquals(200, response4.getStatus());
+        assertEquals("nestedPotato", responseObject4.getTest());
+        Response response5 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/TEST_WDL_FILE/descriptor/%2Ftest.potato.json").request().get();
+        assertEquals(204, response5.getStatus());
+        Response response6 = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/TEST_CWL_FILE/descriptor/%2Ftest.cwl.json");
+        ToolTests responseObject6 = response6.readEntity(ToolTests.class);
+        assertEquals(200, response6.getStatus());
+        assertEquals("potato", responseObject6.getTest());
     }
 
     private void toolsIdVersionsVersionIdTypeDescriptorRelativePathMissingSlash() throws Exception {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
@@ -145,9 +145,18 @@ public abstract class GA4GHIT {
         assertDescriptor(MAPPER.writeValueAsString(responseObject));
     }
 
-    // Use relative-paths endpoint to return of the test parameter file
+    //
+
+    /**
+     * Tests GET /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path} with:
+     * Tool with nested cwl test parameter file
+     * Tool with non-existent cwl test parameter file
+     * Tool with nested wdl test parameter file
+     * Tool with non-existent wdl test parameter file
+     * @throws Exception
+     */
     @Test
-    public void toolsIdVersionsVersionIdTypeDescriptorRelativePathTestFile() throws Exception {
+    public void RelativePathEndpointToolTestParameterFile() throws Exception {
         Response response = checkedResponse(
             basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_CWL_FILE/descriptor/%2Fnested%2Ftest.cwl.json");
         String responseObject = response.readEntity(String.class);
@@ -165,13 +174,14 @@ public abstract class GA4GHIT {
     }
 
     /**
-     * This tests if the 4 workflows with a combination of different repositories and either same or matching workflow name
-     * can be retrieved separately.  In the test database, the author happens to uniquely identify the workflows.
-     *
+     * Tests GET /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path} with:
+     * Workflow with nested cwl test parameter file
+     * Workflow with non-existent wdl test parameter file
+     * Workflow with non-nested cwl test parameter file
      * @throws Exception
      */
     @Test
-    public void toolsIdGetstff() throws Exception {
+    public void RelativePathEndpointWorkflowTestParameterFile() throws Exception {
         // Insert the 4 workflows into the database using migrations
         CommonTestUtilities.setupTestWorkflow(SUPPORT);
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
@@ -147,7 +147,7 @@ public abstract class GA4GHIT {
     }
 
     /**
-     * Tests GET /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path} with:
+     * Tests PLAIN GET /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path} with:
      * Tool with nested cwl test parameter file
      * Tool with non-existent cwl test parameter file
      * Tool with nested wdl test parameter file
@@ -155,21 +155,42 @@ public abstract class GA4GHIT {
      * @throws Exception
      */
     @Test
-    public void RelativePathEndpointToolTestParameterFile() throws Exception {
+    public void RelativePathEndpointToolTestParameterFilePLAIN() {
         Response response = checkedResponse(
             basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_CWL/descriptor/%2Fnested%2Ftest.cwl.json");
         String responseObject = response.readEntity(String.class);
-        assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(responseObject.equals("potato"));
+        assertEquals(200, response.getStatus());
+        assertEquals("nestedPotato", responseObject);
         Response response2 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_CWL/descriptor/%2Ftest.potato.json").request().get();
-        assertThat(response2.getStatus()).isEqualTo(404);
+        assertEquals(404, response2.getStatus());
         Response response3 = checkedResponse(
             basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_WDL/descriptor/%2Fnested%2Ftest.wdl.json");
         String responseObject3 = response3.readEntity(String.class);
-        assertThat(response3.getStatus()).isEqualTo(200);
-        assertThat(responseObject3.equals("potato"));
+        assertEquals(200, response3.getStatus());
+        assertEquals("nestedPotato", responseObject3);
         Response response4 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_WDL/descriptor/%2Ftest.potato.json").request().get();
-        assertThat(response4.getStatus()).isEqualTo(404);
+        assertEquals(404, response4.getStatus());
+    }
+
+    /**
+     * Tests JSON GET /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path} with:
+     * Tool with nested cwl test parameter file
+     * Tool with non-existent cwl test parameter file
+     * Tool with nested wdl test parameter file
+     * Tool with non-existent wdl test parameter file
+     */
+    @Test
+    public void RelativePathEndpointToolTestParameterFileJSON() {
+        Response response = checkedResponse(
+            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
+        ToolTests responseObject = response.readEntity(ToolTests.class);
+        assertEquals(200, response.getStatus());
+        assertEquals("nestedPotato", responseObject.getTest());
+        Response response2 = checkedResponse(
+            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/descriptor/%2Fnested%2Ftest.wdl.json");
+        ToolTests responseObject2 = response2.readEntity(ToolTests.class);
+        assertEquals(200, response2.getStatus());
+        assertEquals("nestedPotato", responseObject2.getTest());
     }
 
     /**
@@ -178,48 +199,62 @@ public abstract class GA4GHIT {
      * @throws Exception
      */
     @Test
-    public void RelativePathEndpointToolContainerfile() throws Exception {
+    public void RelativePathEndpointToolContainerfile() {
         Response response = checkedResponse(
             basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_CWL/descriptor/%2FDockerfile");
         String responseObject = response.readEntity(String.class);
-        assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(responseObject.equals("potato"));
+        assertEquals(200, response.getStatus());
+        assertEquals("potato", responseObject);
     }
 
     /**
-     * Tests GET /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path} with:
+     * Tests PLAIN GET /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path} with:
      * Workflow with nested cwl test parameter file
      * Workflow with non-existent wdl test parameter file
      * Workflow with non-nested cwl test parameter file
      * @throws Exception
      */
     @Test
-    public void RelativePathEndpointWorkflowTestParameterFile() throws Exception {
+    public void RelativePathEndpointWorkflowTestParameterFilePLAIN() throws Exception {
         // Insert the 4 workflows into the database using migrations
         CommonTestUtilities.setupTestWorkflow(SUPPORT);
 
         // Check responses
         Response response = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor/%2Fnested%2Ftest.cwl.json");
         String responseObject = response.readEntity(String.class);
-        assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(responseObject.equals("nestedPotato"));
+        assertEquals(200, response.getStatus());
+        assertEquals("nestedPotato", responseObject);
         Response response2 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_WDL/descriptor/%2Ftest.potato.json").request().get();
-        assertThat(response2.getStatus()).isEqualTo(404);
+        assertEquals(404, response2.getStatus());
         Response response3 = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor/%2Ftest.cwl.json");
         String responseObject3 = response3.readEntity(String.class);
-        assertThat(response3.getStatus()).isEqualTo(200);
-        assertThat(responseObject3.equals("potato"));
+        assertEquals(200, response3.getStatus());
+        assertEquals("potato", responseObject3);
+    }
 
-        Response response4 = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
-        ToolTests responseObject4 = response4.readEntity(ToolTests.class);
-        assertEquals(200, response4.getStatus());
-        assertEquals("nestedPotato", responseObject4.getTest());
-        Response response5 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/descriptor/%2Ftest.potato.json").request().get();
-        assertEquals(404, response5.getStatus());
-        Response response6 = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
-        ToolTests responseObject6 = response6.readEntity(ToolTests.class);
-        assertEquals(200, response6.getStatus());
-        assertEquals("potato", responseObject6.getTest());
+    /**
+     * Tests JSON GET /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path} with:
+     * Workflow with nested cwl test parameter file
+     * Workflow with non-existent wdl test parameter file
+     * Workflow with non-nested cwl test parameter file
+     * @throws Exception
+     */
+    @Test
+    public void RelativePathEndpointWorkflowTestParameterFileJSON() throws Exception {
+        // Insert the 4 workflows into the database using migrations
+        CommonTestUtilities.setupTestWorkflow(SUPPORT);
+
+        // Check responses
+        Response response = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
+        ToolTests responseObject = response.readEntity(ToolTests.class);
+        assertEquals(200, response.getStatus());
+        assertEquals("nestedPotato", responseObject.getTest());
+        Response response2 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/descriptor/%2Ftest.potato.json").request().get();
+        assertEquals(404, response2.getStatus());
+        Response response3 = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
+        ToolTests responseObject3 = response3.readEntity(ToolTests.class);
+        assertEquals(200, response3.getStatus());
+        assertEquals("potato", responseObject3.getTest());
     }
 
     private void toolsIdVersionsVersionIdTypeDescriptorRelativePathMissingSlash() throws Exception {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
@@ -146,8 +146,6 @@ public abstract class GA4GHIT {
         assertDescriptor(MAPPER.writeValueAsString(responseObject));
     }
 
-    //
-
     /**
      * Tests GET /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path} with:
      * Tool with nested cwl test parameter file
@@ -159,19 +157,33 @@ public abstract class GA4GHIT {
     @Test
     public void RelativePathEndpointToolTestParameterFile() throws Exception {
         Response response = checkedResponse(
-            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_CWL_FILE/descriptor/%2Fnested%2Ftest.cwl.json");
+            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_CWL/descriptor/%2Fnested%2Ftest.cwl.json");
         String responseObject = response.readEntity(String.class);
         assertThat(response.getStatus()).isEqualTo(200);
         assertThat(responseObject.equals("potato"));
-        Response response2 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_CWL_FILE/descriptor/%2Ftest.potato.json").request().get();
-        assertThat(response2.getStatus()).isEqualTo(204);
+        Response response2 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_CWL/descriptor/%2Ftest.potato.json").request().get();
+        assertThat(response2.getStatus()).isEqualTo(404);
         Response response3 = checkedResponse(
-            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_WDL_FILE/descriptor/%2Fnested%2Ftest.wdl.json");
+            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_WDL/descriptor/%2Fnested%2Ftest.wdl.json");
         String responseObject3 = response3.readEntity(String.class);
         assertThat(response3.getStatus()).isEqualTo(200);
         assertThat(responseObject3.equals("potato"));
-        Response response4 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_WDL_FILE/descriptor/%2Ftest.potato.json").request().get();
-        assertThat(response4.getStatus()).isEqualTo(204);
+        Response response4 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_WDL/descriptor/%2Ftest.potato.json").request().get();
+        assertThat(response4.getStatus()).isEqualTo(404);
+    }
+
+    /**
+     * Tests GET /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path} with:
+     * Tool with a dockerfile
+     * @throws Exception
+     */
+    @Test
+    public void RelativePathEndpointToolContainerfile() throws Exception {
+        Response response = checkedResponse(
+            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_CWL/descriptor/%2FDockerfile");
+        String responseObject = response.readEntity(String.class);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(responseObject.equals("potato"));
     }
 
     /**
@@ -187,24 +199,24 @@ public abstract class GA4GHIT {
         CommonTestUtilities.setupTestWorkflow(SUPPORT);
 
         // Check responses
-        Response response = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_TEST_CWL_FILE/descriptor/%2Fnested%2Ftest.cwl.json");
+        Response response = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor/%2Fnested%2Ftest.cwl.json");
         String responseObject = response.readEntity(String.class);
         assertThat(response.getStatus()).isEqualTo(200);
         assertThat(responseObject.equals("nestedPotato"));
-        Response response2 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_WDL_FILE/descriptor/%2Ftest.potato.json").request().get();
-        assertThat(response2.getStatus()).isEqualTo(204);
-        Response response3 = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_TEST_CWL_FILE/descriptor/%2Ftest.cwl.json");
+        Response response2 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_WDL/descriptor/%2Ftest.potato.json").request().get();
+        assertThat(response2.getStatus()).isEqualTo(404);
+        Response response3 = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor/%2Ftest.cwl.json");
         String responseObject3 = response3.readEntity(String.class);
         assertThat(response3.getStatus()).isEqualTo(200);
         assertThat(responseObject3.equals("potato"));
 
-        Response response4 = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/TEST_CWL_FILE/descriptor/%2Fnested%2Ftest.cwl.json");
+        Response response4 = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
         ToolTests responseObject4 = response4.readEntity(ToolTests.class);
         assertEquals(200, response4.getStatus());
         assertEquals("nestedPotato", responseObject4.getTest());
-        Response response5 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/TEST_WDL_FILE/descriptor/%2Ftest.potato.json").request().get();
-        assertEquals(204, response5.getStatus());
-        Response response6 = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/TEST_CWL_FILE/descriptor/%2Ftest.cwl.json");
+        Response response5 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/descriptor/%2Ftest.potato.json").request().get();
+        assertEquals(404, response5.getStatus());
+        Response response6 = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
         ToolTests responseObject6 = response6.readEntity(ToolTests.class);
         assertEquals(200, response6.getStatus());
         assertEquals("potato", responseObject6.getTest());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
@@ -30,6 +30,7 @@ import io.dropwizard.testing.DropwizardTestSupport;
 import io.swagger.client.model.ToolDescriptor;
 import io.swagger.client.model.ToolTests;
 import io.swagger.model.Error;
+import io.swagger.model.Tool;
 import org.apache.http.HttpStatus;
 import org.glassfish.jersey.client.ClientProperties;
 import org.junit.AfterClass;
@@ -148,19 +149,43 @@ public abstract class GA4GHIT {
     @Test
     public void toolsIdVersionsVersionIdTypeDescriptorRelativePathTestFile() throws Exception {
         Response response = checkedResponse(
-            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_CWL_FILE/descriptor/%2Ftest.cwl.json");
+            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_CWL_FILE/descriptor/%2Fnested%2Ftest.cwl.json");
         String responseObject = response.readEntity(String.class);
         assertThat(response.getStatus()).isEqualTo(200);
         assertThat(responseObject.equals("potato"));
         Response response2 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_CWL_FILE/descriptor/%2Ftest.potato.json").request().get();
         assertThat(response2.getStatus()).isEqualTo(204);
         Response response3 = checkedResponse(
-            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_WDL_FILE/descriptor/%2Ftest.wdl.json");
+            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_WDL_FILE/descriptor/%2Fnested%2Ftest.wdl.json");
         String responseObject3 = response3.readEntity(String.class);
         assertThat(response3.getStatus()).isEqualTo(200);
         assertThat(responseObject3.equals("potato"));
         Response response4 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_WDL_FILE/descriptor/%2Ftest.potato.json").request().get();
         assertThat(response4.getStatus()).isEqualTo(204);
+    }
+
+    /**
+     * This tests if the 4 workflows with a combination of different repositories and either same or matching workflow name
+     * can be retrieved separately.  In the test database, the author happens to uniquely identify the workflows.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void toolsIdGetstff() throws Exception {
+        // Insert the 4 workflows into the database using migrations
+        CommonTestUtilities.setupTestWorkflow(SUPPORT);
+
+        // Check responses
+        Response response = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_TEST_CWL_FILE/descriptor/%2Fnested%2Ftest.cwl.json");
+        String responseObject = response.readEntity(String.class);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(responseObject.equals("nestedPotato"));
+        Response response2 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_WDL_FILE/descriptor/%2Ftest.potato.json").request().get();
+        assertThat(response2.getStatus()).isEqualTo(204);
+        Response response3 = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_TEST_CWL_FILE/descriptor/%2Ftest.cwl.json");
+        String responseObject3 = response3.readEntity(String.class);
+        assertThat(response3.getStatus()).isEqualTo(200);
+        assertThat(responseObject3.equals("potato"));
     }
 
     private void toolsIdVersionsVersionIdTypeDescriptorRelativePathMissingSlash() throws Exception {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2IT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2IT.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author gluu
@@ -144,15 +145,22 @@ public class GA4GHV2IT extends GA4GHIT {
     /**
      * Tests GET /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path} with:
      * Tool with non-encoded nested cwl test parameter file
+     * Tool with non-encoded non-nested cwl test parameter file
      * @throws Exception
      */
     @Test
-    public void RelativePathEndpointToolTestParameterFileEscaped() throws Exception {
-        Response response5 = checkedResponse(
+    public void RelativePathEndpointToolTestParameterFileNoEncode() {
+        Response response = checkedResponse(
             basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_CWL/descriptor//nested/test.cwl.json");
-        String responseObject5= response5.readEntity(String.class);
-        assertThat(response5.getStatus()).isEqualTo(200);
-        assertThat(responseObject5.equals("potato"));
+        String responseObject = response.readEntity(String.class);
+        assertEquals(200, response.getStatus());
+        assertEquals("nestedPotato", responseObject);
+
+        Response response2 = checkedResponse(
+            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_CWL/descriptor//test.cwl.json");
+        String responseObject2 = response2.readEntity(String.class);
+        assertEquals(200, response2.getStatus());
+        assertEquals("potato", responseObject2);
     }
 
     /**
@@ -162,21 +170,19 @@ public class GA4GHV2IT extends GA4GHIT {
      * @throws Exception
      */
     @Test
-    public void RelativePathEndpointWorkflowTestParameterFileEscaped() throws Exception {
+    public void RelativePathEndpointWorkflowTestParameterFileNoEncode() throws Exception {
         // Insert the 4 workflows into the database using migrations
         CommonTestUtilities.setupTestWorkflow(SUPPORT);
 
         // Check responses
         Response response = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//nested/test.cwl.json");
         String responseObject = response.readEntity(String.class);
-        assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(responseObject.equals("nestedPotato"));
-        Response response2 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_WDL/descriptor/%2Ftest.potato.json").request().get();
-        assertThat(response2.getStatus()).isEqualTo(404);
-        Response response3 = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//test.cwl.json");
-        String responseObject3 = response3.readEntity(String.class);
-        assertThat(response3.getStatus()).isEqualTo(200);
-        assertThat(responseObject3.equals("potato"));
+        assertEquals(200, response.getStatus());
+        assertEquals("nestedPotato", responseObject);
+        Response response2 = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//test.cwl.json");
+        String responseObject2 = response2.readEntity(String.class);
+        assertEquals(200, response2.getStatus());
+        assertEquals("potato", responseObject2);
     }
 
     private void toolsIdVersionsVersionIdTypeFileCWL() throws Exception {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2IT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2IT.java
@@ -141,6 +141,44 @@ public class GA4GHV2IT extends GA4GHIT {
         assertDescriptor(MAPPER.writeValueAsString(responseObject));
     }
 
+    /**
+     * Tests GET /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path} with:
+     * Tool with non-encoded nested cwl test parameter file
+     * @throws Exception
+     */
+    @Test
+    public void RelativePathEndpointToolTestParameterFileEscaped() throws Exception {
+        Response response5 = checkedResponse(
+            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_CWL_FILE/descriptor//nested/test.cwl.json");
+        String responseObject5= response5.readEntity(String.class);
+        assertThat(response5.getStatus()).isEqualTo(200);
+        assertThat(responseObject5.equals("potato"));
+    }
+
+    /**
+     * Tests GET /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path} with:
+     * Workflow with non-encoded nested cwl test parameter file
+     * Workflow with non-encoded non-nested cwl test parameter file
+     * @throws Exception
+     */
+    @Test
+    public void RelativePathEndpointWorkflowTestParameterFileEscaped() throws Exception {
+        // Insert the 4 workflows into the database using migrations
+        CommonTestUtilities.setupTestWorkflow(SUPPORT);
+
+        // Check responses
+        Response response = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_TEST_CWL_FILE/descriptor//nested/test.cwl.json");
+        String responseObject = response.readEntity(String.class);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(responseObject.equals("nestedPotato"));
+        Response response2 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_WDL_FILE/descriptor/%2Ftest.potato.json").request().get();
+        assertThat(response2.getStatus()).isEqualTo(204);
+        Response response3 = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_TEST_CWL_FILE/descriptor//test.cwl.json");
+        String responseObject3 = response3.readEntity(String.class);
+        assertThat(response3.getStatus()).isEqualTo(200);
+        assertThat(responseObject3.equals("potato"));
+    }
+
     private void toolsIdVersionsVersionIdTypeFileCWL() throws Exception {
         Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/files");
         List<ToolFile> responseObject = response.readEntity(new GenericType<List<ToolFile>>() {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2IT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2IT.java
@@ -149,7 +149,7 @@ public class GA4GHV2IT extends GA4GHIT {
     @Test
     public void RelativePathEndpointToolTestParameterFileEscaped() throws Exception {
         Response response5 = checkedResponse(
-            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_CWL_FILE/descriptor//nested/test.cwl.json");
+            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_CWL/descriptor//nested/test.cwl.json");
         String responseObject5= response5.readEntity(String.class);
         assertThat(response5.getStatus()).isEqualTo(200);
         assertThat(responseObject5.equals("potato"));
@@ -167,13 +167,13 @@ public class GA4GHV2IT extends GA4GHIT {
         CommonTestUtilities.setupTestWorkflow(SUPPORT);
 
         // Check responses
-        Response response = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_TEST_CWL_FILE/descriptor//nested/test.cwl.json");
+        Response response = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//nested/test.cwl.json");
         String responseObject = response.readEntity(String.class);
         assertThat(response.getStatus()).isEqualTo(200);
         assertThat(responseObject.equals("nestedPotato"));
-        Response response2 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_TEST_WDL_FILE/descriptor/%2Ftest.potato.json").request().get();
-        assertThat(response2.getStatus()).isEqualTo(204);
-        Response response3 = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_TEST_CWL_FILE/descriptor//test.cwl.json");
+        Response response2 = client.target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_WDL/descriptor/%2Ftest.potato.json").request().get();
+        assertThat(response2.getStatus()).isEqualTo(404);
+        Response response3 = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//test.cwl.json");
         String responseObject3 = response3.readEntity(String.class);
         assertThat(response3.getStatus()).isEqualTo(200);
         assertThat(responseObject3.equals("potato"));

--- a/dockstore-integration-testing/src/test/resources/fixtures/cwlFiles.json
+++ b/dockstore-integration-testing/src/test/resources/fixtures/cwlFiles.json
@@ -6,9 +6,10 @@
   {
     "path": "\/Dockstore.cwl",
     "file_type": "PRIMARY_DESCRIPTOR"
-  },
+  },{"file_type":"TEST_FILE","path":"/nested/test.cwl.json"},
   {
     "path": "\/test.cwl.json",
     "file_type": "TEST_FILE"
   }
+
 ]

--- a/dockstore-integration-testing/src/test/resources/fixtures/wdlFiles.json
+++ b/dockstore-integration-testing/src/test/resources/fixtures/wdlFiles.json
@@ -6,7 +6,7 @@
   {
     "path": "\/Dockstore.wdl",
     "file_type": "PRIMARY_DESCRIPTOR"
-  },
+  },{"file_type":"TEST_FILE","path":"/nested/test.wdl.json"},
   {
     "path": "\/test.wdl.json",
     "file_type": "TEST_FILE"

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
@@ -440,9 +440,13 @@ public class ToolsApiServiceImpl extends ToolsApiService {
                 }
 
                 // If there's a relative path specified, only keep the file(s) that match the path specified
-                if (!relativePath.isEmpty() || relativePath != null) {
-                    testSourceFiles.removeIf(sourceFile -> !sourceFile.getPath().equals(relativePath));
-                    if (testSourceFiles.isEmpty()) {
+                if (relativePath != null) {
+                    Optional<SourceFile> sourceFile = testSourceFiles.stream().filter(file -> file.getPath().equals(relativePath)).findFirst();
+                    if (sourceFile.isPresent()) {
+                        ToolTests toolTest = ToolsImplCommon.sourceFileToToolTests(sourceFile.get());
+                        return Response.status(Response.Status.OK).type(unwrap ? MediaType.TEXT_PLAIN : MediaType.APPLICATION_JSON).entity(
+                            unwrap ? toolTest.getTest() : toolTest).build();
+                    } else {
                         return Response.status(Response.Status.NO_CONTENT).build();
                     }
                 }

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
@@ -477,10 +477,10 @@ public class ToolsApiServiceImpl extends ToolsApiService {
                         final SourceFile entity = first1.get();
                         ToolDescriptor toolDescriptor = ToolsImplCommon.sourceFileToToolDescriptor(entity);
                         if (toolDescriptor == null) {
-                            // Then this source file is probably not a descriptor!  Let's try test parameter file
+                            // Then this source file is probably not a descriptor.  Trying test parameter file
                             ToolTests toolTest = ToolsImplCommon.sourceFileToToolTests(entity);
                             if (toolTest == null) {
-                                // Then this source file is probably not a descriptor!  Let's try container file
+                                // Then this source file is probably not a test parameter file either.  Trying containerfile...
                                 final ToolContainerfile toolContainerfile = (ToolContainerfile)table.get(toolVersionName, SourceFile.FileType.DOCKERFILE);
                                 if (!toolContainerfile.getUrl().contains(relativePath)) {
                                     // Congrats on making it here, not sure how that was possible

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
@@ -251,8 +251,9 @@ public class ToolsApiServiceImpl extends ToolsApiService {
 
     @Override
     public Response toolsIdVersionsVersionIdContainerfileGet(String id, String versionId, SecurityContext securityContext,
-        ContainerRequestContext value) throws NotFoundException {
-        return getFileByToolVersionID(id, versionId, DOCKERFILE, null, value.getAcceptableMediaTypes().contains(MediaType.TEXT_PLAIN_TYPE));
+        ContainerRequestContext value) {
+        boolean unwrap = !value.getAcceptableMediaTypes().contains(MediaType.APPLICATION_JSON_TYPE);
+        return getFileByToolVersionID(id, versionId, DOCKERFILE, null, unwrap);
     }
 
     @SuppressWarnings("CheckStyle")

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
@@ -229,7 +229,11 @@ public class ToolsApiServiceImpl extends ToolsApiService {
 
     private SourceFile.FileType getFileType(String format) {
         SourceFile.FileType type;
-        if (StringUtils.containsIgnoreCase(format, "CWL")) {
+        if (StringUtils.containsIgnoreCase(format, "TEST_CWL")) {
+            type = SourceFile.FileType.CWL_TEST_JSON;
+        } else if (StringUtils.containsIgnoreCase(format, "TEST_WDL")) {
+            type = SourceFile.FileType.WDL_TEST_JSON;
+        } else if (StringUtils.containsIgnoreCase(format, "CWL")) {
             type = DOCKSTORE_CWL;
         } else if (StringUtils.containsIgnoreCase(format, "WDL")) {
             type = DOCKSTORE_WDL;
@@ -432,6 +436,14 @@ public class ToolsApiServiceImpl extends ToolsApiService {
                     testSourceFiles.addAll(workflowHelper.getAllSourceFiles(entry.getId(), versionId, type));
                 } catch (CustomWebApplicationException e) {
 
+                }
+
+                // If there's a relative path specified, only keep the file(s) that match the path specified
+                if (!relativePath.isEmpty() || relativePath != null) {
+                    testSourceFiles.removeIf(sourceFile -> !sourceFile.getPath().equals(relativePath));
+                    if (testSourceFiles.isEmpty()) {
+                        return Response.status(Response.Status.NO_CONTENT).build();
+                    }
                 }
 
                 List<ToolTests> toolTestsList = new ArrayList<>();

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
@@ -229,11 +229,7 @@ public class ToolsApiServiceImpl extends ToolsApiService {
 
     private SourceFile.FileType getFileType(String format) {
         SourceFile.FileType type;
-        if (StringUtils.containsIgnoreCase(format, "TEST_CWL")) {
-            type = SourceFile.FileType.CWL_TEST_JSON;
-        } else if (StringUtils.containsIgnoreCase(format, "TEST_WDL")) {
-            type = SourceFile.FileType.WDL_TEST_JSON;
-        } else if (StringUtils.containsIgnoreCase(format, "CWL")) {
+        if (StringUtils.containsIgnoreCase(format, "CWL")) {
             type = DOCKSTORE_CWL;
         } else if (StringUtils.containsIgnoreCase(format, "WDL")) {
             type = DOCKSTORE_WDL;

--- a/dockstore-webservice/src/main/resources/migrations.test.testworkflow.xml
+++ b/dockstore-webservice/src/main/resources/migrations.test.testworkflow.xml
@@ -36,6 +36,18 @@
             <column name="path" value="cwl/tar-param.cwl"/>
             <column name="type" value="DOCKSTORE_CWL"/>
         </insert>
+        <insert tableName="sourcefile">
+            <column name="id" valueNumeric="35"/>
+            <column name="content" value="potato"/>
+            <column name="path" value="/test.cwl.json"/>
+            <column name="type" value="CWL_TEST_JSON"/>
+        </insert>
+        <insert tableName="sourcefile">
+            <column name="id" valueNumeric="36"/>
+            <column name="content" value="nestedPotato"/>
+            <column name="path" value="/nested/test.cwl.json"/>
+            <column name="type" value="CWL_TEST_JSON"/>
+        </insert>
     </changeSet>
     <changeSet author="gluu (generated)" id="1518537418938-110">
         <insert tableName="version_sourcefile">
@@ -49,6 +61,14 @@
         <insert tableName="version_sourcefile">
             <column name="versionid" valueNumeric="32"/>
             <column name="sourcefileid" valueNumeric="34"/>
+        </insert>
+        <insert tableName="version_sourcefile">
+            <column name="versionid" valueNumeric="32"/>
+            <column name="sourcefileid" valueNumeric="35"/>
+        </insert>
+        <insert tableName="version_sourcefile">
+            <column name="versionid" valueNumeric="32"/>
+            <column name="sourcefileid" valueNumeric="36"/>
         </insert>
     </changeSet>
     <changeSet author="gluu (generated)" id="1518537418938-111">

--- a/dockstore-webservice/src/main/resources/migrations.test.xml
+++ b/dockstore-webservice/src/main/resources/migrations.test.xml
@@ -349,6 +349,18 @@
             <column name="path" value="/test.wdl.json"/>
             <column name="type" value="NEXTFLOW_TEST_PARAMS"/>
         </insert>
+        <insert tableName="sourcefile">
+            <column name="id" valueNumeric="9009"/>
+            <column name="content" value="nestedPotato"/>
+            <column name="path" value="/nested/test.cwl.json"/>
+            <column name="type" value="CWL_TEST_JSON"/>
+        </insert>
+        <insert tableName="sourcefile">
+            <column name="id" valueNumeric="9010"/>
+            <column name="content" value="nestedPotato"/>
+            <column name="path" value="/nested/test.wdl.json"/>
+            <column name="type" value="WDL_TEST_JSON"/>
+        </insert>
     </changeSet>
     <changeSet author="gluu" id="insert_version_sourcefiles">
         <insert tableName="version_sourcefile">
@@ -382,6 +394,14 @@
         <insert tableName="version_sourcefile">
             <column name="versionid" valueNumeric="1"/>
             <column name="sourcefileid" value="9008"/>
+        </insert>
+        <insert tableName="version_sourcefile">
+            <column name="versionid" valueNumeric="1"/>
+            <column name="sourcefileid" value="9009"/>
+        </insert>
+        <insert tableName="version_sourcefile">
+            <column name="versionid" valueNumeric="1"/>
+            <column name="sourcefileid" value="9010"/>
         </insert>
     </changeSet>
     <changeSet author="dyuen" id="custom_test_sequence1">


### PR DESCRIPTION
For issue #1422 

Change the "default" of the /containerfile endpoint to return plain text so that using the link from the browser or wget returns plain text.

relative-paths endpoint now handles containerfile and test parameter files too