### PR TITLE
Add descriptions and warning abouts imports

### DIFF
--- a/_docs/dnastack-launch-with.md
+++ b/_docs/dnastack-launch-with.md
@@ -45,4 +45,8 @@ You will need to pick a version of your workflow to import and a project to impo
 Then hit the button to "Import" and continue from within the DNAstack interface to run your workflow. 
 Note that as with the above approach, you will want to double-check that the workflow specifies a runtime environment (docker, cpu, memory, and disks) if you have trouble importing the workflow and that the workflow has not been imported before. 
 
-Additionally, DNAStack does not currently support HTTP or file-based imports.  Importing a workflow with those imports will result in error.
+
+## Limitations
+0. Only launching of workflows is supported, not tools.
+0. DNAStack does not currently support http(s) or file-path based imports.  Importing a workflow with those imports will result in error.  See [cromwell imports docs](https://cromwell.readthedocs.io/en/develop/Imports/) for more info about imports.
+0. Only support the WDL language.

--- a/_docs/dnastack-launch-with.md
+++ b/_docs/dnastack-launch-with.md
@@ -44,3 +44,5 @@ If not logged into DNAstack, you will be prompted to login. Otherwise or after l
 You will need to pick a version of your workflow to import and a project to import it into.
 Then hit the button to "Import" and continue from within the DNAstack interface to run your workflow. 
 Note that as with the above approach, you will want to double-check that the workflow specifies a runtime environment (docker, cpu, memory, and disks) if you have trouble importing the workflow and that the workflow has not been imported before. 
+
+Additionally, DNAStack does not currently support HTTP or file-based imports.  Importing a workflow with those imports will result in error.

--- a/_docs/dnastack-launch-with.md
+++ b/_docs/dnastack-launch-with.md
@@ -47,6 +47,6 @@ Note that as with the above approach, you will want to double-check that the wor
 
 
 ## Limitations
-0. Only launching of workflows is supported, not tools.
+1. While we support launching of WDL workflows, tools as listed in Dockstore are currently not supported.
 0. DNAStack does not currently support http(s) or file-path based imports.  Importing a workflow with those imports will result in error.  See [cromwell imports docs](https://cromwell.readthedocs.io/en/develop/Imports/) for more info about imports.
-0. Only support the WDL language.
+0. Only the WDL language is supported.

--- a/_docs/firecloud-launch-with.md
+++ b/_docs/firecloud-launch-with.md
@@ -36,6 +36,6 @@ Note that you will want to double-check that the workflow specifies a runtime en
 and disks). 
 
 ## Limitations
-0. Only launching of workflows is supported, not tools.
+1. While we support launching of WDL workflows, tools as listed in Dockstore are currently not supported.
 0. FireCloud does not currently support file-path based imports.  Importing a workflow with file-based imports will result in error.  See [developer docs](/docs/publisher-tutorials/for-developers/#converting-file-path-based-imports-to-public-https-based-imports) for more info.
-0. Only support the WDL language.
+0. Only the WDL language is supported.

--- a/_docs/firecloud-launch-with.md
+++ b/_docs/firecloud-launch-with.md
@@ -12,8 +12,6 @@ information on what that looks like from a user point of view in a mini tutorial
 When browsing WDL workflows from within Dockstore, you will see a "Launch with FireCloud" button on the right. The currently selected
 version of the workflow will be exported, but this can subsequently be changed in the FireCloud UI if need be.
 
-Note: Workflows with file-based imports are unsupported in FireCloud, the button will be disabled for those workflow versions.
-
 ![WDL workflow](/assets/images/docs/firecloud/firecloud_from_dockstore1.png)
 
 If not logged into FireCloud, you will be prompted to login. Otherwise, or after login, you will be presented with the following screen. 

--- a/_docs/firecloud-launch-with.md
+++ b/_docs/firecloud-launch-with.md
@@ -12,6 +12,8 @@ information on what that looks like from a user point of view in a mini tutorial
 When browsing WDL workflows from within Dockstore, you will see a "Launch with FireCloud" button on the right. The currently selected
 version of the workflow will be exported, but this can subsequently be changed in the FireCloud UI if need be.
 
+Note: Workflows with file-based imports are unsupported in FireCloud, the button will be disabled for those workflow versions.
+
 ![WDL workflow](/assets/images/docs/firecloud/firecloud_from_dockstore1.png)
 
 If not logged into FireCloud, you will be prompted to login. Otherwise, or after login, you will be presented with the following screen. 

--- a/_docs/firecloud-launch-with.md
+++ b/_docs/firecloud-launch-with.md
@@ -36,3 +36,8 @@ Select the desired version in the dropdown.
  
 Note that you will want to double-check that the workflow specifies a runtime environment (docker, cpu, memory,
 and disks). 
+
+## Limitations
+0. Only launching of workflows is supported, not tools.
+0. FireCloud does not currently support file-path based imports.  Importing a workflow with file-based imports will result in error.  See [developer docs](/docs/publisher-tutorials/for-developers/#converting-file-path-based-imports-to-public-https-based-imports) for more info.
+0. Only support the WDL language.

--- a/_docs/for-developers.md
+++ b/_docs/for-developers.md
@@ -171,3 +171,26 @@ Registering many tools or very few tools?
         - Use the Write API webservice and client.  After some setup time (getting GitHub and Quay.io tokens, setting up service, etc), it allows you to programmatically create GitHub and Quay.io repositories on the fly, then register/publish them on Dockstore.
 
 Generally, Write API webservice and client has the highest setup time compared to the other methods of registering.  But, as you register more tools, the Write API tends to become the better choice (since it performs many intermediary steps for you).
+
+## Converting File-path Based Imports to Public http(s) Based Imports
+
+See https://cromwell.readthedocs.io/en/develop/Imports/ for a general knowledge on imports.  
+
+Imports allow you to reference other files in your workflow.  There are two types of resources that are supported in imports: http(s) and file-path based. Any public http(s) based URL can be used as the resource for an import, such as a website, GitHub, GA4GH compliant TES endpoint, and etc.
+
+There are times when you may want to convert file-path based imports to public http(s) imports.  One such reason is to ensure compatibility with FireCloud since it currently does not support file-path based imports.  There are so many different ways to convert to a public http(s) based import, the following are two examples.
+
+You can host your file on GitHub and import it in the workflow descriptor like Topmed does:
+
+```
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.11.0/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl" as TopMed_variantcaller
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.11.0/variant-caller/variant-caller-wdl-checker/topmed-variantcaller-checker.wdl" as checker
+...
+```
+
+Similarly, you can also host your file on a public google bucket and import it in the workflow descriptor like:
+
+```
+import "http://storage.googleapis.com/..."
+...
+```

--- a/_docs/for-developers.md
+++ b/_docs/for-developers.md
@@ -178,9 +178,9 @@ See https://cromwell.readthedocs.io/en/develop/Imports/ for a general knowledge 
 
 Imports allow you to reference other files in your workflow.  There are two types of resources that are supported in imports: http(s) and file-path based. Any public http(s) based URL can be used as the resource for an import, such as a website, GitHub, GA4GH compliant TES endpoint, and etc.
 
-There are times when you may want to convert file-path based imports to public http(s) imports.  One such reason is to ensure compatibility with FireCloud since it currently does not support file-path based imports.  There are so many different ways to convert to a public http(s) based import, the following are two examples.
+There are times when you may want to convert file-path based imports to public http(s) imports.  One such reason is to ensure compatibility with FireCloud since it currently does not support file-path based imports.  There are many different ways to convert to a public http(s) based import, the following are two examples.
 
-You can host your file on GitHub and import it in the workflow descriptor like Topmed does:
+You can host your file on GitHub and import it in the workflow descriptor like this:
 
 ```
 import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.11.0/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl" as TopMed_variantcaller
@@ -188,7 +188,7 @@ import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.11.0/
 ...
 ```
 
-Similarly, you can also host your file on a public google bucket and import it in the workflow descriptor like:
+Similarly, you can also host your file on a public google bucket and import it in the workflow descriptor like this:
 
 ```
 import "http://storage.googleapis.com/..."

--- a/_docs/language-support.md
+++ b/_docs/language-support.md
@@ -10,13 +10,12 @@ To help lay out what parts of Dockstore are available in which languages, we cov
 
 {% include language-support.html %}
 
-<sup>[1] See [FireCloud Limitations](/docs/user-tutorials/firecloud-launch-with/#limitations) for limitations
+<sup>[1] Does not support file-path based imports. See [FireCloud Limitations](/docs/user-tutorials/firecloud-launch-with/#limitations) for limitations.
 </sup>
 
-<sup>[2] See [DNAStack Limitations](/docs/user-tutorials/dnastack-launch-with/#limitations) for limitations
+<sup>[2] Does not support file-path or http(s) based imports. See [DNAStack Limitations](/docs/user-tutorials/dnastack-launch-with/#limitations) for limitations.
 </sup>
 
-<sup> [3] The handful of verified WDL tools/workflows were tested successfully.  More verification/testing likely needed.</sup>
+<sup> [3] The small number of verified Dockstore WDL tools/workflows were tested successfully.  More verification/testing likely needed.</sup>
 
-<sup> [4] Bunny file output provisioning fails if the parameter file has "metadata" property or similar, see https://github.com/ga4gh/dockstore/issues/1317 </sup>
 <!-- &ast; Nextflow has preliminary support for workflow registration -->

--- a/_docs/language-support.md
+++ b/_docs/language-support.md
@@ -10,10 +10,13 @@ To help lay out what parts of Dockstore are available in which languages, we cov
 
 {% include language-support.html %}
 
-<sup>[1] Some verified tools/workflows are known to execute unsuccessfully with Bunny.  As a result, these tools/workflows will also execute unsuccessfully with Bunny through Dockstore.
+<sup>[1] See [FireCloud Limitations](/docs/user-tutorials/firecloud-launch-with/#limitations) for limitations
 </sup>
 
-<sup> [2] The handful of verified WDL tools/workflows were tested successfully.  More verification/testing likely needed.</sup>
+<sup>[2] See [DNAStack Limitations](/docs/user-tutorials/dnastack-launch-with/#limitations) for limitations
+</sup>
 
-<sup> [3] Bunny file output provisioning fails if the parameter file has "metadata" property or similar, see https://github.com/ga4gh/dockstore/issues/1317 </sup>
+<sup> [3] The handful of verified WDL tools/workflows were tested successfully.  More verification/testing likely needed.</sup>
+
+<sup> [4] Bunny file output provisioning fails if the parameter file has "metadata" property or similar, see https://github.com/ga4gh/dockstore/issues/1317 </sup>
 <!-- &ast; Nextflow has preliminary support for workflow registration -->

--- a/_includes/language-support.html
+++ b/_includes/language-support.html
@@ -107,13 +107,9 @@
         <tr>
             <td>File Provisioning Out</td>
             <td class="success">Local File System
-                <sup>[4]</sup>
                 <br>HTTP
-                <sup>[4]</sup>
                 <br>FTP
-                <sup>[4]</sup>
                 <br>S3 via plugins 
-                <sup>[4]</sup>
             </td>
             <td class="warning">Local File System
             </td>

--- a/_includes/language-support.html
+++ b/_includes/language-support.html
@@ -51,8 +51,10 @@
         <tr>
             <td>Launch-with Platforms</td>
             <td class="danger">N/A</td>
-            <td class="success">FireCloud
-                <br>DNAStack (workflows only)</td>
+            <td class="success">
+                FireCloud (HTTP imports supported, but not file-based imports)
+                <br>
+                DNAStack (workflows only, no imports supported)</td>
         </tr>
         <tr>
             <td>Metadata Extraction</td>

--- a/_includes/language-support.html
+++ b/_includes/language-support.html
@@ -52,9 +52,9 @@
             <td>Launch-with Platforms</td>
             <td class="danger">N/A</td>
             <td class="success">
-                FireCloud (HTTP imports supported, but not file-based imports)
+                FireCloud (workflows only)<sup>[1]</sup>
                 <br>
-                DNAStack (workflows only, no imports supported)</td>
+                DNAStack (workflows only)<sup>[2]</sup></td>
         </tr>
         <tr>
             <td>Metadata Extraction</td>
@@ -68,12 +68,10 @@
         </tr>
         <tr>
             <td>Local workflow engines</td>
-            <td class="success">Bunny
-                <sup>[1]</sup>
-                <br>cwltool
+            <td class="success">cwltool
             </td>
             <td class="success">Cromwell
-                <sup>[2]</sup>
+                <sup>[3]</sup>
             </td>
         </tr>
         <tr>
@@ -109,13 +107,13 @@
         <tr>
             <td>File Provisioning Out</td>
             <td class="success">Local File System
-                <sup>[3]</sup>
+                <sup>[4]</sup>
                 <br>HTTP
-                <sup>[3]</sup>
+                <sup>[4]</sup>
                 <br>FTP
-                <sup>[3]</sup>
+                <sup>[4]</sup>
                 <br>S3 via plugins 
-                <sup>[3]</sup>
+                <sup>[4]</sup>
             </td>
             <td class="warning">Local File System
             </td>


### PR DESCRIPTION
Part of #1548 

Updating the language-support table, also add some warnings into the launch-with docs.  The latter might not even be necessary if the disabled button has a tooltip that provides this information