### PR TITLE
Use emails as unique identifier

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GoogleHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GoogleHelper.java
@@ -18,7 +18,6 @@ import java.security.GeneralSecurityException;
  */
 public final class GoogleHelper {
     // Prefix for Dockstore usernames where the account was originally registered with Google
-    public static final String GOOGLE_USERNAME_PREFIX = "google/";
     public static final String GOOGLE_AUTHORIZATION_SERVICE_ENCODED_URL = "https://accounts.google.com/o/oauth2/v2/auth";
     public static final String GOOGLE_ENCODED_URL = "https://www.googleapis.com/oauth2/v4/token";
 
@@ -49,7 +48,7 @@ public final class GoogleHelper {
      * @param user      The pre-updated User object
      */
     public static void updateUserFromGoogleUserinfoplus(Userinfoplus userinfo, User user) {
-        user.setUsername(GoogleHelper.GOOGLE_USERNAME_PREFIX + userinfo.getName());
+        user.setUsername(userinfo.getEmail());
         user.setEmail(userinfo.getEmail());
         user.setAvatarUrl(userinfo.getPicture());
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -345,9 +345,9 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
             long userID;
             Token dockstoreToken = null;
             Token googleToken = null;
-            String googleLoginName = GoogleHelper.GOOGLE_USERNAME_PREFIX + userinfo.getName();
+            String googleLoginName = userinfo.getEmail();
             User user = userDAO.findByUsername(googleLoginName);
-            List<Token> googleByUsername = tokenDAO.findTokenByUsername(GoogleHelper.GOOGLE_USERNAME_PREFIX + userinfo.getName(), TokenType.GOOGLE_COM);
+            List<Token> googleByUsername = tokenDAO.findTokenByUsername(userinfo.getEmail(), TokenType.GOOGLE_COM);
             if (user == null && !authUser.isPresent() && googleByUsername.isEmpty()) {
                 user = new User();
                 // Pull user information from Google


### PR DESCRIPTION
For issue #1458 

Google names are not unique, but emails are.  Using that instead as the unique identifier.

Also got rid of the google prefix because no github username is going to be "somebody@gmail.com"