### PR TITLE
swagger-kongchen plugin update and reader switch

### DIFF
--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -825,9 +825,7 @@
             <plugin>
                 <groupId>com.github.kongchen</groupId>
                 <artifactId>swagger-maven-plugin</artifactId>
-                <!-- fixed at 3.1.5 due to odd issue with our EntryDAO making it into Swagger and not being ignorable -->
-                <!-- for 3.1.7 specific issues seem to include messed up subclass structure with hosted tool and workflow endpoints ( https://github.com/kongchen/swagger-maven-plugin/issues/626 or https://github.com/kongchen/swagger-maven-plugin/issues/619 ) -->
-                <version>3.1.5</version>
+                <version>3.1.7</version>
                 <configuration>
                     <apiSources>
                         <apiSource>
@@ -843,15 +841,8 @@
                             <swaggerFileName>swagger</swaggerFileName>
                             <outputFormats>yaml</outputFormats>
                             <basePath>/</basePath>
-                            <!-- "can be used to strictly use the official Swagger reader in order to generate the exact same output as Swagger''s runtime generation (with all its bugs). "
                             <swaggerApiReader>com.github.kongchen.swagger.docgen.reader.SwaggerReader</swaggerApiReader>
-                            -->
                             <attachSwaggerArtifact>true</attachSwaggerArtifact>
-                            <securityDefinitions>
-                                <securityDefinition>
-                                    <json>/securityDefinition.json</json>
-                                </securityDefinition>
-                            </securityDefinitions>
                         </apiSource>
                     </apiSources>
                 </configuration>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -161,9 +161,9 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
      * <p>If the authorization header is present, then the OPTIONS method is always set,
      * and the other headers are set based on the user's permissions.</p>
      *
-     * @param optionalUser
-     * @param
-     * @return
+     * @param optionalUser provided when the user is logged in
+     * @param entryId the id of the tool or workflow to check options for
+     * @return methods that are accessible based on optionalUser's role
      */
     @OPTIONS
     @Path("/hostedEntry/{entryId}")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -162,7 +162,7 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
      * and the other headers are set based on the user's permissions.</p>
      *
      * @param optionalUser
-     * @param entryId
+     * @param
      * @return
      */
     @OPTIONS
@@ -178,13 +178,13 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
         checkEntry(entry);
         headers.addAll(optionalUser.map(user -> {
             final List<String> list = new ArrayList<>();
-            if (checkUserCanLambda(user, entry, (u, e) -> checkUserCanDelete(u, e))) {
+            if (checkUserCanLambda(user, entry, this::checkUserCanDelete)) {
                 headers.add(HttpMethod.DELETE);
             }
-            if (checkUserCanLambda(user, entry, (u, e) -> checkUserCanUpdate(u, e))) {
+            if (checkUserCanLambda(user, entry, this::checkUserCanUpdate)) {
                 headers.add(PATCH_METHOD); // Why is there no value for PATCH in HttpHeader?
             }
-            if (checkUserCanLambda(user, entry, (u, e) -> checkUserCanRead(u, e))) {
+            if (checkUserCanLambda(user, entry, this::checkUserCanRead)) {
                 headers.add(HttpMethod.GET);
             }
             return list;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/Description.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/Description.java
@@ -18,10 +18,12 @@ package io.dockstore.webservice.resources;
 
 import javax.ws.rs.ext.Provider;
 
+import io.swagger.annotations.Api;
 import io.swagger.annotations.Contact;
 import io.swagger.annotations.ExternalDocs;
 import io.swagger.annotations.Info;
 import io.swagger.annotations.License;
+import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
 import io.swagger.annotations.Tag;
 import io.swagger.jaxrs.Reader;
@@ -37,25 +39,26 @@ import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
  *
  * @author dyuen
  */
+@Api("tools")
 @Provider
 @SwaggerDefinition(info = @Info(description =
-        "This describes the dockstore API, a webservice that manages pairs of Docker images and associated metadata such as "
-                + "CWL documents and Dockerfiles used to build those images", version = "1.4.4", title = "Dockstore API", contact = @Contact(name = "Dockstore@ga4gh", email = "theglobalalliance@genomicsandhealth.org", url = "https://github.com/ga4gh/dockstore"), license = @License(name = "Apache License Version 2.0", url = "https://github.com/ga4gh/dockstore/blob/develop/LICENSE")), consumes = "application/json", produces = "application/json", tags = {
-        @Tag(name = "entries", description = "Interact with entries in Dockstore regardless of whether they are containers or workflows"),
-        @Tag(name = "containers", description = "List and register entries in the dockstore (pairs of images + metadata (CWL and Dockerfile))"),
-        @Tag(name = "containertags", description = "List and modify tags for containers"),
-        @Tag(name = "GA4GHV1", description = "A curated subset of resources proposed as a common standard for tool repositories"),
-        @Tag(name = "GA4GH", description = "A curated subset of resources proposed as a common standard for tool repositories"),
-        @Tag(name = "extendedGA4GH", description = "Optional experimental extensions of the GA4GH API"),
-        @Tag(name = "github.repo", description = "List source code repositories (should be generalized from github)"),
-        @Tag(name = "integration.bitbucket.org", description = "stop-gap allowing developers to associate with bitbucket"),
-        @Tag(name = "integration.github.com", description = "stop-gap allowing developers to associate with github"),
-        @Tag(name = "integration.gitlab.com", description = "stop-gap allowing developers to associate with gitlab"),
-        @Tag(name = "integration.quay.io", description = "stop-gap allowing developers to associate with quay.io"),
-        @Tag(name = "tokens", description = "List, modify, refresh, and delete tokens for external services"),
-        @Tag(name = "workflows", description = "List and register workflows in the dockstore (CWL or WDL)"),
-        @Tag(name = "hosted", description = "Created and modify hosted entries in the dockstore"),
-        @Tag(name = "users", description = "List, modify, and manage end users of the dockstore") }, externalDocs = @ExternalDocs(value = "Dockstore documentation", url = "https://www.dockstore.org/docs/getting-started"))
+    "This describes the dockstore API, a webservice that manages pairs of Docker images and associated metadata such as "
+        + "CWL documents and Dockerfiles used to build those images", version = "1.4.4", title = "Dockstore API", contact = @Contact(name = "Dockstore@ga4gh", email = "theglobalalliance@genomicsandhealth.org", url = "https://github.com/ga4gh/dockstore"), license = @License(name = "Apache License Version 2.0", url = "https://github.com/ga4gh/dockstore/blob/develop/LICENSE"), termsOfService = "TBD"), tags = {
+    @Tag(name = "entries", description = "Interact with entries in Dockstore regardless of whether they are containers or workflows"),
+    @Tag(name = "containers", description = "List and register entries in the dockstore (pairs of images + metadata (CWL and Dockerfile))"),
+    @Tag(name = "containertags", description = "List and modify tags for containers"),
+    @Tag(name = "GA4GHV1", description = "A curated subset of resources proposed as a common standard for tool repositories"),
+    @Tag(name = "GA4GH", description = "A curated subset of resources proposed as a common standard for tool repositories"),
+    @Tag(name = "extendedGA4GH", description = "Optional experimental extensions of the GA4GH API"),
+    @Tag(name = "integration.bitbucket.org", description = "stop-gap allowing developers to associate with bitbucket"),
+    @Tag(name = "integration.github.com", description = "stop-gap allowing developers to associate with github"),
+    @Tag(name = "integration.gitlab.com", description = "stop-gap allowing developers to associate with gitlab"),
+    @Tag(name = "integration.quay.io", description = "stop-gap allowing developers to associate with quay.io"),
+    @Tag(name = "tokens", description = "List, modify, refresh, and delete tokens for external services"),
+    @Tag(name = "workflows", description = "List and register workflows in the dockstore (CWL or WDL)"),
+    @Tag(name = "hosted", description = "Created and modify hosted entries in the dockstore"),
+    @Tag(name = "users", description = "List, modify, and manage end users of the dockstore") }, externalDocs = @ExternalDocs(value = "Dockstore documentation", url = "https://www.dockstore.org/docs/getting-started"), securityDefinition = @SecurityDefinition(apiKeyAuthDefinitions = {
+    @io.swagger.annotations.ApiKeyAuthDefinition(key = JWT_SECURITY_DEFINITION_NAME, in = io.swagger.annotations.ApiKeyAuthDefinition.ApiKeyLocation.HEADER, name = "Authorization") }))
 public class Description implements ReaderListener {
     @Override
     public void beforeScan(Reader reader, Swagger swagger) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
@@ -32,6 +32,7 @@ import io.dockstore.webservice.jdbi.FileDAO;
 import io.dockstore.webservice.jdbi.TagDAO;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import io.dockstore.webservice.jdbi.UserDAO;
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.Authorization;
 
@@ -40,6 +41,7 @@ import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
 /**
  * @author dyuen
  */
+@Api("hosted")
 @Path("/containers")
 public class HostedToolResource extends AbstractHostedEntryResource<Tool, Tag, ToolDAO, TagDAO> {
     private final ToolDAO toolDAO;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
@@ -39,6 +39,7 @@ import io.dockstore.webservice.jdbi.WorkflowVersionDAO;
 import io.dockstore.webservice.languages.LanguageHandlerFactory;
 import io.dockstore.webservice.permissions.PermissionsInterface;
 import io.dockstore.webservice.permissions.Role;
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.Authorization;
 
@@ -47,6 +48,7 @@ import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
 /**
  * @author dyuen
  */
+@Api("hosted")
 @Path("/workflows")
 public class HostedWorkflowResource extends AbstractHostedEntryResource<Workflow, WorkflowVersion, WorkflowDAO, WorkflowVersionDAO> {
     private final WorkflowDAO workflowDAO;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/SwaggerTester.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/SwaggerTester.java
@@ -1,0 +1,42 @@
+/*
+ *    Copyright 2018 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.dockstore.webservice.resources;
+
+import io.swagger.jaxrs.Reader;
+import io.swagger.models.Swagger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Demo how to debug swagger parsing of our classes
+ */
+public final class SwaggerTester {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractHostedEntryResource.class);
+
+
+    private SwaggerTester() {
+        // hide utility class
+    }
+
+    public static void main(String[] args) {
+        Swagger swagger = new Swagger();
+        Reader reader = new Reader(swagger);
+        Swagger read = reader.read(AbstractHostedEntryResource.class);
+        System.out.println();
+
+    }
+}

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -8,7 +8,7 @@ info:
     build those images
   version: 1.4.4
   title: Dockstore API
-  termsOfService: ''
+  termsOfService: TBD
   contact:
     name: Dockstore@ga4gh
     url: 'https://github.com/ga4gh/dockstore'
@@ -592,11 +592,6 @@ paths:
       responses:
         '200':
           description: An array of Tools of the input organization.
-          content:
-            text/plain:
-              schema:
-                type: integer
-                format: int32
       security:
         - BEARER: []
   '/api/ga4gh/v2/extended/tools/{organization}':
@@ -1615,16 +1610,7 @@ paths:
       security:
         - BEARER: []
       requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/SourceFile'
-        description: >-
-          Set of updated sourcefiles, add files by adding new files with unknown
-          paths, delete files by including them with emptied content
-        required: true
+        $ref: '#/components/requestBodies/SourceFileArray'
   '/containers/namespace/{namespace}/published':
     get:
       tags:
@@ -2682,22 +2668,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SourceFile'
-  '/hostedEntry/{entryId}':
-    options:
-      tags:
-        - hosted
-      summary: Options for a hosted entry
-      description: ''
-      operationId: hostedEntryOptions
-      parameters:
-        - name: entryId
-          in: path
-          description: The entry id.
-      responses:
-        default:
-          description: successful operation
-      security:
-        - BEARER: []
   '/entries/{id}/aliases':
     put:
       tags:
@@ -2839,9 +2809,11 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties:
+                type: array
+                items:
                   type: object
+                  additionalProperties:
+                    type: object
   /metadata/rss:
     get:
       tags:
@@ -3753,16 +3725,7 @@ paths:
       security:
         - BEARER: []
       requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/SourceFile'
-        description: >-
-          Set of updated sourcefiles, add files by adding new files with unknown
-          paths, delete files by including them with emptied content
-        required: true
+        $ref: '#/components/requestBodies/SourceFileArray'
   /workflows/manualRegister:
     post:
       tags:
@@ -5035,6 +4998,9 @@ paths:
                 $ref: '#/components/schemas/WorkflowVersion'
         description: List of modified workflow versions
         required: true
+externalDocs:
+  description: Dockstore documentation
+  url: 'https://www.dockstore.org/docs/getting-started'
 components:
   requestBodies:
     PublishRequest:
@@ -5071,6 +5037,17 @@ components:
           schema:
             $ref: '#/components/schemas/DockstoreTool'
       description: Tool with updated information
+      required: true
+    SourceFileArray:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/SourceFile'
+      description: >-
+        Set of updated sourcefiles, add files by adding new files with unknown
+        paths, delete files by including them with emptied content
       required: true
     StarRequest:
       content:

--- a/dockstore-webservice/src/main/resources/securityDefinition.json
+++ b/dockstore-webservice/src/main/resources/securityDefinition.json
@@ -1,7 +1,0 @@
-{
-  "BEARER": {
-    "type": "apiKey",
-    "name": "Authorization",
-    "in": "header"
-  }
-}

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -6,7 +6,7 @@ info:
     \ used to build those images"
   version: "1.4.4"
   title: "Dockstore API"
-  termsOfService: ""
+  termsOfService: "TBD"
   contact:
     name: "Dockstore@ga4gh"
     url: "https://github.com/ga4gh/dockstore"
@@ -14,7 +14,6 @@ info:
   license:
     name: "Apache License Version 2.0"
     url: "https://github.com/ga4gh/dockstore/blob/develop/LICENSE"
-host: ""
 basePath: "/"
 tags:
 - name: "GA4GH"
@@ -487,9 +486,6 @@ paths:
       responses:
         200:
           description: "An array of Tools of the input organization."
-          schema:
-            type: "integer"
-            format: "int32"
       security:
       - BEARER: []
   /api/ga4gh/v2/extended/tools/{organization}:
@@ -2426,27 +2422,6 @@ paths:
             $ref: "#/definitions/Entry"
       security:
       - BEARER: []
-  /hostedEntry/{entryId}:
-    options:
-      tags:
-      - "hosted"
-      summary: "Options for a hosted entry"
-      description: ""
-      operationId: "hostedEntryOptions"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "entryId"
-        in: "path"
-        description: "The entry id."
-        required: true
-        type: "integer"
-        format: "int64"
-      responses:
-        default:
-          description: "successful operation"
-      security:
-      - BEARER: []
   /integration.bitbucket.org:
     get:
       tags:
@@ -2558,9 +2533,11 @@ paths:
         200:
           description: "successful operation"
           schema:
-            type: "object"
-            additionalProperties:
+            type: "array"
+            items:
               type: "object"
+              additionalProperties:
+                type: "object"
   /metadata/rss:
     get:
       tags:
@@ -6066,3 +6043,6 @@ definitions:
         description: "This is the commit id for the source control that the files\
           \ belong to"
     description: "This describes one workflow version associated with a workflow."
+externalDocs:
+  description: "Dockstore documentation"
+  url: "https://www.dockstore.org/docs/getting-started"


### PR DESCRIPTION
Try to handle #1530 by updating the swagger kongchen plugin, switching to the swaggerreader (which they normally recommend against, but seems closer to what we see generated at runtime) and fixing some of the differences. 

Note that a endpoint disappears but it might be legitimate. 