### PR TITLE
Optional auth for TRS endpoints

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BaseIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BaseIT.java
@@ -90,4 +90,18 @@ public class BaseIT {
             .runSelectStatement("select content from token where tokensource='dockstore';", new ScalarHandler<>())));
         return client;
     }
+
+    /**
+     * Shared convenience method
+     * @return
+     * @throws IOException
+     * @throws TimeoutException
+     */
+    protected static ApiClient getAnonWebClient() {
+        File configFile = FileUtils.getFile("src", "test", "resources", "config2");
+        INIConfiguration parseConfig = Utilities.parseConfig(configFile.getAbsolutePath());
+        ApiClient client = new ApiClient();
+        client.setBasePath(parseConfig.getString(Constants.WEBSERVICE_BASE_PATH));
+        return client;
+    }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -948,10 +948,19 @@ public class WorkflowIT extends BaseIT {
 
         // can get relative paths with admin user
         toolFiles.forEach(file -> {
-            ToolDescriptor toolDescriptor = adminGa4Ghv2Api
-                .toolsIdVersionsVersionIdTypeDescriptorRelativePathGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW,
+            if (file.getFileType() == ToolFile.FileTypeEnum.TEST_FILE) {
+                // enable later with a simplification to TRS
+//                ToolTests test = (ToolTests)adminGa4Ghv2Api.toolsIdVersionsVersionIdTypeDescriptorRelativePathGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW,
+//                    "master", file.getPath());
+//                assertTrue("test exists", !test.getTest().isEmpty());
+            } else if (file.getFileType() == ToolFile.FileTypeEnum.PRIMARY_DESCRIPTOR || file.getFileType() == ToolFile.FileTypeEnum.SECONDARY_DESCRIPTOR) {
+                // annoyingly, some files are tool tests, some are tooldescriptor
+                ToolDescriptor toolDescriptor = adminGa4Ghv2Api.toolsIdVersionsVersionIdTypeDescriptorRelativePathGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW,
                     "master", file.getPath());
-            assertTrue("descriptor exists", !toolDescriptor.getDescriptor().isEmpty());
+                assertTrue("descriptor exists", !toolDescriptor.getDescriptor().isEmpty());
+            } else {
+                fail();
+            }
         });
 
         // check on urls created for test files

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -180,27 +180,31 @@ public class WorkflowIT extends BaseIT {
         assertEquals("should find 4 valid versions for bitbucket workflow, found : " + refreshBitbucket.getWorkflowVersions().stream()
                 .filter(WorkflowVersion::isValid).count(), 4,
             refreshBitbucket.getWorkflowVersions().stream().filter(WorkflowVersion::isValid).count());
+
+        // should not be able to get content normally
+        Ga4GhApi anonymousGa4Ghv2Api = new Ga4GhApi(getAnonWebClient());
+        Ga4GhApi adminGa4Ghv2Api = new Ga4GhApi(webClient);
+        boolean exceptionThrown = false;
+        try {
+            anonymousGa4Ghv2Api
+                .toolsIdVersionsVersionIdTypeDescriptorGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_DOCKSTORE_WORKFLOW, "master");
+        } catch (ApiException e) {
+            exceptionThrown = true;
+        }
+        assertTrue(exceptionThrown);
+        ToolDescriptor adminToolDesciptor = adminGa4Ghv2Api
+            .toolsIdVersionsVersionIdTypeDescriptorGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_DOCKSTORE_WORKFLOW, "master");
+        assertTrue("could not get content via optional auth", adminToolDesciptor != null && !adminToolDesciptor.getDescriptor().isEmpty());
+
         workflowApi.publish(workflowByPathBitbucket.getId(), new PublishRequest(){
             public Boolean isPublish() { return true;}
         });
         // check on URLs for workflows via ga4gh calls
-        Ga4GhApi ga4Ghv2Api = new Ga4GhApi(webClient);
-        ToolDescriptor toolDescriptor = ga4Ghv2Api
+        ToolDescriptor toolDescriptor = adminGa4Ghv2Api
             .toolsIdVersionsVersionIdTypeDescriptorGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_DOCKSTORE_WORKFLOW, "master");
         String content = IOUtils.toString(new URI(toolDescriptor.getUrl()), StandardCharsets.UTF_8);
         Assert.assertTrue("could not find content from generated URL", !content.isEmpty());
