### PR TITLE
Update cwltool version

### DIFF
--- a/dockstore-webservice/src/main/resources/requirements/1.5.0/requirements.txt
+++ b/dockstore-webservice/src/main/resources/requirements/1.5.0/requirements.txt
@@ -1,7 +1,7 @@
 setuptools==36.5.0
 cwl-runner
-cwltool==1.0.20170828135420
-schema-salad==2.6.20170806163416
+cwltool==1.0.20180403145700
+schema-salad==2.7.20180514132321
 avro==1.8.1
 ruamel.yaml==0.14.12
 requests==2.18.4


### PR DESCRIPTION
For issue #1381 
Updating cwltool version for dockstore 1.5.0 python2.  It was tested to work on tooltester (no new failures compared to the previous runs)