### PR TITLE
Return empty map of shared workflows if not in SAM

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
@@ -125,6 +125,10 @@ public class SamPermissionsImpl implements PermissionsInterface {
                     }).collect(Collectors.toList())));
         } catch (ApiException e) {
             LOG.error("Error getting shared workflows", e);
+            if (e.getCode() == HttpStatus.SC_UNAUTHORIZED) {
+                // If user is unauthorized in SAM, then nothing has been shared with that user
+                return Collections.emptyMap();
+            }
             throw new CustomWebApplicationException("Error getting shared workflows", e.getCode());
         }
     }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
@@ -274,6 +274,14 @@ public class SamPermissionsImplTest {
         }
     }
 
+    @Test
+    public void userNotInSamReturnsEmptyMap() throws ApiException {
+        // https://github.com/ga4gh/dockstore/issues/1597
+        when(resourcesApiMock.listResourcesAndPolicies(SamConstants.RESOURCE_TYPE)).thenThrow(new ApiException(HttpStatus.SC_UNAUTHORIZED, "Unauthorized"));
+        final Map<Role, List<String>> sharedWithUser = samPermissionsImpl.workflowsSharedWithUser(userMock);
+        Assert.assertEquals(0, sharedWithUser.size());
+    }
+
     private void setupInitializePermissionsMocks(String encodedPath) {
         try {
             doNothing().when(resourcesApiMock).createResourceWithDefaults(anyString(), anyString());


### PR DESCRIPTION
Fixes #1597

If user is unauthorized in SAM, e.g., you have a Google token but
haven't registered with FireCloud, you will get a 401 making SAM
API calls. In that case, just return an empty map instead of
throwing an exception, as that is legitimate.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