-        checkForRelativeFile(ga4Ghv2Api, "#workflow/" + DOCKSTORE_TEST_USER2_DOCKSTORE_WORKFLOW, "master", "grep.cwl");
-
-
-        workflowApi.publish(workflowByPathBitbucket.getId(), new PublishRequest(){
-            public Boolean isPublish() { return true;}
-        });
-        // check on URLs for workflows via ga4gh calls
-        toolDescriptor = ga4Ghv2Api
-            .toolsIdVersionsVersionIdTypeDescriptorGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_DOCKSTORE_WORKFLOW, "master");
-        content = IOUtils.toString(new URI(toolDescriptor.getUrl()), StandardCharsets.UTF_8);
-        Assert.assertTrue("could not find content from generated URL", !content.isEmpty());
-        checkForRelativeFile(ga4Ghv2Api, "#workflow/" + DOCKSTORE_TEST_USER2_DOCKSTORE_WORKFLOW, "master", "grep.cwl");
+        checkForRelativeFile(adminGa4Ghv2Api, "#workflow/" + DOCKSTORE_TEST_USER2_DOCKSTORE_WORKFLOW, "master", "grep.cwl");
 
 
         // check on commit ids for github
@@ -892,6 +896,70 @@ public class WorkflowIT extends BaseIT {
         assertTrue("could not find tool tests", toolTests.size() > 0);
         for(ToolTests test: toolTests) {
             content = IOUtils.toString(new URI(test.getUrl()), StandardCharsets.UTF_8);
+            Assert.assertTrue("could not find content from generated test JSON URL", !content.isEmpty());
+        }
+    }
+
+    @Test
+    public void testAnonAndAdminGA4GH() throws ApiException, URISyntaxException, IOException {
+        WorkflowsApi workflowApi = new WorkflowsApi(getWebClient());
+        workflowApi.manualRegister("github", "DockstoreTestUser2/dockstore_workflow_cnv", "/workflow/cnv.cwl", "", "cwl", "/test.json");
+        final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW);
+        workflowApi.refresh(workflowByPathGithub.getId());
+
+        // should not be able to get content normally
+        Ga4GhApi anonymousGa4Ghv2Api = new Ga4GhApi(getAnonWebClient());
+        boolean thrownException = false;
+        try {
+            anonymousGa4Ghv2Api
+                .toolsIdVersionsVersionIdTypeFilesGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, "master");
+        } catch (ApiException e) {
+            thrownException = true;
+        }
+        assert (thrownException);
+
+        boolean thrownListException = false;
+        try {
+            anonymousGa4Ghv2Api
+                .toolsIdVersionsVersionIdTypeTestsGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, "master");
+        } catch (ApiException e) {
+            thrownListException = true;
+        }
+        assert (thrownListException);
+
+        // can get content via admin user
+        Ga4GhApi adminGa4Ghv2Api = new Ga4GhApi(getWebClient());
+
+        List<ToolFile> toolFiles = adminGa4Ghv2Api
+            .toolsIdVersionsVersionIdTypeFilesGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, "master");
+        assertTrue("should have at least 5 files", toolFiles.size() >= 5);
+
+        // cannot get relative paths anonymously
+        toolFiles.forEach(file -> {
+            boolean thrownInnerException = false;
+            try {
+                anonymousGa4Ghv2Api.toolsIdVersionsVersionIdTypeDescriptorRelativePathGet("CWL",
+                    "#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, "master", file.getPath());
+            } catch (ApiException e) {
+                thrownInnerException = true;
+            }
+            assertTrue(thrownInnerException);
+        });
+
+        // can get relative paths with admin user
+        toolFiles.forEach(file -> {
+            ToolDescriptor toolDescriptor = adminGa4Ghv2Api
+                .toolsIdVersionsVersionIdTypeDescriptorRelativePathGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW,
+                    "master", file.getPath());
+            assertTrue("descriptor exists", !toolDescriptor.getDescriptor().isEmpty());
+        });
+
+        // check on urls created for test files
+        List<ToolTests> toolTests = adminGa4Ghv2Api
+            .toolsIdVersionsVersionIdTypeTestsGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, "master");
+        assertTrue("could not find tool tests", toolTests.size() > 0);
+        for (ToolTests test : toolTests) {
+            String content = IOUtils.toString(new URI(test.getUrl()), StandardCharsets.UTF_8);
             Assert.assertTrue("could not find content from generated test JSON URL", !content.isEmpty());
         }
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -212,7 +212,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
         String metadata) {
         ToolsApiServiceImpl impl = new ToolsApiServiceImpl();
         ToolsApiServiceImpl.ParsedRegistryID parsedID = new ToolsApiServiceImpl.ParsedRegistryID(id);
-        Entry entry = impl.getEntry(parsedID);
+        Entry entry = impl.getEntry(parsedID, Optional.empty());
         Optional<? extends Version> versionOptional;
 
         if (entry instanceof Workflow) {

--- a/dockstore-webservice/src/main/java/io/swagger/api/MetadataApiV1.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/MetadataApiV1.java
@@ -15,6 +15,8 @@
  */
 package io.swagger.api;
 
+import java.util.Optional;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -45,6 +47,6 @@ public class MetadataApiV1 {
     @io.swagger.annotations.ApiResponses(value = {
         @io.swagger.annotations.ApiResponse(code = 200, message = "A Metadata object describing this service.", response = MetadataV1.class) })
     public Response metadataGet(@Context SecurityContext securityContext, @Context ContainerRequestContext containerRequestContext) throws NotFoundException {
-        return ApiVersionConverter.convertToVersion(delegate.metadataGet(securityContext, containerRequestContext));
+        return ApiVersionConverter.convertToVersion(delegate.metadataGet(securityContext, containerRequestContext, Optional.empty()));
     }
 }

--- a/dockstore-webservice/src/main/java/io/swagger/api/ToolClassesApiV1.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/ToolClassesApiV1.java
@@ -15,6 +15,8 @@
  */
 package io.swagger.api;
 
+import java.util.Optional;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -44,6 +46,6 @@ public class ToolClassesApiV1 {
     @io.swagger.annotations.ApiResponses(value = {
         @io.swagger.annotations.ApiResponse(code = 200, message = "An array of methods that match the filter.", response = ToolClass.class, responseContainer = "List") })
     public Response toolClassesGet(@Context SecurityContext securityContext, @Context ContainerRequestContext containerContext) throws NotFoundException {
-        return delegate.toolClassesGet(securityContext, containerContext);
+        return delegate.toolClassesGet(securityContext, containerContext, Optional.empty());
     }
 }

--- a/dockstore-webservice/src/main/java/io/swagger/api/ToolsApiV1.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/ToolsApiV1.java
@@ -15,6 +15,8 @@
  */
 package io.swagger.api;
 
+import java.util.Optional;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -63,7 +65,7 @@ public class ToolsApiV1 {
         @ApiParam(value = "Amount of records to return in a given page.  By default it is 1000.") @QueryParam("limit") Integer limit,
         @Context SecurityContext securityContext, @Context ContainerRequestContext value) throws NotFoundException {
         return ApiVersionConverter.convertToVersion(
-            delegate.toolsGet(id, null, registry, organization, name, toolname, description, author, null , offset, limit, securityContext, value));
+            delegate.toolsGet(id, null, registry, organization, name, toolname, description, author, null , offset, limit, securityContext, value, Optional.empty()));
     }
 
     @GET
@@ -77,7 +79,7 @@ public class ToolsApiV1 {
     public Response toolsIdGet(
         @ApiParam(value = "A unique identifier of the tool, scoped to this registry, for example `123456`", required = true) @PathParam("id") String id,
         @Context SecurityContext securityContext, @Context ContainerRequestContext value) throws NotFoundException {
-        return ApiVersionConverter.convertToVersion(delegate.toolsIdGet(id, securityContext, value));
+        return ApiVersionConverter.convertToVersion(delegate.toolsIdGet(id, securityContext, value, Optional.empty()));
     }
 
     @GET
@@ -92,7 +94,7 @@ public class ToolsApiV1 {
         @ApiParam(value = "A unique identifier of the tool, scoped to this registry, for example `123456`", required = true) @PathParam("id") String id,
         @Context SecurityContext securityContext, @Context ContainerRequestContext value) throws NotFoundException {
         return ApiVersionConverter
-            .convertToVersion(delegate.toolsIdVersionsGet(id, securityContext, value));
+            .convertToVersion(delegate.toolsIdVersionsGet(id, securityContext, value, Optional.empty()));
     }
 
     @GET
@@ -109,7 +111,7 @@ public class ToolsApiV1 {
         @ApiParam(value = "A unique identifier of the tool, scoped to this registry, for example `123456`", required = true) @PathParam("id") String id,
         @ApiParam(value = "An identifier of the tool version for this particular tool registry, for example `v1`", required = true) @PathParam("version_id") String versionId,
         @Context SecurityContext securityContext, @Context ContainerRequestContext value) throws NotFoundException {
-        return ApiVersionConverter.convertToVersion(delegate.toolsIdVersionsVersionIdContainerfileGet(id, versionId, securityContext, value));
+        return ApiVersionConverter.convertToVersion(delegate.toolsIdVersionsVersionIdContainerfileGet(id, versionId, securityContext, value, Optional.empty()));
     }
 
     @GET
@@ -124,7 +126,7 @@ public class ToolsApiV1 {
         @ApiParam(value = "A unique identifier of the tool, scoped to this registry, for example `123456`", required = true) @PathParam("id") String id,
         @ApiParam(value = "An identifier of the tool version, scoped to this registry, for example `v1`", required = true) @PathParam("version_id") String versionId,
         @Context SecurityContext securityContext, @Context ContainerRequestContext value) throws NotFoundException {
-        return ApiVersionConverter.convertToVersion(delegate.toolsIdVersionsVersionIdGet(id, versionId, securityContext, value));
+        return ApiVersionConverter.convertToVersion(delegate.toolsIdVersionsVersionIdGet(id, versionId, securityContext, value, Optional.empty()));
     }
 
     @GET
@@ -143,7 +145,7 @@ public class ToolsApiV1 {
         @ApiParam(value = "An identifier of the tool version for this particular tool registry, for example `v1`", required = true) @PathParam("version_id") String versionId,
         @Context SecurityContext securityContext, @Context ContainerRequestContext value) throws NotFoundException {
         return ApiVersionConverter
-            .convertToVersion(delegate.toolsIdVersionsVersionIdTypeDescriptorGet(type, id, versionId, securityContext, value));
+            .convertToVersion(delegate.toolsIdVersionsVersionIdTypeDescriptorGet(type, id, versionId, securityContext, value, Optional.empty()));
     }
 
     @GET
@@ -163,7 +165,7 @@ public class ToolsApiV1 {
         @ApiParam(value = "A relative path to the additional file (same directory or subdirectories), for example 'foo.cwl' would return a 'foo.cwl' from the same directory as the main descriptor", required = true) @PathParam("relative_path") String relativePath,
         @Context SecurityContext securityContext, @Context ContainerRequestContext value) throws NotFoundException {
         return ApiVersionConverter.convertToVersion(
-            delegate.toolsIdVersionsVersionIdTypeDescriptorRelativePathGet(type, id, versionId, relativePath, securityContext, value));
+            delegate.toolsIdVersionsVersionIdTypeDescriptorRelativePathGet(type, id, versionId, relativePath, securityContext, value, Optional.empty()));
     }
 
     @GET
@@ -182,6 +184,6 @@ public class ToolsApiV1 {
         @ApiParam(value = "An identifier of the tool version for this particular tool registry, for example `v1`", required = true) @PathParam("version_id") String versionId,
         @Context SecurityContext securityContext, @Context ContainerRequestContext value) throws NotFoundException {
         return ApiVersionConverter
-            .convertToVersion(delegate.toolsIdVersionsVersionIdTypeTestsGet(type, id, versionId, securityContext, value));
+            .convertToVersion(delegate.toolsIdVersionsVersionIdTypeTestsGet(type, id, versionId, securityContext, value, Optional.empty()));
     }
 }

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/MetadataApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/MetadataApiServiceImpl.java
@@ -16,17 +16,20 @@
 
 package io.swagger.api.impl;
 
