### PR TITLE
Don't Return Duplicate Shared Workflows

### DIFF
--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -863,7 +863,7 @@
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-codegen-maven-plugin</artifactId>
                 <configuration>
-                    <inputSpec>https://raw.githubusercontent.com/ga4gh/tool-registry-service-schemas/feature/search/src/main/resources/swagger/ga4gh-tool-discovery.yaml</inputSpec>
+                    <inputSpec>https://raw.githubusercontent.com/ga4gh/tool-registry-service-schemas/9b3f735535437c0b666207abe107e6e539761765/src/main/resources/swagger/ga4gh-tool-discovery.yaml</inputSpec>
                     <language>jaxrs</language>
                     <configOptions>
                         <dateLibrary>legacy</dateLibrary>


### PR DESCRIPTION
#1609

In SAM, for the same resource id, the same email can be added to
more than one policy for that resource.

That would lead to the same workflow showing up more than once, each
time for a different role, on the shared flows endpoint.

Now weed out duplicates by only returning the resource of the most
privileged role.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
