### PR TITLE
return descriptor type even with null sourcefile content

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -86,7 +86,10 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
             entry.setUsers(null);
             // need to have this evicted so that hibernate does not actually delete the tags and users
             Set<U> versions = entry.getVersions();
-            versions.forEach(version -> version.getSourceFiles().clear());
+            versions.forEach(version ->
+                version.getSourceFiles().forEach(sourceFile ->
+                        ((SourceFile)sourceFile).setContent(null))
+            );
         }
     }
 


### PR DESCRIPTION
Properly return the descriptor type without returning sourcefile content.
https://github.com/ga4gh/dockstore/issues/1434