### PR TITLE
Add endpoint for users to get their actions

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
@@ -94,15 +94,34 @@ public class InMemoryPermissionsImpl implements PermissionsInterface {
         final List<Permission> permissions = getWorkflowPermissions(workflow);
         if (isOwner(user, permissions)) {
             return permissions;
-        } else {
-            final String userKey = userKey(user);
-            final List<Permission> userPermissions = permissions.stream()
-                    .filter(p -> p.getEmail().equals(userKey)).collect(Collectors.toList());
-            if (userPermissions.isEmpty()) {
-                throw new CustomWebApplicationException("Forbidden", HttpStatus.SC_FORBIDDEN);
-            }
-            return userPermissions;
         }
+        throw new CustomWebApplicationException("Forbidden", HttpStatus.SC_FORBIDDEN);
+    }
+
+    @Override
+    public List<Role.Action> getActionsForWorkflow(User user, Workflow workflow) {
+        final ArrayList<Role.Action> actions = new ArrayList<>();
+        final List<Permission> permissions = getWorkflowPermissions(workflow);
+        final String userKey = userKey(user);
+        final Optional<Permission> permission = permissions.stream().filter(p ->
+            p.getEmail().equals(userKey)
+        ).findFirst();
+        if (permission.isPresent()) {
+            final Role role = permission.get().getRole();
+            switch (role) {
+            case OWNER:
+                actions.add(Role.Action.SHARE);
+                actions.add(Role.Action.DELETE);
+                // No break statement on purpose
+            case WRITER:
+                actions.add(Role.Action.WRITE);
+                // No break statement on purpose
+            case READER:
+                actions.add(Role.Action.READ);
+            default: // Checkstyle complains otherwise
+            }
+        }
+        return actions;
     }
 
     private boolean isOwner(User user, List<Permission> workflowPermissions) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
