### PR TITLE
Permissions API Cleanup

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceConfiguration.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceConfiguration.java
@@ -107,7 +107,7 @@ public class DockstoreWebserviceConfiguration extends Configuration {
 
     private String authorizerType = null;
 
-    private List<String> externalGoogleClientIds = new ArrayList<>();
+    private List<String> externalGoogleClientIdPrefixes = new ArrayList<>();
 
     @JsonProperty("database")
     public DataSourceFactory getDataSourceFactory() {
@@ -391,13 +391,13 @@ public class DockstoreWebserviceConfiguration extends Configuration {
      * to getGoogleClientID, and is intended for any external Google clients that Dockstore will accept tokens from.
      * @return a list of google client ids
      */
-    @JsonProperty("externalGoogleClientIds")
-    public List<String> getExternalGoogleClientIds() {
-        return externalGoogleClientIds;
+    @JsonProperty("externalGoogleClientIdPrefixes")
+    public List<String> getExternalGoogleClientIdPrefixes() {
+        return externalGoogleClientIdPrefixes;
     }
 
-    public void setExternalGoogleClientIds(List<String> externalGoogleClientIds) {
-        this.externalGoogleClientIds = externalGoogleClientIds;
+    public void setExternalGoogleClientIdPrefixes(List<String> externalGoogleClientIdPrefixes) {
+        this.externalGoogleClientIdPrefixes = externalGoogleClientIdPrefixes;
     }
 
     public class ElasticSearchConfig {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GoogleHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GoogleHelper.java
@@ -126,7 +126,16 @@ public final class GoogleHelper {
 
     static boolean isValidAudience(Tokeninfo tokenInfo) {
         final String audience = tokenInfo.getAudience();
-        return config.getGoogleClientID().equals(audience) || config.getExternalGoogleClientIds().contains(audience);
+        if (config.getGoogleClientID().equals(audience)) {
+            return true;
+        } else {
+            final int index = audience.indexOf('-');
+            if (index != -1) {
+                final String prefix = audience.substring(0, index);
+                return config.getExternalGoogleClientIdPrefixes().contains(prefix);
+            }
+        }
+        return false;
     }
 
     private static Optional<Tokeninfo> tokenInfoFromToken(String googleToken) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/NoOpPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/NoOpPermissionsImpl.java
@@ -14,7 +14,7 @@ import io.dockstore.webservice.core.Workflow;
 public class NoOpPermissionsImpl implements PermissionsInterface {
 
     @Override
-    public List<Permission> setPermission(Workflow workflow, User requester, Permission permission) {
+    public List<Permission> setPermission(User requester, Workflow workflow, Permission permission) {
         return Collections.emptyList();
     }
 
@@ -24,13 +24,8 @@ public class NoOpPermissionsImpl implements PermissionsInterface {
     }
 
     @Override
-    public List<Permission> getPermissionsForWorkflow(User user, Workflow workflow) {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public void removePermission(Workflow workflow, User user, String email, Role role) {
-
+    public void removePermission(User user, Workflow workflow, String email, Role role) {
+        PermissionsInterface.checkUserNotOriginalOwner(email, workflow);
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -725,6 +725,7 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
                 .workflowsSharedWithUser(user).entrySet().stream()
                 .map(e -> {
                     final List<Workflow> workflows = e.getValue().stream().map(path -> {
+                        // TODO: Fetch workflows in bulk rather than 1 by 1.
                         final Workflow workflow = workflowDAO.findByPath(path, false);
                         // If user is the owner of the workflow, don't include it as shared with
                         if (workflow != null && !workflow.getUsers().contains(user)) {
@@ -860,6 +861,7 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
             @ApiParam(value = "user permission", required = true) Permission permission) {
         Workflow workflow = workflowDAO.findByPath(path, false);
         checkEntry(workflow);
+        // TODO: Remove this guard when ready to expand sharing to non-hosted workflows. https://github.com/ga4gh/dockstore/issues/1593
         if (workflow.getMode() != WorkflowMode.HOSTED) {
             throw new CustomWebApplicationException("Setting permissions is only allowed on hosted workflows.", HttpStatus.SC_BAD_REQUEST);
         }

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -4066,7 +4066,9 @@ paths:
       tags:
         - workflows
       summary: Set the specified permission for a user on a workflow
-      description: Adds a permission for a workflow. The user must be the workflow owner.
+      description: >-
+        Adds a permission for a workflow. The user must be the workflow owner.
+        Currently only supported on hosted workflows.
       operationId: addWorkflowPermission
       parameters:
         - name: repository

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -3745,7 +3745,7 @@ paths:
       - "workflows"
       summary: "Set the specified permission for a user on a workflow"
       description: "Adds a permission for a workflow. The user must be the workflow\
-        \ owner."
+        \ owner. Currently only supported on hosted workflows."
       operationId: "addWorkflowPermission"
       produces:
       - "application/json"

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/GoogleHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/GoogleHelperTest.java
@@ -13,18 +13,20 @@ import static org.mockito.Mockito.when;
 
 public class GoogleHelperTest {
 
-    private static final String ID1 = "id1";
-    private static final String ID2 = "id2";
-    private static final String ID3 = "id3";
+    private static final String SUFFIX = "-abcdefghijklmnopqrstuvwxyz123456.apps.googleusercontent.com";
+    private static final String AUDIENCE1 = "123456789012" + SUFFIX;
+    private static final String EXTERNAL_PREFIX = "987654321098";
+    private static final String EXTERNAL_AUDIENCE = EXTERNAL_PREFIX + SUFFIX;
+    private static final String INVALID_AUDIENCE = "extremelyunlikelyaudiencewithoutadash";
 
     @Test
     public void isValidAudience() {
         final DockstoreWebserviceConfiguration config = new DockstoreWebserviceConfiguration();
-        config.setGoogleClientID(ID1);
-        config.getExternalGoogleClientIds().add(ID2);
+        config.setGoogleClientID(AUDIENCE1);
+        config.getExternalGoogleClientIdPrefixes().add(EXTERNAL_PREFIX);
         GoogleHelper.setConfig(config);
         final Tokeninfo tokeninfo = Mockito.mock(Tokeninfo.class);
-        when(tokeninfo.getAudience()).thenReturn(ID1).thenReturn(ID2).thenReturn(ID3);
+        when(tokeninfo.getAudience()).thenReturn(AUDIENCE1).thenReturn(EXTERNAL_AUDIENCE).thenReturn(INVALID_AUDIENCE);
         Assert.assertTrue(GoogleHelper.isValidAudience(tokeninfo));
         Assert.assertTrue(GoogleHelper.isValidAudience(tokeninfo));
         Assert.assertFalse(GoogleHelper.isValidAudience(tokeninfo));

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/InMemoryPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/InMemoryPermissionsImplTest.java
@@ -1,15 +1,20 @@
 package io.dockstore.webservice.permissions;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 import static org.mockito.Mockito.spy;
@@ -22,9 +27,13 @@ public class InMemoryPermissionsImplTest {
     public static final String DOCKSTORE_ORG_JOHN_MYWORKFLOW = "dockstore.org/john/myworkflow";
     private InMemoryPermissionsImpl inMemoryPermissions;
     private User userMock = Mockito.mock(User.class);
+    private User user2 = new User();
     private Workflow fooWorkflow;
     private Workflow gooWorkflow;
     private Workflow dockstoreOrgWorkflow;
+
+    @Rule
+    public ExpectedException thrown= ExpectedException.none();
 
     @Before
     public void setup() {
@@ -33,13 +42,17 @@ public class InMemoryPermissionsImplTest {
         gooWorkflow = Mockito.mock(Workflow.class);
         dockstoreOrgWorkflow = Mockito.mock(Workflow.class);
         when(fooWorkflow.getWorkflowPath()).thenReturn("foo");
+        when(fooWorkflow.getUsers()).thenReturn(new HashSet<>(Arrays.asList(userMock)));
         when(gooWorkflow.getWorkflowPath()).thenReturn("goo");
+        when(gooWorkflow.getUsers()).thenReturn(new HashSet<>(Arrays.asList(userMock)));
         when(dockstoreOrgWorkflow.getWorkflowPath()).thenReturn(DOCKSTORE_ORG_JOHN_MYWORKFLOW);
+        when(dockstoreOrgWorkflow.getUsers()).thenReturn(new HashSet<>(Arrays.asList(userMock)));
         Map<String, User.Profile> profiles = new HashMap<>();
         User.Profile profile = new User.Profile();
         profile.email = JOHN_DOE_EXAMPLE_COM;
         profiles.put(TokenType.GOOGLE_COM.toString(), profile);
         when(userMock.getUserProfiles()).thenReturn(profiles);
+        user2.setUsername("joan");
     }
 
     @Test
@@ -47,7 +60,7 @@ public class InMemoryPermissionsImplTest {
         final Permission permission = new Permission();
         permission.setRole(Role.WRITER);
         permission.setEmail(JANE_DOE_EXAMPLE_COM);
-        final List<Permission> permissions = inMemoryPermissions.setPermission(fooWorkflow, userMock, permission);
+        final List<Permission> permissions = inMemoryPermissions.setPermission(userMock, fooWorkflow, permission);
         Assert.assertEquals(permissions.get(0), permission);
     }
 
@@ -57,11 +70,11 @@ public class InMemoryPermissionsImplTest {
         final Permission permission = new Permission();
         permission.setRole(Role.WRITER);
         permission.setEmail(JOHN_DOE_EXAMPLE_COM);
-        inMemoryPermissions.setPermission(fooWorkflow, userMock, permission);
-        inMemoryPermissions.setPermission(gooWorkflow, userMock, permission);
+        inMemoryPermissions.setPermission(userMock, fooWorkflow, permission);
+        inMemoryPermissions.setPermission(userMock, gooWorkflow, permission);
         Assert.assertEquals(1, inMemoryPermissions.workflowsSharedWithUser(userMock).size());
         permission.setRole(Role.READER);
-        inMemoryPermissions.setPermission(dockstoreOrgWorkflow, userMock, permission);
+        inMemoryPermissions.setPermission(userMock, dockstoreOrgWorkflow, permission);
         final Map<Role, List<String>> roleListMap = inMemoryPermissions.workflowsSharedWithUser(userMock);
         Assert.assertEquals(2, roleListMap.size());
         Assert.assertEquals(DOCKSTORE_ORG_JOHN_MYWORKFLOW, roleListMap.get(Role.READER).get(0));
@@ -73,12 +86,12 @@ public class InMemoryPermissionsImplTest {
         final Permission permission = new Permission();
         permission.setRole(Role.WRITER);
         permission.setEmail(JOHN_DOE_EXAMPLE_COM);
-        inMemoryPermissions.setPermission(fooWorkflow, userMock, permission);
-        inMemoryPermissions.setPermission(gooWorkflow, userMock, permission);
+        inMemoryPermissions.setPermission(userMock, fooWorkflow, permission);
+        inMemoryPermissions.setPermission(userMock, gooWorkflow, permission);
         final Map<Role, List<String>> sharedWithUser = inMemoryPermissions.workflowsSharedWithUser(userMock);
         Assert.assertEquals(1, sharedWithUser.size());
         Assert.assertEquals(2, sharedWithUser.entrySet().iterator().next().getValue().size());
-        inMemoryPermissions.removePermission(fooWorkflow, userMock, JOHN_DOE_EXAMPLE_COM, Role.WRITER);
+        inMemoryPermissions.removePermission(userMock, fooWorkflow, JOHN_DOE_EXAMPLE_COM, Role.WRITER);
         final Map<Role, List<String>> sharedWithUser1 = inMemoryPermissions.workflowsSharedWithUser(userMock);
         Assert.assertEquals(1, sharedWithUser1.size());
         Assert.assertEquals(1, sharedWithUser1.entrySet().iterator().next().getValue().size());
@@ -90,9 +103,18 @@ public class InMemoryPermissionsImplTest {
         final Permission permission = new Permission();
         permission.setRole(Role.READER);
         permission.setEmail(JOHN_DOE_EXAMPLE_COM);
-        inMemoryPermissions.setPermission(fooWorkflow, userMock, permission);
+        inMemoryPermissions.setPermission(userMock, fooWorkflow, permission);
         Assert.assertTrue(inMemoryPermissions.canDoAction(userMock, fooWorkflow, Role.Action.READ));
         Assert.assertFalse(inMemoryPermissions.canDoAction(userMock, fooWorkflow, Role.Action.WRITE));
+    }
+
+    @Test
+    public void getPermissionsUnauthorized() {
+        final Permission permission = new Permission();
+        permission.setRole(Role.READER);
+        permission.setEmail("whatever");
+        thrown.expect(CustomWebApplicationException.class);
+        inMemoryPermissions.setPermission(user2, fooWorkflow, permission);
     }
 
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/PermissionsInterfaceTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/PermissionsInterfaceTest.java
@@ -1,0 +1,107 @@
+package io.dockstore.webservice.permissions;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.TokenType;
+import io.dockstore.webservice.core.User;
+import io.dockstore.webservice.core.Workflow;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.when;
+
+public class PermissionsInterfaceTest {
+
+    public static final String JOHN_DOE_EXAMPLE_COM = "john.doe@example.com";
+    public static final String JANE_DOE_EXAMPLE_COM = "jane.doe@example.com";
+    private User user1;
+    private Permission janeDoeOwnerPermission;
+    private Permission janeDoeWriterPermission;
+    private User user2;
+    private PermissionsInterface permissionsInterface;
+
+    private Workflow workflow = Mockito.mock(Workflow.class);
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setup() {
+        user1 = new User();
+        user1.setUsername(JOHN_DOE_EXAMPLE_COM);
+        final User.Profile profile1 = new User.Profile();
+        profile1.email = JOHN_DOE_EXAMPLE_COM;
+        user1.getUserProfiles().put(TokenType.GOOGLE_COM.toString(), profile1);
+
+        user2 = new User();
+        user2.setUsername(JANE_DOE_EXAMPLE_COM);
+        final User.Profile profile2 = new User.Profile();
+        profile2.email = JANE_DOE_EXAMPLE_COM;
+        user2.getUserProfiles().put(TokenType.GOOGLE_COM.toString(), profile2);
+
+        janeDoeOwnerPermission = new Permission();
+        janeDoeOwnerPermission.setRole(Role.OWNER);
+        janeDoeOwnerPermission.setEmail(JANE_DOE_EXAMPLE_COM);
+        janeDoeWriterPermission = new Permission();
+        janeDoeWriterPermission.setEmail(JOHN_DOE_EXAMPLE_COM);
+        janeDoeWriterPermission.setRole(Role.WRITER);
+
+        permissionsInterface = new PermissionsInterface() {
+            @Override
+            public List<Permission> setPermission(User requester, Workflow workflow, Permission permission) {
+                return null;
+            }
+
+            @Override
+            public Map<Role, List<String>> workflowsSharedWithUser(User user) {
+                return null;
+            }
+
+            @Override
+            public void removePermission(User user, Workflow workflow, String email, Role role) {
+            }
+
+            @Override
+            public boolean canDoAction(User user, Workflow workflow, Role.Action action) {
+                return false;
+            }
+        };
+    }
+
+    @Test
+    public void mergePermissions() {
+        Assert.assertEquals(2, PermissionsInterface.mergePermissions(Arrays.asList(janeDoeOwnerPermission), Arrays.asList(
+                janeDoeOwnerPermission, janeDoeWriterPermission)).size());
+    }
+
+    @Test
+    public void getOriginalOwnersForWorkflow() {
+        final Set<User> users = new HashSet<>(Arrays.asList(user1));
+        workflow = Mockito.mock(Workflow.class);
+        when(workflow.getUsers()).thenReturn(users);
+
+        Assert.assertEquals(1, PermissionsInterface.getOriginalOwnersForWorkflow(workflow).size());
+    }
+
+    @Test
+    public void unauthorizedGetPermissionsForWorkflow() {
+        final Set<User> users = new HashSet<>(Arrays.asList(user1));
+        when(workflow.getUsers()).thenReturn(users);
+        thrown.expect(CustomWebApplicationException.class);
+        permissionsInterface.getPermissionsForWorkflow(user2, workflow);
+    }
+
+    @Test
+    public void checkUserNotOriginalOwner() {
+
+    }
+}

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
+import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.jdbi.TokenDAO;
@@ -89,6 +90,7 @@ public class SamPermissionsImplTest {
         when(configMock.getSamConfiguration()).thenReturn(new DockstoreWebserviceConfiguration.SamConfiguration());
         samPermissionsImpl = Mockito.spy(new SamPermissionsImpl(tokenDAO, configMock));
         doReturn(Optional.of("my token")).when(samPermissionsImpl).googleAccessToken(userMock);
+        doReturn(Mockito.mock(Token.class)).when(samPermissionsImpl).googleToken(userMock);
         resourcesApiMock = Mockito.mock(ResourcesApi.class);
         apiClient = Mockito.mock(ApiClient.class);
         when(apiClient.escapeString(ArgumentMatchers.anyString()))
@@ -216,7 +218,7 @@ public class SamPermissionsImplTest {
         Permission permission = new Permission();
         permission.setEmail(JANE_DOE_GMAIL_COM);
         permission.setRole(Role.READER);
-        List<Permission> permissions = samPermissionsImpl.setPermission(fooWorkflow, userMock, permission);
+        List<Permission> permissions = samPermissionsImpl.setPermission(userMock, fooWorkflow, permission);
         Assert.assertEquals(permissions.size(), 1);
     }
 
@@ -228,7 +230,7 @@ public class SamPermissionsImplTest {
             permission.setEmail("jdoe@example.com");
             permission.setRole(Role.WRITER);
             thrown.expect(CustomWebApplicationException.class);
-            samPermissionsImpl.setPermission(fooWorkflow, userMock, permission);
+            samPermissionsImpl.setPermission(userMock, fooWorkflow, permission);
             Assert.fail("setPermissions did not throw Exception");
         } catch (ApiException e) {
             Assert.fail();
@@ -248,7 +250,7 @@ public class SamPermissionsImplTest {
                     .thenReturn( Arrays.asList(readerAccessPolicyResponseEntry));
             try {
                 setupInitializePermissionsMocks(SamConstants.WORKFLOW_PREFIX + FOO_WORKFLOW_NAME);
-                final List<Permission> permissions = samPermissionsImpl.setPermission(fooWorkflow, userMock, permission);
+                final List<Permission> permissions = samPermissionsImpl.setPermission(userMock, fooWorkflow, permission);
                 Assert.assertEquals(permissions.size(), 1);
             } catch (CustomWebApplicationException ex) {
                 Assert.fail("setPermissions threw Exception");
@@ -266,7 +268,7 @@ public class SamPermissionsImplTest {
         final List<Permission> permissions = samPermissionsImpl.getPermissionsForWorkflow(userMock, fooWorkflow);
         Assert.assertEquals(permissions.size(), 1);
         try {
-            samPermissionsImpl.removePermission(fooWorkflow, userMock, JANE_DOE_GMAIL_COM, Role.READER);
+            samPermissionsImpl.removePermission(userMock, fooWorkflow, JANE_DOE_GMAIL_COM, Role.READER);
         } catch (CustomWebApplicationException e) {
             Assert.fail();
         }


### PR DESCRIPTION
Fixes #1582

Original owners are what Workflow.getUsers() returns. These are
the users who created the hosted workflow or belong to the GitHub
repo of a workflow. This commit resolves those users with users
who have been authorized via SAM, users that sometimes overlap, as well
as other issues.

* Don't allow "original owners" to remove themselves as owners.
* Also return "original owners" when fetching permissions.
* When returning shared workflows, don't return workflows that you
are an original owner of.
* If you are not an owner of a workflow, the request to get permissions
for that workflow now fails
* If you are not logged in with Google, requesting workflows shared
with you know returns an empty map instead of a 401.
* Change check for audience to only be prefix

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
