### PR TITLE
For shared flows, don't show roles without workflows

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -725,6 +725,7 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
                     }).filter(w -> w != null).collect(Collectors.toList());
                     return new SharedWorkflows(e.getKey(), workflows);
                 })
+                .filter(sharedWorkflow -> sharedWorkflow.getWorkflows().size() > 0)
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
If a SharedWorkflows object has no workflows, don't return it.

This can happen if workflowDAO.findByPath doesn't find the any of the
workflows for a given role. I believe this is an unlikely scenario, but
I've seen it an a dev environment where I register a resource with SAM,
then effectively delete the resource by reinitializing my database, so
that SAM ends up pointing to a resource that doesn't exist.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