@@ -17,6 +17,7 @@
 package io.dockstore.webservice.permissions;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -100,6 +101,9 @@ public class InMemoryPermissionsImpl implements PermissionsInterface {
 
     @Override
     public List<Role.Action> getActionsForWorkflow(User user, Workflow workflow) {
+        if (workflow.getUsers().contains(user)) {
+            return Arrays.asList(Role.Action.values());
+        }
         final ArrayList<Role.Action> actions = new ArrayList<>();
         final List<Permission> permissions = getWorkflowPermissions(workflow);
         final String userKey = userKey(user);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/NoOpPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/NoOpPermissionsImpl.java
@@ -4,8 +4,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
+import org.apache.http.HttpStatus;
 
 /**
  * A no-op <code>PermissionsInteface</code> implementation that
@@ -15,7 +17,7 @@ public class NoOpPermissionsImpl implements PermissionsInterface {
 
     @Override
     public List<Permission> setPermission(User requester, Workflow workflow, Permission permission) {
-        return Collections.emptyList();
+        throw new CustomWebApplicationException("Not implemented", HttpStatus.SC_NOT_IMPLEMENTED);
     }
 
     @Override
@@ -24,8 +26,13 @@ public class NoOpPermissionsImpl implements PermissionsInterface {
     }
 
     @Override
+    public List<Role.Action> getActionsForWorkflow(User user, Workflow workflow) {
+        return Collections.emptyList();
+    }
+
+    @Override
     public void removePermission(User user, Workflow workflow, String email, Role role) {
-        PermissionsInterface.checkUserNotOriginalOwner(email, workflow);
+        throw new CustomWebApplicationException("Not implemented", HttpStatus.SC_NOT_IMPLEMENTED);
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/NoOpPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/NoOpPermissionsImpl.java
@@ -1,5 +1,6 @@
 package io.dockstore.webservice.permissions;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +28,9 @@ public class NoOpPermissionsImpl implements PermissionsInterface {
 
     @Override
     public List<Role.Action> getActionsForWorkflow(User user, Workflow workflow) {
+        if (workflow.getUsers().contains(user)) {
+            return Arrays.asList(Role.Action.values());
+        }
         return Collections.emptyList();
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/PermissionsInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/PermissionsInterface.java
@@ -95,6 +95,14 @@ public interface PermissionsInterface {
     }
 
     /**
+     * List all {@link Role.Action} <code>user</code> can perform on <code>workflow</code>.
+     * @param user
+     * @param workflow
+     * @return a list of allowed actions on a workflow, possibly empty
+     */
+    List<Role.Action> getActionsForWorkflow(User user, Workflow workflow);
+
+    /**
      * Removes the <code>email</code> from the <code>role</code> from
      * <code>workflow</code>'s permissions.
      * @param user the requester, must be an owner of <code>workflow</code> or an admin.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
@@ -186,7 +186,7 @@ public class SamPermissionsImpl implements PermissionsInterface {
     @Override
     public List<Role.Action> getActionsForWorkflow(User user, Workflow workflow) {
         List<Role.Action> list = new ArrayList<>();
-        if (canDoAction(user, workflow, Role.Action.SHARE)) {
+        if (workflow.getUsers().contains(user) || canDoAction(user, workflow, Role.Action.SHARE)) {
             // Short cut to avoid multiple calls; if we can share, we're an owner and can do all actions
             list.addAll(Arrays.asList(Role.Action.values()));
         } else if (canDoAction(user, workflow, Role.Action.WRITE)) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
@@ -176,17 +176,27 @@ public class SamPermissionsImpl implements PermissionsInterface {
             return PermissionsInterface.mergePermissions(dockstoreOwners, samPermissions);
         } catch (ApiException e) {
             final String errorGettingPermissions = "Error getting permissions";
-            if (e.getCode() == HttpStatus.SC_FORBIDDEN) {
-                // If it's a 403; it may exist, but we may not have permissions to view
-                // the permissions, so derive the permission
-                return derivePermission(user, workflow)
-                        .map(permission -> Arrays.asList(permission)) // If we're not an owner, only return our own permission
-                        .orElseThrow(() -> new CustomWebApplicationException(errorGettingPermissions, e.getCode()));
-            } else if (e.getCode() != HttpStatus.SC_NOT_FOUND) { // If 404, SAM resource has not been created; just return Dockstore owners
+            if (e.getCode() != HttpStatus.SC_NOT_FOUND) { // If 404, SAM resource has not been created; just return Dockstore owners
                 throw new CustomWebApplicationException(errorGettingPermissions, e.getCode());
             }
         }
         return dockstoreOwners;
+    }
+
+    @Override
+    public List<Role.Action> getActionsForWorkflow(User user, Workflow workflow) {
+        List<Role.Action> list = new ArrayList<>();
+        if (canDoAction(user, workflow, Role.Action.SHARE)) {
+            // Short cut to avoid multiple calls; if we can share, we're an owner and can do all actions
+            list.addAll(Arrays.asList(Role.Action.values()));
+        } else if (canDoAction(user, workflow, Role.Action.WRITE)) {
+            // If we can write, we can read
+            list.add(Role.Action.WRITE);
+            list.add(Role.Action.READ);
+        } else if (canDoAction(user, workflow, Role.Action.READ)) {
+            list.add(Role.Action.READ);
+        }
+        return list;
     }
 
     @Override
@@ -207,27 +217,6 @@ public class SamPermissionsImpl implements PermissionsInterface {
             LOG.error(MessageFormat.format("Error removing {0} from workflow {1}", email, encodedPath), e);
             throw new CustomWebApplicationException("Error removing permissions", e.getCode());
         }
-    }
-
-    /**
-     * Derives <code>user</code>'s {@link Permission} (email + role) on <code>workflow</code>, without
-     * being able to read the SAM permissions directly, by calling the SAM
-     * APIs to see what actions the user can perform on the workflow.
-     *
-     * @param user
-     * @param workflow
-     * @return
-     */
-    private Optional<Permission> derivePermission(User user, Workflow workflow) {
-        final User.Profile googleProfile = user.getUserProfiles().get(TokenType.GOOGLE_COM.toString());
-        assert googleProfile != null; // If we gotten this far, we can safely assume there is a Google TokenType
-        final String email = googleProfile.email;
-        if (canDoAction(user, workflow, Role.Action.WRITE)) {
-            return Optional.of(new Permission(email, Role.WRITER));
-        } else if (canDoAction(user, workflow, Role.Action.READ)) {
-            return Optional.of(new Permission(email, Role.READER));
-        }
-        return Optional.empty();
     }
 
     private void initializePermission(Workflow workflow, User user) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -814,7 +814,7 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @UnitOfWork
     @Path("/path/workflow/{repository}/actions")
     @ApiOperation(value = "Gets all actions a user can perform on a workflow", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "", response = Role.Action.class, responseContainer = "List")
-    public List<Role.Action> getMyWorkflowPermissions(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
+    public List<Role.Action> getWorkflowActions(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
         Workflow workflow = workflowDAO.findByPath(path, false);
         checkEntry(workflow);
         return this.permissionsInterface.getActionsForWorkflow(user, workflow);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -809,6 +809,17 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
         return this.permissionsInterface.getPermissionsForWorkflow(user, workflow);
     }
 
+    @GET
+    @Timed
+    @UnitOfWork
+    @Path("/path/workflow/{repository}/actions")
+    @ApiOperation(value = "Gets all actions a user can perform on a workflow", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "", response = Role.Action.class, responseContainer = "List")
+    public List<Role.Action> getMyWorkflowPermissions(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
+        Workflow workflow = workflowDAO.findByPath(path, false);
+        checkEntry(workflow);
+        return this.permissionsInterface.getActionsForWorkflow(user, workflow);
+    }
+
     @PATCH
     @Timed
     @UnitOfWork

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -3907,6 +3907,36 @@ paths:
                 $ref: '#/components/schemas/Workflow'
       security:
         - BEARER: []
+  '/workflows/path/workflow/{repository}/actions':
+    get:
+      tags:
+        - workflows
+      summary: Gets all actions a user can perform on a workflow
+      description: ''
+      operationId: getWorkflowActions
+      parameters:
+        - name: repository
+          in: path
+          description: repository path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                  enum:
+                    - WRITE
+                    - READ
+                    - DELETE
+                    - SHARE
+      security:
+        - BEARER: []
   '/workflows/path/workflow/{repository}/permissions':
     get:
       tags:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -3585,6 +3585,35 @@ paths:
             $ref: "#/definitions/Workflow"
       security:
       - BEARER: []
+  /workflows/path/workflow/{repository}/actions:
+    get:
+      tags:
+      - "workflows"
+      summary: "Gets all actions a user can perform on a workflow"
+      description: ""
+      operationId: "getWorkflowActions"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "repository"
+        in: "path"
+        description: "repository path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "string"
+              enum:
+              - "WRITE"
+              - "READ"
+              - "DELETE"
+              - "SHARE"
+      security:
+      - BEARER: []
   /workflows/path/workflow/{repository}/permissions:
     get:
       tags:

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/InMemoryPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/InMemoryPermissionsImplTest.java
@@ -112,12 +112,32 @@ public class InMemoryPermissionsImplTest {
     }
 
     @Test
-    public void testSelfPermissions() {
+    public void testOwnersActions() {
+        // Test that reader can see her own permission even if she is not an owner
+        final Permission permission = new Permission("jane", Role.OWNER);
+        inMemoryPermissions.setPermission(johnDoeUser, fooWorkflow, permission);
+        final List<Role.Action> actions = inMemoryPermissions.getActionsForWorkflow(janeDoeUser, fooWorkflow);
+        Assert.assertEquals(Role.Action.values().length, actions.size()); // Owner can perform all actions
+    }
+
+    @Test
+    public void testWritersActions() {
+        // Test that reader can see her own permission even if she is not an owner
+        final Permission permission = new Permission("jane", Role.WRITER);
+        inMemoryPermissions.setPermission(johnDoeUser, fooWorkflow, permission);
+        final List<Role.Action> actions = inMemoryPermissions.getActionsForWorkflow(janeDoeUser, fooWorkflow);
+        Assert.assertEquals(2, actions.size());
+        Assert.assertTrue(actions.contains(Role.Action.WRITE) && actions.contains(Role.Action.WRITE));
+    }
+
+    @Test
+    public void testReadersActions() {
         // Test that reader can see her own permission even if she is not an owner
         final Permission permission = new Permission("jane", Role.READER);
         inMemoryPermissions.setPermission(johnDoeUser, fooWorkflow, permission);
-        final List<Permission> permissions = inMemoryPermissions.getPermissionsForWorkflow(janeDoeUser, fooWorkflow);
-        Assert.assertEquals(1, permissions.size());
+        final List<Role.Action> actions = inMemoryPermissions.getActionsForWorkflow(janeDoeUser, fooWorkflow);
+        Assert.assertEquals(1, actions.size());
+        Assert.assertTrue(actions.contains(Role.Action.READ));
     }
 
     @Test

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/PermissionsInterfaceTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/PermissionsInterfaceTest.java
@@ -1,6 +1,7 @@
 package io.dockstore.webservice.permissions;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -64,6 +65,11 @@ public class PermissionsInterfaceTest {
             @Override
             public Map<Role, List<String>> workflowsSharedWithUser(User user) {
                 return null;
+            }
+
+            @Override
+            public List<Role.Action> getActionsForWorkflow(User user, Workflow workflow) {
+                return Collections.emptyList();
             }
 
             @Override

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
@@ -5,6 +5,7 @@ import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -323,6 +324,13 @@ public class SamPermissionsImplTest {
         final List<Role.Action> actions = samPermissionsImpl.getActionsForWorkflow(userMock, fooWorkflow);
         Assert.assertEquals(1, actions.size());
         Assert.assertTrue(actions.contains(Role.Action.READ));
+    }
+
+    @Test
+    public void testDockstoreOwnerNoSamPermissions() {
+        when(fooWorkflow.getUsers()).thenReturn(new HashSet<>(Arrays.asList(userMock)));
+        final List<Role.Action> actions = samPermissionsImpl.getActionsForWorkflow(userMock, fooWorkflow);
+        Assert.assertEquals(Role.Action.values().length, actions.size()); // Owner can perform all actions
     }
 
     /**

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
@@ -290,22 +290,39 @@ public class SamPermissionsImplTest {
         Assert.assertEquals(0, sharedWithUser.size());
     }
 
-    /**
-     * Test that a reader gets herself back
-     * @throws ApiException
-     */
     @Test
-    public void testSelfPermissions() throws ApiException {
+    public void testOwnersActions() throws ApiException {
         final String resourceId = SamConstants.WORKFLOW_PREFIX + FOO_WORKFLOW_NAME;
-        when(resourcesApiMock.listResourcePolicies(SamConstants.RESOURCE_TYPE, resourceId))
-                .thenThrow(new ApiException(HttpStatus.SC_FORBIDDEN, "Unauthorized"));
-        when(resourcesApiMock.resourceAction(SamConstants.RESOURCE_TYPE, resourceId, SamConstants.toSamAction(Role.Action.READ)))
+        when(resourcesApiMock.resourceAction(SamConstants.RESOURCE_TYPE, resourceId, SamConstants.toSamAction(Role.Action.SHARE)))
                 .thenReturn(Boolean.TRUE);
+        final List<Role.Action> actions = samPermissionsImpl.getActionsForWorkflow(userMock, fooWorkflow);
+        Assert.assertEquals(Role.Action.values().length, actions.size()); // Owner can perform all actions
+    }
+
+    @Test
+    public void testWritersActions() throws ApiException {
+        final String resourceId = SamConstants.WORKFLOW_PREFIX + FOO_WORKFLOW_NAME;
+        when(resourcesApiMock.resourceAction(SamConstants.RESOURCE_TYPE, resourceId, SamConstants.toSamAction(Role.Action.SHARE)))
+                .thenReturn(Boolean.FALSE);
+        when(resourcesApiMock.resourceAction(SamConstants.RESOURCE_TYPE, resourceId, SamConstants.toSamAction(Role.Action.WRITE)))
+                .thenReturn(Boolean.TRUE);
+        final List<Role.Action> actions = samPermissionsImpl.getActionsForWorkflow(userMock, fooWorkflow);
+        Assert.assertEquals(2, actions.size());
+        Assert.assertTrue(actions.contains(Role.Action.WRITE) && actions.contains(Role.Action.READ));
+    }
+
+    @Test
+    public void testReadersActions() throws ApiException {
+        final String resourceId = SamConstants.WORKFLOW_PREFIX + FOO_WORKFLOW_NAME;
+        when(resourcesApiMock.resourceAction(SamConstants.RESOURCE_TYPE, resourceId, SamConstants.toSamAction(Role.Action.SHARE)))
+                .thenReturn(Boolean.FALSE);
         when(resourcesApiMock.resourceAction(SamConstants.RESOURCE_TYPE, resourceId, SamConstants.toSamAction(Role.Action.WRITE)))
                 .thenReturn(Boolean.FALSE);
-        final List<Permission> permissions = samPermissionsImpl.getPermissionsForWorkflow(userMock, fooWorkflow);
-        Assert.assertEquals(1, permissions.size());
-        Assert.assertEquals(Role.READER, permissions.iterator().next().getRole());
+        when(resourcesApiMock.resourceAction(SamConstants.RESOURCE_TYPE, resourceId, SamConstants.toSamAction(Role.Action.READ)))
+                .thenReturn(Boolean.TRUE);
+        final List<Role.Action> actions = samPermissionsImpl.getActionsForWorkflow(userMock, fooWorkflow);
+        Assert.assertEquals(1, actions.size());
+        Assert.assertTrue(actions.contains(Role.Action.READ));
     }
 
     /**


### PR DESCRIPTION
#1589

The issue in the ticket was because the UI was comparing
the GitHub username with the Google email address that came back from
the permissions call. That, plus the fact that I had forgotten about
SAM's support for groups, means we do need an endpoint to indicate
the actions a user can perform on workflow.

I had this before, with OPTIONS operations on a few API calls, but it
was clunky and overkill, so I've added a new endpoint,
`/path/workflow/{repository}/actions`, that returns the actions a user
can perform on a workflow.

The issue with groups is that a user can be given permissions to a
resource through a group -- in that case the user's individual email
will not show up in the list of permissions. So we could not tell
client-side what a user's permissions are just by reading the email
addresses.

Also:

* Added Not Implemented to state changing operations in
NoOpPermissionsImpl, just in case it gets turned on and somebody
tries to use it.
* Not sure why openapi and swagger files have new endpoint unrelated
to my changes; maybe they not commited with a change made to
WorkflowResource?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
