### PR TITLE
Make Allow header readable for CORS

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -212,6 +212,7 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
 
         final Response.ResponseBuilder builder = Response.ok();
         headers.forEach(header -> builder.header(HttpHeaders.ALLOW, header));
+        builder.header("Access-Control-Expose-Headers", HttpHeaders.ALLOW);
         return builder.build();
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -789,6 +789,7 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
 
         final Response.ResponseBuilder builder = Response.ok();
         headers.forEach(header -> builder.header(HttpHeaders.ALLOW, header));
+        builder.header("Access-Control-Expose-Headers", HttpHeaders.ALLOW);
         return builder.build();
     }
 


### PR DESCRIPTION
Part of fix for #1589

Was setting Allow header with allowed methods, but browser code was
not able to read it.

Unfortunately, I couldn't find an existing constant for the header name.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
