### PR TITLE
Feature/1381/update cwl tool

### DIFF
--- a/dockstore-client/src/main/java/io/github/collaboratory/cwl/cwlrunner/CWLToolWrapper.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/cwl/cwlrunner/CWLToolWrapper.java
@@ -15,6 +15,13 @@
  */
 package io.github.collaboratory.cwl.cwlrunner;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.ProcessingException;
+
 import com.google.common.base.Joiner;
 import io.dockstore.client.cli.ArgumentUtility;
 import io.dockstore.client.cli.Client;
@@ -23,12 +30,6 @@ import io.swagger.client.ApiException;
 import io.swagger.client.Configuration;
 import io.swagger.client.api.MetadataApi;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-
-import javax.ws.rs.ProcessingException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 
 import static io.dockstore.common.PipHelper.convertPipRequirementsStringToMap;
 
@@ -49,8 +50,7 @@ public class CWLToolWrapper implements CWLRunnerInterface {
         String[] split = pair2.getKey().split(" ");
         final String schemaSaladVersion = split[split.length - 1].trim();
 
-        ApiClient defaultApiClient;
-        defaultApiClient = Configuration.getDefaultApiClient();
+        ApiClient defaultApiClient = Configuration.getDefaultApiClient();
         MetadataApi metadataApi = new MetadataApi(defaultApiClient);
         try {
             String runnerDependencies = metadataApi

--- a/dockstore-client/src/main/java/io/github/collaboratory/cwl/cwlrunner/CWLToolWrapper.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/cwl/cwlrunner/CWLToolWrapper.java
@@ -19,10 +19,12 @@ import com.google.common.base.Joiner;
 import io.dockstore.client.cli.ArgumentUtility;
 import io.dockstore.client.cli.Client;
 import io.swagger.client.ApiClient;
+import io.swagger.client.ApiException;
 import io.swagger.client.Configuration;
 import io.swagger.client.api.MetadataApi;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
+import javax.ws.rs.ProcessingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -50,19 +52,22 @@ public class CWLToolWrapper implements CWLRunnerInterface {
         ApiClient defaultApiClient;
         defaultApiClient = Configuration.getDefaultApiClient();
         MetadataApi metadataApi = new MetadataApi(defaultApiClient);
-        String runnerDependencies = metadataApi
-            .getRunnerDependencies(this.getClass().getPackage().getImplementationVersion(), "2", "cwltool", "text");
-        Map<String, String> stringStringMap = convertPipRequirementsStringToMap(runnerDependencies);
-        final String expectedCwltoolVersion = stringStringMap.get("cwltool");
-        final String expectedSchemaSaladVersion = stringStringMap.get("schema-salad");
-
-        if (expectedCwltoolVersion != null && !cwlToolVersion.equals(expectedCwltoolVersion)) {
-            ArgumentUtility.errorMessage("cwltool version is " + cwlToolVersion + " , Dockstore is tested with " + expectedCwltoolVersion
+        try {
+            String runnerDependencies = metadataApi
+                .getRunnerDependencies(this.getClass().getPackage().getImplementationVersion(), "2", "cwltool", "text");
+            Map<String, String> stringStringMap = convertPipRequirementsStringToMap(runnerDependencies);
+            final String expectedCwltoolVersion = stringStringMap.get("cwltool");
+            final String expectedSchemaSaladVersion = stringStringMap.get("schema-salad");
+            if (expectedCwltoolVersion != null && !cwlToolVersion.equals(expectedCwltoolVersion)) {
+                ArgumentUtility.errorMessage("cwltool version is " + cwlToolVersion + " , Dockstore is tested with " + expectedCwltoolVersion
                     + "\nOverride and run with `--script`", Client.COMMAND_ERROR);
-        }
-        if (expectedSchemaSaladVersion != null && !schemaSaladVersion.equals(expectedSchemaSaladVersion)) {
-            ArgumentUtility.errorMessage("schema-salad version is " + schemaSaladVersion + " , Dockstore is tested with " + expectedSchemaSaladVersion
+            }
+            if (expectedSchemaSaladVersion != null && !schemaSaladVersion.equals(expectedSchemaSaladVersion)) {
+                ArgumentUtility.errorMessage("schema-salad version is " + schemaSaladVersion + " , Dockstore is tested with " + expectedSchemaSaladVersion
                     + "\nOverride and run with `--script`", Client.COMMAND_ERROR);
+            }
+        } catch (ProcessingException | ApiException e) {
+            ArgumentUtility.out("Could not get cwltool dependencies");
         }
     }
 

--- a/dockstore-client/src/main/java/io/github/collaboratory/cwl/cwlrunner/CWLToolWrapper.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/cwl/cwlrunner/CWLToolWrapper.java
@@ -15,14 +15,20 @@
  */
 package io.github.collaboratory.cwl.cwlrunner;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import com.google.common.base.Joiner;
 import io.dockstore.client.cli.ArgumentUtility;
 import io.dockstore.client.cli.Client;
+import io.swagger.client.ApiClient;
+import io.swagger.client.Configuration;
+import io.swagger.client.api.MetadataApi;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static io.dockstore.common.PipHelper.convertPipRequirementsStringToMap;
 
 public class CWLToolWrapper implements CWLRunnerInterface {
     @Override
@@ -41,13 +47,20 @@ public class CWLToolWrapper implements CWLRunnerInterface {
         String[] split = pair2.getKey().split(" ");
         final String schemaSaladVersion = split[split.length - 1].trim();
 
-        final String expectedCwltoolVersion = "1.0.20170828135420";
-        if (!cwlToolVersion.equals(expectedCwltoolVersion)) {
+        ApiClient defaultApiClient;
+        defaultApiClient = Configuration.getDefaultApiClient();
+        MetadataApi metadataApi = new MetadataApi(defaultApiClient);
+        String runnerDependencies = metadataApi
+            .getRunnerDependencies(this.getClass().getPackage().getImplementationVersion(), "2", "cwltool", "text");
+        Map<String, String> stringStringMap = convertPipRequirementsStringToMap(runnerDependencies);
+        final String expectedCwltoolVersion = stringStringMap.get("cwltool");
+        final String expectedSchemaSaladVersion = stringStringMap.get("schema-salad");
+
+        if (expectedCwltoolVersion != null && !cwlToolVersion.equals(expectedCwltoolVersion)) {
             ArgumentUtility.errorMessage("cwltool version is " + cwlToolVersion + " , Dockstore is tested with " + expectedCwltoolVersion
                     + "\nOverride and run with `--script`", Client.COMMAND_ERROR);
         }
-        final String expectedSchemaSaladVersion = "2.6.20170806163416";
-        if (!schemaSaladVersion.equals(expectedSchemaSaladVersion)) {
+        if (expectedSchemaSaladVersion != null && !schemaSaladVersion.equals(expectedSchemaSaladVersion)) {
             ArgumentUtility.errorMessage("schema-salad version is " + schemaSaladVersion + " , Dockstore is tested with " + expectedSchemaSaladVersion
                     + "\nOverride and run with `--script`", Client.COMMAND_ERROR);
         }

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
@@ -1014,7 +1014,7 @@ public class LaunchTestIT {
 
         runClientCommand(args, false);
 
-        assertTrue("output should include an error message", systemErrRule.getLog().contains("The error was: 'NoneType' object is not iterable"));
+        assertTrue("output should include an error message", systemErrRule.getLog().contains("\"outputs\" section is not valid"));
     }
 
     @Test
@@ -1056,6 +1056,7 @@ public class LaunchTestIT {
 
     @Test
     public void cwl2jsonNoOutput() {
+        exit.expectSystemExit();
         File file = new File(ResourceHelpers.resourceFilePath("noOutput.cwl"));
         ArrayList<String> args = new ArrayList<String>() {{
             add("tool");
@@ -1066,7 +1067,8 @@ public class LaunchTestIT {
         }};
 
         runClientCommand(args, false);
-
-        assertTrue("output should include an error message", systemErrRule.getLog().contains("missing required field `outputs`"));
+        exit.checkAssertionAfterwards(() ->
+            assertTrue("output should include an error message", systemErrRule.getLog().contains("\"outputs section is not valid\""))
+        );
     }
 }

--- a/dockstore-client/src/test/resources/1st-workflow.cwl
+++ b/dockstore-client/src/test/resources/1st-workflow.cwl
@@ -1,4 +1,4 @@
-cwlVersion: cwl:draft-3
+cwlVersion: v1.0
 class: Workflow
 inputs:
   - id: inp
@@ -9,23 +9,23 @@ inputs:
 outputs:
   - id: classout
     type: File
-    source: "#compile/classfile"
+    outputSource: "#compile/classfile"
 
 steps:
   - id: untar
     run: tar-param.cwl
-    inputs:
+    in:
       - id: tarfile
         source: "#inp"
       - id: extractfile
         source: "#ex"
-    outputs:
+    out:
       - id: example_out
 
   - id: compile
     run: arguments.cwl
-    inputs:
+    in:
       - id: src
         source: "#untar/example_out"
-    outputs:
+    out:
       - id: classfile

--- a/dockstore-client/src/test/resources/arguments.cwl
+++ b/dockstore-client/src/test/resources/arguments.cwl
@@ -1,4 +1,4 @@
-cwlVersion: cwl:draft-3
+cwlVersion: v1.0
 class: CommandLineTool
 baseCommand: javac
 hints:

--- a/dockstore-client/src/test/resources/cwlNoExt
+++ b/dockstore-client/src/test/resources/cwlNoExt
@@ -1,4 +1,4 @@
-cwlVersion: cwl:draft-3
+cwlVersion: v1.0
 class: Workflow
 inputs:
   - id: inp
@@ -9,23 +9,23 @@ inputs:
 outputs:
   - id: classout
     type: File
-    source: "#compile/classfile"
+    outputSource: "#compile/classfile"
 
 steps:
   - id: untar
     run: tar-param.cwl
-    inputs:
+    in:
       - id: tarfile
         source: "#inp"
       - id: extractfile
         source: "#ex"
-    outputs:
+    out:
       - id: example_out
 
   - id: compile
     run: arguments.cwl
-    inputs:
+    in:
       - id: src
         source: "#untar/example_out"
-    outputs:
+    out:
       - id: classfile

--- a/dockstore-client/src/test/resources/file_provision/split_to_directory.json
+++ b/dockstore-client/src/test/resources/file_provision/split_to_directory.json
@@ -1,6 +1,7 @@
 {
   "bam_input": {
     "class": "File",
+    "format": "http://edamontology.org/format_2572",
     "path": "https://github.com/CancerCollaboratory/dockstore-tool-bamstats/raw/1.25-6_1.0/rna.SRR948778.bam"
   },
   "bamstats_report": {

--- a/dockstore-client/src/test/resources/file_provision/split_to_malformed.json
+++ b/dockstore-client/src/test/resources/file_provision/split_to_malformed.json
@@ -1,6 +1,7 @@
 {
   "bam_input": {
     "class": "File",
+    "format": "http://edamontology.org/format_2572",
     "path": "https://github.com/CancerCollaboratory/dockstore-tool-bamstats/raw/1.25-6_1.0/rna.SRR948778.bam"
   },
   "bamstats_report": "/tmp/provision_out_with_files/"

--- a/dockstore-client/src/test/resources/file_provision/split_to_missing_directory.json
+++ b/dockstore-client/src/test/resources/file_provision/split_to_missing_directory.json
@@ -1,6 +1,7 @@
 {
   "bam_input": {
     "class": "File",
+    "format": "http://edamontology.org/format_2572",
     "path": "https://github.com/CancerCollaboratory/dockstore-tool-bamstats/raw/1.25-6_1.0/rna.SRR948778.bam"
   }
 }

--- a/dockstore-client/src/test/resources/split.extra.json
+++ b/dockstore-client/src/test/resources/split.extra.json
@@ -1,6 +1,7 @@
 {
   "bam_input": {
     "class": "File",
+    "format": "http://edamontology.org/format_2572",
     "path": "https://github.com/CancerCollaboratory/dockstore-tool-bamstats/raw/1.25-6_1.0/rna.SRR948778.bam"
   },
   "bamstats_report": {

--- a/dockstore-client/src/test/resources/split.json
+++ b/dockstore-client/src/test/resources/split.json
@@ -1,6 +1,7 @@
 {
   "bam_input": {
     "class": "File",
+    "format": "http://edamontology.org/format_2572",
     "path": "https://github.com/CancerCollaboratory/dockstore-tool-bamstats/raw/1.25-6_1.0/rna.SRR948778.bam"
   },
   "bamstats_report": {

--- a/dockstore-client/src/test/resources/split.renamed.json
+++ b/dockstore-client/src/test/resources/split.renamed.json
@@ -1,6 +1,7 @@
 {
   "bam_input": {
     "class": "File",
+    "format": "http://edamontology.org/format_2572",
     "path": "https://github.com/CancerCollaboratory/dockstore-tool-bamstats/raw/1.25-6_1.0/rna.SRR948778.bam"
   },
   "bamstats_report": {

--- a/dockstore-client/src/test/resources/splitBlob.json
+++ b/dockstore-client/src/test/resources/splitBlob.json
@@ -1,6 +1,7 @@
 {
   "bam_input": {
     "class": "File",
+    "format": "http://edamontology.org/format_2572",
     "path": "https://github.com/CancerCollaboratory/dockstore-tool-bamstats/raw/1.25-6_1.0/rna.SRR948778.bam"
   },
   "bamstats_report": {

--- a/dockstore-client/src/test/resources/split_no_provision_out.json
+++ b/dockstore-client/src/test/resources/split_no_provision_out.json
@@ -1,6 +1,7 @@
 {
   "bam_input": {
     "class": "File",
+    "format": "http://edamontology.org/format_2572",
     "path": "https://github.com/CancerCollaboratory/dockstore-tool-bamstats/raw/1.25-6_1.0/rna.SRR948778.bam"
   }
 }

--- a/dockstore-client/src/test/resources/tar-param.cwl
+++ b/dockstore-client/src/test/resources/tar-param.cwl
@@ -1,4 +1,4 @@
-cwlVersion: cwl:draft-3
+cwlVersion: v1.0
 class: CommandLineTool
 baseCommand: [tar, xf]
 inputs:

--- a/dockstore-client/src/test/resources/testDirectory3/workflow.cwl
+++ b/dockstore-client/src/test/resources/testDirectory3/workflow.cwl
@@ -13,9 +13,9 @@ inputs:
 
   INDEX: File
 
-  TUMOR_BAM: File
+  TUMOR_BAM: { type: File, secondaryFiles: [.bai] }
 
-  NORMAL_BAM: File
+  NORMAL_BAM: { type: File, secondaryFiles: [.bai] }
 
   OUTVCF: string
 

--- a/dockstore-client/src/test/resources/wrongExtcwl.wdl
+++ b/dockstore-client/src/test/resources/wrongExtcwl.wdl
@@ -1,4 +1,4 @@
-cwlVersion: cwl:draft-3
+cwlVersion: v1.0
 class: Workflow
 inputs:
   - id: inp
@@ -9,23 +9,23 @@ inputs:
 outputs:
   - id: classout
     type: File
-    source: "#compile/classfile"
+    outputSource: "#compile/classfile"
 
 steps:
   - id: untar
     run: tar-param.cwl
-    inputs:
+    in:
       - id: tarfile
         source: "#inp"
       - id: extractfile
         source: "#ex"
-    outputs:
+    out:
       - id: example_out
 
   - id: compile
     run: arguments.cwl
-    inputs:
+    in:
       - id: src
         source: "#untar/example_out"
-    outputs:
+    out:
       - id: classfile

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -29,6 +29,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.github.zafarkhaja</groupId>
+            <artifactId>java-semver</artifactId>
+            <version>0.9.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
             <version>2.2.0</version>

--- a/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
@@ -1,4 +1,4 @@
-package io.dockstore.webservice.helpers;
+package io.dockstore.common;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
@@ -26,7 +26,8 @@ public final class PipHelper {
             semVerString = "9001.9001.9001";
         }
         Version semVer = Version.valueOf(semVerString);
-        if (semVer.greaterThanOrEqualTo(Version.valueOf("1.5.0"))) {
+        // Use the 1.5.0 even for snapshot
+        if (semVer.greaterThan(Version.valueOf("1.4.0"))) {
             return "1.5.0";
         } else {
             return "1.4.0";

--- a/dockstore-common/src/test/resources/cwl.json
+++ b/dockstore-common/src/test/resources/cwl.json
@@ -1,5 +1,5 @@
 {
-  "cwlVersion": "https://w3id.org/cwl/cwl#draft-3.dev2",
+  "cwlVersion": "https://w3id.org/cwl/cwl#v1.0",
   "inputs": [
     {
       "default": 4,

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
@@ -101,8 +101,8 @@ public class CheckerWorkflowIT extends BaseIT {
         // Check if the output file format is added to the file_formats property
         Assert.assertTrue(refresh.getTags().stream().anyMatch(tag -> tag.getOutputFileFormats().stream().anyMatch(fileFormat -> fileFormat.getValue().equals("http://edamontology.org/data_3671"))));
         Assert.assertTrue(refresh.getOutputFileFormats().stream().anyMatch(fileFormat -> fileFormat.getValue().equals("http://edamontology.org/data_3671")));
-        Assert.assertTrue(refresh.getTags().stream().anyMatch(tag -> tag.getInputFileFormats().stream().anyMatch(fileFormat -> fileFormat.getValue().equals("fakeFileFormat"))));
-        Assert.assertTrue(refresh.getInputFileFormats().stream().anyMatch(fileFormat -> fileFormat.getValue().equals("fakeFileFormat")));
+        Assert.assertTrue(refresh.getTags().stream().anyMatch(tag -> tag.getInputFileFormats().stream().anyMatch(fileFormat -> fileFormat.getValue().equals("file://fakeFileFormat"))));
+        Assert.assertTrue(refresh.getInputFileFormats().stream().anyMatch(fileFormat -> fileFormat.getValue().equals("file://fakeFileFormat")));
 
         // Add checker workflow
         workflowApi.registerCheckerWorkflow("/checker-workflow-wrapping-tool.cwl", githubTool.getId(), "cwl", null);

--- a/dockstore-integration-testing/src/test/resources/md5sum-wrapper-tool.json
+++ b/dockstore-integration-testing/src/test/resources/md5sum-wrapper-tool.json
@@ -1,6 +1,7 @@
 {
   "input_file": {
     "class": "File",
+    "format": "file://fakeFileFormat",
     "path": "md5sum.input"
   },
   "expected_md5": "00579a00e3e7fa0674428ac7049423e2"

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -40,11 +40,6 @@
             <version>v1-rev141-1.22.0</version>
         </dependency>
         <dependency>
-            <groupId>com.github.zafarkhaja</groupId>
-            <artifactId>java-semver</artifactId>
-            <version>0.9.0</version>
-        </dependency>
-        <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
             <version>4.11</version>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -48,7 +48,7 @@ import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.Workflow;
-import io.dockstore.webservice.helpers.PipHelper;
+import io.dockstore.common.PipHelper;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import io.dockstore.webservice.jdbi.WorkflowDAO;
 import io.dockstore.webservice.resources.rss.RSSEntry;

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -14,6 +14,5 @@ fi
 if [ "${TESTING_PROFILE}" = "toil-integration-tests" ]; then
     pip2.7 install --user toil[cwl]==3.15.0
 else
-    pip2.7 install --user setuptools==36.5.0
-    pip2.7 install --user cwl-runner cwltool==1.0.20170828135420 schema-salad==2.6.20170806163416 avro==1.8.1 ruamel.yaml==0.14.12 requests==2.18.4
+    pip2.7 install --user -r dockstore-webservice/src/main/resources/requirements/1.4.0/requirements.txt
 fi

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -14,5 +14,5 @@ fi
 if [ "${TESTING_PROFILE}" = "toil-integration-tests" ]; then
     pip2.7 install --user toil[cwl]==3.15.0
 else
-    pip2.7 install --user -r dockstore-webservice/src/main/resources/requirements/1.4.0/requirements.txt
+    pip2.7 install --user -r dockstore-webservice/src/main/resources/requirements/1.5.0/requirements.txt
 fi


### PR DESCRIPTION
Update to use the 1.5.0 requirements.txt cwltool and schema-salad version

A few changes:

cwl version below 1.0 is completely unsupported.  formats in the descriptor must also be specified in the test parameter file.  format must be a URI.  

All snapshots will use the non-existent final release requirements.txt file (1.5.0-SNAPSHOT will use 1.5.0).