+import java.util.Optional;
+
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
+import io.dockstore.webservice.core.User;
 import io.swagger.api.MetadataApiService;
 import io.swagger.api.NotFoundException;
 import io.swagger.model.Metadata;
 
 public class MetadataApiServiceImpl extends MetadataApiService {
     @Override
-    public Response metadataGet(SecurityContext securityContext, ContainerRequestContext containerContext) throws NotFoundException {
+    public Response metadataGet(SecurityContext securityContext, ContainerRequestContext containerContext, Optional<User> user) throws NotFoundException {
         Metadata metadata = new Metadata();
         metadata.setCountry("CAN");
         metadata.setApiVersion("2.0.0");

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolClassesApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolClassesApiServiceImpl.java
@@ -18,11 +18,13 @@ package io.swagger.api.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
+import io.dockstore.webservice.core.User;
 import io.swagger.api.NotFoundException;
 import io.swagger.api.ToolClassesApiService;
 import io.swagger.model.ToolClass;
@@ -45,7 +47,7 @@ public class ToolClassesApiServiceImpl extends ToolClassesApiService {
     }
 
     @Override
-    public Response toolClassesGet(SecurityContext securityContext, ContainerRequestContext containerContext) throws NotFoundException {
+    public Response toolClassesGet(SecurityContext securityContext, ContainerRequestContext containerContext, Optional<User> user) throws NotFoundException {
         final List<ToolClass> toolTypes = new ArrayList<ToolClass>();
         toolTypes.add(getCommandLineToolClass());
         toolTypes.add(getWorkflowClass());

--- a/dockstore-webservice/src/main/resources/swagger-templates/api.mustache
+++ b/dockstore-webservice/src/main/resources/swagger-templates/api.mustache
@@ -1,5 +1,7 @@
 package {{package}};
 
+import java.util.Optional;
+
 import {{modelPackage}}.*;
 import {{package}}.{{classname}}Service;
 import {{package}}.factories.{{classname}}ServiceFactory;
@@ -20,6 +22,8 @@ import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
 import io.dockstore.webservice.DockstoreWebserviceApplication;
+import io.dockstore.webservice.core.User;
+import io.dropwizard.auth.Auth;
 import io.dropwizard.hibernate.UnitOfWork;
 import javax.servlet.ServletConfig;
 import javax.ws.rs.core.Context;
@@ -77,9 +81,9 @@ public class {{classname}}  {
     @io.swagger.annotations.ApiResponses(value = { {{#responses}}
         @io.swagger.annotations.ApiResponse(code = {{{code}}}, message = "{{{message}}}", response = {{{baseType}}}.class{{#containerType}}, responseContainer = "{{{containerType}}}"{{/containerType}}){{#hasMore}},
         {{/hasMore}}{{/responses}} })
-    public Response {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}},{{/allParams}}@Context SecurityContext securityContext, @Context ContainerRequestContext containerContext)
+    public Response {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}},{{/allParams}}@Context SecurityContext securityContext, @Context ContainerRequestContext containerContext, @ApiParam(hidden = true) @Auth Optional<User> user)
     throws NotFoundException {
-        return delegate.{{nickname}}({{#allParams}}{{#isFile}}{{paramName}}InputStream, {{paramName}}Detail{{/isFile}}{{^isFile}}{{paramName}}{{/isFile}},{{/allParams}}securityContext, containerContext);
+        return delegate.{{nickname}}({{#allParams}}{{#isFile}}{{paramName}}InputStream, {{paramName}}Detail{{/isFile}}{{^isFile}}{{paramName}}{{/isFile}},{{/allParams}}securityContext, containerContext, user);
     }
 {{/operation}}
 }

--- a/dockstore-webservice/src/main/resources/swagger-templates/apiService.mustache
+++ b/dockstore-webservice/src/main/resources/swagger-templates/apiService.mustache
@@ -1,5 +1,7 @@
 package {{package}};
 
+import java.util.Optional;
+
 import {{package}}.*;
 import {{modelPackage}}.*;
 
@@ -13,6 +15,8 @@ import {{package}}.NotFoundException;
 
 import java.io.InputStream;
 
+import io.dockstore.webservice.core.User;
+
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
@@ -23,7 +27,7 @@ import javax.validation.constraints.*;
 {{#operations}}
 public abstract class {{classname}}Service {
     {{#operation}}
-    public abstract Response {{nickname}}({{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{>serviceFormParams}},{{/allParams}}SecurityContext securityContext, ContainerRequestContext value) throws NotFoundException;
+    public abstract Response {{nickname}}({{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{>serviceFormParams}},{{/allParams}}SecurityContext securityContext, ContainerRequestContext value, Optional<User> user) throws NotFoundException;
     {{/operation}}
 }
 {{/operations}}


### PR DESCRIPTION
* compatible with unmodified TRS swagger.yaml
* add optional authentication via the TRS endpoints as a way of getting unpublished and private workflows (used by the UI so it doesn't have to use two different ways of displaying relative file trees)
* includes tests and mustache template changes
