### PR TITLE
Set PluginManager system version

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/common/VersionAwarePluginManager.java
+++ b/dockstore-client/src/main/java/io/dockstore/common/VersionAwarePluginManager.java
@@ -41,6 +41,8 @@ import ro.fortsoft.pf4j.util.NotFileFilter;
 public class VersionAwarePluginManager extends DefaultPluginManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(VersionAwarePluginManager.class);
+    // Version 0.0.0 -> Up to 1.4; Version 0.0.1 -> 1.5
+    private static final Version SYSTEM_VERSION = Version.forIntegers(0, 0, 1);
     // maps plugin id -> version, directory path
     private Map<String, Pair<Version, File>> pluginVersionMap = new HashMap<>();
 
@@ -51,6 +53,7 @@ public class VersionAwarePluginManager extends DefaultPluginManager {
      */
     VersionAwarePluginManager(File pluginsDirectory) {
         super(pluginsDirectory);
+        setSystemVersion(SYSTEM_VERSION);
     }
 
     void cleanupOldVersions() {


### PR DESCRIPTION
#1629

Allows the data object service file plugin, which has its
requires set to `>0.0.0` to get loaded by this version of
Dockstore. Older versions of Dockstore, which have the system version
set to 0.0.0, will not load that plugin.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
