### PR TITLE
Features/1373/dos file provisioner preProvisionInterface

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/PluginClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/PluginClient.java
@@ -15,6 +15,7 @@
  */
 package io.dockstore.client.cli;
 
+import java.util.Collections;
 import java.util.List;
 
 import avro.shaded.com.google.common.base.Joiner;
@@ -24,6 +25,7 @@ import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 import io.dockstore.common.FileProvisionUtil;
 import io.dockstore.common.TabExpansionUtil;
+import io.dockstore.provision.PreProvisionInterface;
 import io.dockstore.provision.ProvisionInterface;
 import org.apache.commons.configuration2.INIConfiguration;
 import org.slf4j.Logger;
@@ -98,7 +100,7 @@ public final class PluginClient {
         PluginManager pluginManager = FileProvisionUtil.getPluginManager(configFile);
         List<PluginWrapper> plugins = pluginManager.getStartedPlugins();
         StringBuilder builder = new StringBuilder();
-        builder.append("PluginId\tPlugin Version\tPlugin Path\tSchemes handled\n");
+        builder.append("PluginId\tPlugin Version\tPlugin Path\tSchemes handled\tPlugin Type\n");
         for (PluginWrapper plugin : plugins) {
             builder.append(plugin.getPluginId());
             builder.append("\t");
@@ -108,7 +110,12 @@ public final class PluginClient {
                     .append("(.zip)");
             builder.append("\t");
             List<ProvisionInterface> extensions = pluginManager.getExtensions(ProvisionInterface.class, plugin.getPluginId());
+            List<PreProvisionInterface> preProvisionExtensions = pluginManager.getExtensions(PreProvisionInterface.class, plugin.getPluginId());
             extensions.forEach(extension -> Joiner.on(',').appendTo(builder, extension.schemesHandled()));
+            preProvisionExtensions.forEach(extension -> Joiner.on(',').appendTo(builder, extension.schemesHandled()));
+            builder.append("\t");
+            extensions.forEach(extension -> Joiner.on(',').appendTo(builder, Collections.singleton("Normal")));
+            preProvisionExtensions.forEach(extension -> Joiner.on(',').appendTo(builder, Collections.singleton("PreProvision")));
             builder.append("\n");
         }
         out(TabExpansionUtil.aligned(builder.toString()));

--- a/dockstore-client/src/main/java/io/dockstore/common/FileProvisioning.java
+++ b/dockstore-client/src/main/java/io/dockstore/common/FileProvisioning.java
@@ -278,8 +278,8 @@ public class FileProvisioning {
                 Optional<ImmutablePair<String, String>> newTarget = findSupportedTargetPath(plugins, list);
                 if (newTarget.isPresent()) {
                     ImmutablePair<String, String> immutablePair = newTarget.get();
-                    targetPath = immutablePair.right;
-                    scheme = immutablePair.left;
+                    targetPath = immutablePair.left;
+                    scheme = immutablePair.right;
                     break;
                 }
             }

--- a/dockstore-client/src/main/java/io/dockstore/common/FileProvisioning.java
+++ b/dockstore-client/src/main/java/io/dockstore/common/FileProvisioning.java
@@ -379,14 +379,20 @@ public class FileProvisioning {
      */
     static Optional<ImmutablePair<String, String>> findSupportedTargetPath(List<ProvisionInterface> pluginList, List<String> targetPaths) {
         for (String target : targetPaths) {
-            URI objectIdentifier = URI.create(target);    // throws IllegalArgumentException if it isn't a valid URI
-            String scheme = objectIdentifier.getScheme().toLowerCase();
-            if (scheme != null) {
-                for (ProvisionInterface provisionInterface : pluginList) {
-                    if (StringUtils.containsIgnoreCase(provisionInterface.schemesHandled().iterator().next(), scheme)) {
-                        return Optional.of(new ImmutablePair<>(target, scheme));
+            try {
+                URI objectIdentifier = URI.create(target);    // throws IllegalArgumentException if it isn't a valid URI
+                String scheme = (objectIdentifier.getScheme() != null) ? objectIdentifier.getScheme().toLowerCase() : null;
+                if (scheme != null) {
+                    for (ProvisionInterface provisionInterface : pluginList) {
+                        for (String currentScheme : provisionInterface.schemesHandled()) {
+                            if (StringUtils.containsIgnoreCase(currentScheme, scheme)) {
+                                return Optional.of(new ImmutablePair<>(target, scheme));
+                            }
+                        }
                     }
                 }
+            } catch (IllegalArgumentException e) {
+                LOG.info("Bad target");
             }
         }
         return Optional.empty();

--- a/dockstore-client/src/main/java/io/dockstore/common/FileProvisioning.java
+++ b/dockstore-client/src/main/java/io/dockstore/common/FileProvisioning.java
@@ -49,6 +49,7 @@ import org.apache.commons.configuration2.INIConfiguration;
 import org.apache.commons.configuration2.SubnodeConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.vfs2.AllFileSelector;
@@ -382,8 +383,7 @@ public class FileProvisioning {
             String scheme = objectIdentifier.getScheme().toLowerCase();
             if (scheme != null) {
                 for (ProvisionInterface provisionInterface : pluginList) {
-                    if (provisionInterface.schemesHandled().contains(scheme.toUpperCase()) || provisionInterface.schemesHandled()
-                            .contains(scheme.toLowerCase())) {
+                    if (StringUtils.containsIgnoreCase(provisionInterface.schemesHandled().iterator().next(), scheme)) {
                         return Optional.of(new ImmutablePair<>(target, scheme));
                     }
                 }

--- a/dockstore-client/src/test/java/io/dockstore/common/FileProvisionTest.java
+++ b/dockstore-client/src/test/java/io/dockstore/common/FileProvisionTest.java
@@ -1,0 +1,35 @@
+package io.dockstore.common;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+
+import io.dockstore.provision.ProvisionInterface;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class FileProvisionTest {
+
+    @Test
+    public void testFindSupportedTargetPath() {
+        ProvisionInterface s3Mock = Mockito.mock(ProvisionInterface.class);
+        when(s3Mock.schemesHandled()).thenReturn(new HashSet<>(Arrays.asList(new String[] {"s3"})));
+        ProvisionInterface httpMock = Mockito.mock(ProvisionInterface.class);
+        when(httpMock.schemesHandled()).thenReturn(new HashSet<>(Arrays.asList(new String[] {"http"})));
+
+        assertEquals(FileProvisioning.findSupportedTargetPath(Arrays.asList(new ProvisionInterface[] {s3Mock, httpMock}),
+                Arrays.asList(new String[] {"s3://something", "http://something"})),
+                Optional.of(new ImmutablePair<>("s3://something", "s3")));
+
+        assertEquals(FileProvisioning.findSupportedTargetPath(Arrays.asList(new ProvisionInterface[] {s3Mock, httpMock}),
+                Arrays.asList(new String[] {"http://something", "s3://something"})),
+                Optional.of(new ImmutablePair<>("http://something", "http")));
+
+        assertEquals(FileProvisioning.findSupportedTargetPath(Arrays.asList(new ProvisionInterface[] {s3Mock, httpMock}),
+                Arrays.asList(new String[] {"gcs://something"})), Optional.empty());
+    }
+}

--- a/dockstore-file-plugin-parent/src/main/java/io/dockstore/provision/PreProvisionInterface.java
+++ b/dockstore-file-plugin-parent/src/main/java/io/dockstore/provision/PreProvisionInterface.java
@@ -1,0 +1,42 @@
+package io.dockstore.provision;
+
+import java.util.List;
+
+import ro.fortsoft.pf4j.ExtensionPoint;
+
+/**
+ * Interface for preprovisioning. This is intended for schemes like the
+ * Data Object Service (https://github.com/ga4gh/data-object-service-schemas),
+ * where resolving a DOS URI returns a data object that has a list of urls, and
+ * one of those urls is what needs to be provisioned.
+ *
+ * <p>
+ *     Implementations of this interface will get called before implementations
+ *     of the {@link ProvisionInterface}, with values being returned by this
+ *     interface being passed on to <code>ProvisionInteface.downloadFrom</code>.
+ * </p>
+ */
+public interface PreProvisionInterface extends ExtensionPoint {
+
+    /**
+     * <p>
+     * Given a target path, return a list of target paths. For example, if
+     * the target path is <code>dos://GUID</code>, this might return
+     * <code>["s3://s3-url", "gs://gs-url", "http://http-url"]</code>.
+     * </p>
+     *
+     * <p>
+     * The order of the list is significant in that Dockstore will provision the first target path
+     * that a file provisioning plugin supports. In the example above, the s3 url would be provisioned
+     * even though Dockstore supports http urls, because the s3 url was first.
+     * </p>
+     *
+     * <p>
+     * The method should return an empty list if no transformation was done.
+     * </p>
+     *
+     * @param targetPath
+     * @return a list of targetPaths
+     */
+    List<String> prepareDownload(String targetPath);
+}

--- a/dockstore-file-plugin-parent/src/main/java/io/dockstore/provision/PreProvisionInterface.java
+++ b/dockstore-file-plugin-parent/src/main/java/io/dockstore/provision/PreProvisionInterface.java
@@ -43,7 +43,7 @@ public interface PreProvisionInterface extends ExtensionPoint {
 
     /**
      * Returns whether a particular file path should be handled by this plugin
-     * @return return schemes that this provision interface handles (ex: http, https, ftp, syn, icgc)
+     * @return return schemes that this preprovisioning interface handles (ex: dos)
      */
     Set<String> schemesHandled();
 }

--- a/dockstore-file-plugin-parent/src/main/java/io/dockstore/provision/PreProvisionInterface.java
+++ b/dockstore-file-plugin-parent/src/main/java/io/dockstore/provision/PreProvisionInterface.java
@@ -1,6 +1,7 @@
 package io.dockstore.provision;
 
 import java.util.List;
+import java.util.Set;
 
 import ro.fortsoft.pf4j.ExtensionPoint;
 
@@ -39,4 +40,10 @@ public interface PreProvisionInterface extends ExtensionPoint {
      * @return a list of targetPaths
      */
     List<String> prepareDownload(String targetPath);
+
+    /**
+     * Returns whether a particular file path should be handled by this plugin
+     * @return return schemes that this provision interface handles (ex: http, https, ftp, syn, icgc)
+     */
+    Set<String> schemesHandled();
 }


### PR DESCRIPTION
Please make sure that you've checked the following before submitting your pull request. Thanks!

- [] Check that you pass the basic style checks and unit tests by running `mvn clean install` 

Adds a PreProvisionInterface that plugins such such as DOS can implement. Also adds edits to FileProvisioning code to handle plugins with PreProvisionInterface extension points.