### PR TITLE
Make swagger2openapi run on Mac

### DIFF
--- a/dockstore-webservice/swagger2open.sh
+++ b/dockstore-webservice/swagger2open.sh
@@ -4,17 +4,18 @@
 HTTP_STATUS=`curl -F "filename=@src/main/resources/swagger.yaml" https://mermade.org.uk/api/v1/convert -o src/main/resources/open_api.yaml -w "%{http_code}"`
 if [ "$?" -eq 0 ] && [ "$HTTP_STATUS" -eq 200  ]; then
   # Parse out position variable not compatible with open-api schemas
-  sed --in-place '/position/d;s/<html><body><pre>//' src/main/resources/open_api.yaml
+  sed -n '/position/d;s/<html><body><pre>//;w src/main/resources/openapi1.yaml' src/main/resources/open_api.yaml
   # Aggregate correct url for dockstore api. Using pipe instead of forward slash, avoid dealing with scape chars
-  sed --in-place 's|url: /|url: https://dockstore.org:8443|' src/main/resources/open_api.yaml
+  sed -n 's|url: /|url: https://dockstore.org:8443|; w src/main/resources/openapi2.yaml' src/main/resources/openapi1.yaml
 
   # Additional tag for smart-api compliance.
-  sed --in-place '/- name: GA4GHV1/i \
-  - name: NIHdatacommons
-  ' src/main/resources/open_api.yaml
+  # Note: Need "\ \" at beginning of subsequent line in order to work on both Linux and Mac
+  sed '/- name: GA4GHV1/i \
+\ \ - name: NIHdatacommons
+  ' src/main/resources/openapi2.yaml > src/main/resources/openapi.yaml
 
   # Clean directory from excess files.
-  mv src/main/resources/open_api.yaml src/main/resources/openapi.yaml
+  rm src/main/resources/open_api.yaml src/main/resources/openapi1.yaml src/main/resources/openapi2.yaml
 else
   echo "Error converting swagger to openapi, skipping openapi generation"
 fi


### PR DESCRIPTION
Fixes #1529.

Use the -n option for quietness. It works on both Linux (Ubuntu 18.04)
and Mac.

Needed the two forward slashes at the beginning of line 14, otherwise
the file ends up with extra indentation on Ubuntu (but not on
Mac OS).

Compared the results of running on Ubuntu before and after my change,
and the output was identical.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
