### PR TITLE
Change /workflows/sharedworkflow response entity

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -42,6 +42,8 @@ import io.dockstore.common.Registry;
 import io.dockstore.common.Utilities;
 import io.dockstore.webservice.DockstoreWebserviceApplication;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
+import io.dockstore.webservice.permissions.Role;
+import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
@@ -59,6 +61,7 @@ import io.swagger.client.model.Group;
 import io.swagger.client.model.MetadataV1;
 import io.swagger.client.model.Permission;
 import io.swagger.client.model.PublishRequest;
+import io.swagger.client.model.SharedWorkflows;
 import io.swagger.client.model.SourceFile;
 import io.swagger.client.model.StarRequest;
 import io.swagger.client.model.Tag;
@@ -761,7 +764,11 @@ public class SwaggerClientIT {
         shareWorkflow(user1WorkflowsApi, user2.getUsername(), fullWorkflowPath, Permission.RoleEnum.READER);
 
         // User 2 should now have 1 workflow shared with
-        Assert.assertEquals(1, user2WorkflowsApi.sharedWorkflows().size());
+        final List<SharedWorkflows> sharedWorkflows = user2WorkflowsApi.sharedWorkflows();
+        Assert.assertEquals(1, sharedWorkflows.size());
+        final SharedWorkflows firstShared = sharedWorkflows.get(0);
+        Assert.assertEquals(SharedWorkflows.RoleEnum.READER, firstShared.getRole());
+        Assert.assertEquals(fullWorkflowPath, firstShared.getWorkflows().get(0).getFullWorkflowPath());
         // OPTIONS should now return include GET
         user2WorkflowsApi.getWorkflowByPathOptions(fullWorkflowPath);
         verifyOptions(user2WorkflowsApi.getApiClient(), Arrays.asList(HttpMethod.GET, HttpMethod.OPTIONS));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
@@ -16,7 +16,9 @@
 
 package io.dockstore.webservice.permissions;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -70,11 +72,21 @@ public class InMemoryPermissionsImpl implements PermissionsInterface {
     }
 
     @Override
-    public List<String> workflowsSharedWithUser(User user) {
-        return resourceToUsersAndRolesMap.entrySet().stream()
-                .filter(e ->  e.getValue().containsKey(userKey(user)))
-                .map(e -> e.getKey())
-                .collect(Collectors.toList());
+    public Map<Role, List<String>> workflowsSharedWithUser(User user) {
+        final String userKey = userKey(user);
+        final Map<Role, List<String>> map = new HashMap<>();
+        resourceToUsersAndRolesMap.entrySet().stream().forEach(e -> {
+            final Role role = e.getValue().get(userKey);
+            if (role != null) {
+                List<String> workflows = map.get(role);
+                if (workflows == null) {
+                    workflows = new ArrayList<>();
+                    map.put(role, workflows);
+                }
+                workflows.add(e.getKey());
+            }
+        });
+        return map;
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/NoOpPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/NoOpPermissionsImpl.java
@@ -2,6 +2,7 @@ package io.dockstore.webservice.permissions;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
@@ -18,8 +19,8 @@ public class NoOpPermissionsImpl implements PermissionsInterface {
     }
 
     @Override
-    public List<String> workflowsSharedWithUser(User user) {
-        return Collections.emptyList();
+    public Map<Role, List<String>> workflowsSharedWithUser(User user) {
+        return Collections.emptyMap();
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/PermissionsInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/PermissionsInterface.java
@@ -17,6 +17,7 @@
 package io.dockstore.webservice.permissions;
 
 import java.util.List;
+import java.util.Map;
 
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
@@ -64,12 +65,15 @@ public interface PermissionsInterface {
     List<Permission> setPermission(Workflow workflow, User requester, Permission permission);
 
     /**
-     * Returns the workflow paths of all entries that have been shared with the specified <code>user</code>.
+     * Returns a map of all the paths of all workflows that have been shared with the specified <code>user</code>.
+     *
+     * <p>Each key in the map is a {@link Role}, and the value is a list of workflow
+     * paths of workflows for which the user has that role. The paths are NOT encoded.</p>
      *
      * @param user
      * @return this list of all entries shared with the user
      */
-    List<String> workflowsSharedWithUser(User user);
+    Map<Role, List<String>> workflowsSharedWithUser(User user);
 
     /**
      * Lists all <code>Permission</code>s for <code>workflow</code>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/SharedWorkflows.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/SharedWorkflows.java
@@ -1,0 +1,28 @@
+package io.dockstore.webservice.permissions;
+
+import java.util.List;
+
+import io.dockstore.webservice.core.Workflow;
+
+/**
+ * The representation of a role and all workflows
+ * that have that role.
+ */
+public class SharedWorkflows {
+    private final Role role;
+    private final List<Workflow> workflows;
+
+    public SharedWorkflows(Role role, List<Workflow> workflows) {
+        this.role = role;
+        this.workflows = workflows;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public List<Workflow> getWorkflows() {
+        return workflows;
+    }
+
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -16,8 +16,6 @@
 
 package io.dockstore.webservice.resources;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -94,6 +92,7 @@ import io.dockstore.webservice.languages.LanguageHandlerInterface;
 import io.dockstore.webservice.permissions.Permission;
 import io.dockstore.webservice.permissions.PermissionsInterface;
 import io.dockstore.webservice.permissions.Role;
+import io.dockstore.webservice.permissions.SharedWorkflows;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.hibernate.UnitOfWork;
 import io.swagger.annotations.Api;
@@ -718,18 +717,16 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("shared")
-    @ApiOperation(value = "All workflows shared with user", authorizations = { @Authorization(value =  JWT_SECURITY_DEFINITION_NAME)}, notes = "List all workflows shared with user", tags = { "workflows"}, response = Workflow.class, responseContainer = "List")
-    public List<Workflow> sharedWorkflows(@ApiParam(hidden = true) @Auth User user) {
-        return this.permissionsInterface.workflowsSharedWithUser(user).stream()
-                .map(encodedPath -> {
-                    try {
-                        final String path = URLDecoder.decode(encodedPath, "UTF-8");
+    @ApiOperation(value = "All workflows shared with user", authorizations = { @Authorization(value =  JWT_SECURITY_DEFINITION_NAME)}, notes = "List all workflows shared with user", tags = { "workflows"}, response = SharedWorkflows.class, responseContainer = "List")
+    public List<SharedWorkflows> sharedWorkflows(@ApiParam(hidden = true) @Auth User user) {
+        return this.permissionsInterface
+                .workflowsSharedWithUser(user).entrySet().stream()
+                .map(e -> {
+                    final List<Workflow> workflows = e.getValue().stream().map(path -> {
                         return workflowDAO.findByPath(path, false);
-                    } catch (UnsupportedEncodingException e) {
-                        return null;
-                    }
+                    }).filter(w -> w != null).collect(Collectors.toList());
+                    return new SharedWorkflows(e.getKey(), workflows);
                 })
-                .filter(w -> w != null) // Just ignore
                 .collect(Collectors.toList());
     }
 

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -2749,26 +2749,6 @@ paths:
         - BEARER: []
       requestBody:
         $ref: '#/components/requestBodies/updateLabelsBody'
-  '/hostedEntry/{entryId}':
-    options:
-      tags:
-        - hosted
-      summary: Options for a hosted entry
-      description: ''
-      operationId: hostedEntryOptions
-      parameters:
-        - name: entryId
-          in: path
-          description: The entry id.
-          required: true
-          schema:
-            type: integer
-            format: int64
-      responses:
-        default:
-          description: successful operation
-      security:
-        - BEARER: []
   /integration.bitbucket.org:
     get:
       tags:
@@ -4229,7 +4209,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Workflow'
+                  $ref: '#/components/schemas/SharedWorkflows'
       security:
         - BEARER: []
   '/workflows/{entryId}/registerCheckerWorkflow/{descriptorType}':
@@ -5711,6 +5691,19 @@ components:
           type: string
         enum:
           type: string
+    SharedWorkflows:
+      type: object
+      properties:
+        role:
+          type: string
+          enum:
+            - OWNER
+            - WRITER
+            - READER
+        workflows:
+          type: array
+          items:
+            $ref: '#/components/schemas/Workflow'
     SourceControlBean:
       type: object
       properties:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -3877,7 +3877,7 @@ paths:
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/Workflow"
+              $ref: "#/definitions/SharedWorkflows"
       security:
       - BEARER: []
   /workflows/{entryId}/registerCheckerWorkflow/{descriptorType}:
@@ -5280,6 +5280,19 @@ definitions:
         type: "string"
       enum:
         type: "string"
+  SharedWorkflows:
+    type: "object"
+    properties:
+      role:
+        type: "string"
+        enum:
+        - "OWNER"
+        - "WRITER"
+        - "READER"
+      workflows:
+        type: "array"
+        items:
+          $ref: "#/definitions/Workflow"
   SourceControlBean:
     type: "object"
     properties:

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/InMemoryPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/InMemoryPermissionsImplTest.java
@@ -19,20 +19,22 @@ public class InMemoryPermissionsImplTest {
 
     public static final String JANE_DOE_EXAMPLE_COM = "jane.doe@example.com";
     public static final String JOHN_DOE_EXAMPLE_COM = "john.doe@example.com";
+    public static final String DOCKSTORE_ORG_JOHN_MYWORKFLOW = "dockstore.org/john/myworkflow";
     private InMemoryPermissionsImpl inMemoryPermissions;
     private User userMock = Mockito.mock(User.class);
-    public static final String FOO_WORKFLOW_NAME = "foo";
-    public static final String GOO_WORKFLOW_NAME = "goo";
     private Workflow fooWorkflow;
     private Workflow gooWorkflow;
+    private Workflow dockstoreOrgWorkflow;
 
     @Before
     public void setup() {
         inMemoryPermissions = new InMemoryPermissionsImpl();
         fooWorkflow = Mockito.mock(Workflow.class);
         gooWorkflow = Mockito.mock(Workflow.class);
+        dockstoreOrgWorkflow = Mockito.mock(Workflow.class);
         when(fooWorkflow.getWorkflowPath()).thenReturn("foo");
         when(gooWorkflow.getWorkflowPath()).thenReturn("goo");
+        when(dockstoreOrgWorkflow.getWorkflowPath()).thenReturn(DOCKSTORE_ORG_JOHN_MYWORKFLOW);
         Map<String, User.Profile> profiles = new HashMap<>();
         User.Profile profile = new User.Profile();
         profile.email = JOHN_DOE_EXAMPLE_COM;
@@ -57,7 +59,12 @@ public class InMemoryPermissionsImplTest {
         permission.setEmail(JOHN_DOE_EXAMPLE_COM);
         inMemoryPermissions.setPermission(fooWorkflow, userMock, permission);
         inMemoryPermissions.setPermission(gooWorkflow, userMock, permission);
-        Assert.assertEquals(inMemoryPermissions.workflowsSharedWithUser(userMock).size(), 2);
+        Assert.assertEquals(1, inMemoryPermissions.workflowsSharedWithUser(userMock).size());
+        permission.setRole(Role.READER);
+        inMemoryPermissions.setPermission(dockstoreOrgWorkflow, userMock, permission);
+        final Map<Role, List<String>> roleListMap = inMemoryPermissions.workflowsSharedWithUser(userMock);
+        Assert.assertEquals(2, roleListMap.size());
+        Assert.assertEquals(DOCKSTORE_ORG_JOHN_MYWORKFLOW, roleListMap.get(Role.READER).get(0));
     }
 
     @Test
@@ -68,9 +75,13 @@ public class InMemoryPermissionsImplTest {
         permission.setEmail(JOHN_DOE_EXAMPLE_COM);
         inMemoryPermissions.setPermission(fooWorkflow, userMock, permission);
         inMemoryPermissions.setPermission(gooWorkflow, userMock, permission);
-        Assert.assertEquals(inMemoryPermissions.workflowsSharedWithUser(userMock).size(), 2);
+        final Map<Role, List<String>> sharedWithUser = inMemoryPermissions.workflowsSharedWithUser(userMock);
+        Assert.assertEquals(1, sharedWithUser.size());
+        Assert.assertEquals(2, sharedWithUser.entrySet().iterator().next().getValue().size());
         inMemoryPermissions.removePermission(fooWorkflow, userMock, JOHN_DOE_EXAMPLE_COM, Role.WRITER);
-        Assert.assertEquals(inMemoryPermissions.workflowsSharedWithUser(userMock).size(), 1);
+        final Map<Role, List<String>> sharedWithUser1 = inMemoryPermissions.workflowsSharedWithUser(userMock);
+        Assert.assertEquals(1, sharedWithUser1.size());
+        Assert.assertEquals(1, sharedWithUser1.entrySet().iterator().next().getValue().size());
     }
 
     @Test


### PR DESCRIPTION
Now returns a List<SharedWorkflows> instead of List<Workflow>, where
SharedWorkflows class has a Role and a list of workflows.

Initially attempted to have the endpoint return a
Map<Role, List<Workflow>>, but the problem when I do that is that
the generated Swagger Java client returns a Map<Role, Object>.

This response is slightly more cumbersome, but it preserves the types
in the Swagger clients, so it seems better.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
