### PR TITLE
Correct Check for Original Owner

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
@@ -62,6 +62,7 @@ public class InMemoryPermissionsImpl implements PermissionsInterface {
 
     @Override
     public List<Permission> setPermission(User requester, Workflow workflow, Permission permission) {
+        PermissionsInterface.checkUserNotOriginalOwner(permission.getEmail(), workflow);
         Map<String, Role> entryMap = resourceToUsersAndRolesMap.get(workflow.getWorkflowPath());
         checkIfOwner(requester, workflow, entryMap);
         if (entryMap == null) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/PermissionsInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/PermissionsInterface.java
@@ -169,17 +169,17 @@ public interface PermissionsInterface {
     }
 
     /**
-     * Checks if a the email is an "original owner" of a workflow, and throws a
+     * Checks if a the username is an "original owner" of a workflow, and throws a
      * {@link CustomWebApplicationException} if it is. To be used as a check so
-     * that original owners never remove themselves as owners.
+     * that original owners can never be removed as owners.
      *
      *
-     * @param email
+     * @param username
      * @param workflow
      */
-    static void checkUserNotOriginalOwner(String email, Workflow workflow) {
-        if (workflow.getUsers().stream().anyMatch(u ->  email.equals(u.getUsername()))) {
-            throw new CustomWebApplicationException("", HttpStatus.SC_BAD_REQUEST);
+    static void checkUserNotOriginalOwner(String username, Workflow workflow) {
+        if (workflow.getUsers().stream().anyMatch(u ->  username.equals(u.getUsername()))) {
+            throw new CustomWebApplicationException(username + " is an original owner and their permissions cannot be modified", HttpStatus.SC_FORBIDDEN);
         }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/PermissionsInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/PermissionsInterface.java
@@ -173,13 +173,17 @@ public interface PermissionsInterface {
      * {@link CustomWebApplicationException} if it is. To be used as a check so
      * that original owners can never be removed as owners.
      *
+     * This method compares <code>username</code> against <code>User.getUsername()</code> of the <code>workflow</code>'s users, only.
+     * That username property is currently set with either the Github username or the Google user email, depending
+     * on the order in which the user linked accounts.
      *
      * @param username
      * @param workflow
      */
     static void checkUserNotOriginalOwner(String username, Workflow workflow) {
         if (workflow.getUsers().stream().anyMatch(u ->  username.equals(u.getUsername()))) {
-            throw new CustomWebApplicationException(username + " is an original owner and their permissions cannot be modified", HttpStatus.SC_FORBIDDEN);
+            throw new CustomWebApplicationException(username + " is an original owner and their permissions cannot be modified",
+                    HttpStatus.SC_FORBIDDEN);
         }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
@@ -90,6 +90,8 @@ public class SamPermissionsImpl implements PermissionsInterface {
      */
     @Override
     public List<Permission> setPermission(User requester, Workflow workflow, Permission permission) {
+        // If original owner, you can't mess with their permissions
+        checkEmailNotOriginalOwner(permission.getEmail(), workflow);
         ResourcesApi resourcesApi = getResourcesApi(requester);
         try {
             final String encodedPath = encodedWorkflowResource(workflow, resourcesApi.getApiClient());
@@ -228,7 +230,7 @@ public class SamPermissionsImpl implements PermissionsInterface {
 
     @Override
     public void removePermission(User user, Workflow workflow, String email, Role role) {
-        PermissionsInterface.checkUserNotOriginalOwner(email, workflow);
+        checkEmailNotOriginalOwner(email, workflow);
         ResourcesApi resourcesApi = getResourcesApi(user);
         String encodedPath = encodedWorkflowResource(workflow, resourcesApi.getApiClient());
         try {
@@ -243,6 +245,28 @@ public class SamPermissionsImpl implements PermissionsInterface {
         } catch (ApiException e) {
             LOG.error(MessageFormat.format("Error removing {0} from workflow {1}", email, encodedPath), e);
             throw new CustomWebApplicationException("Error removing permissions", e.getCode());
+        }
+    }
+
+    /**
+     * Throws a CustomWebApplication if <code>email</code> is an original owner, a user
+     * that owns <code>workflow</code> in Dockstore.
+     *
+     * Can't just check the username; also need to check profiles.
+     * @param email must not be null
+     * @param workflow
+     */
+    void checkEmailNotOriginalOwner(String email, Workflow workflow) {
+        assert email != null;
+        final boolean isOwner = workflow.getUsers().stream().anyMatch(u -> {
+            if (email.equals(u.getUsername())) {
+                return true;
+            }
+            final User.Profile profile = u.getUserProfiles().get(TokenType.GOOGLE_COM.toString());
+            return profile != null && email.equals(profile.email);
+        });
+        if (isOwner) {
+            throw new CustomWebApplicationException(email + " is an original owner and their permissions cannot be modified", HttpStatus.SC_FORBIDDEN);
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
@@ -252,7 +252,11 @@ public class SamPermissionsImpl implements PermissionsInterface {
      * Throws a CustomWebApplication if <code>email</code> is an original owner, a user
      * that owns <code>workflow</code> in Dockstore.
      *
-     * Can't just check the username; also need to check profiles.
+     * The {@link User} class has a <code>username</code> property, which currently can get set to either the user's GitHub id
+     * or Google email, depending on the order that the user associated those accounts. The method first tries to match
+     * comparing the email against the username -- if it doesn't find it, it looks in the user profiles for the email.
+     *
+     *
      * @param email must not be null
      * @param workflow
      */

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ info:
     This describes the dockstore API, a webservice that manages pairs of Docker
     images and associated metadata such as CWL documents and Dockerfiles used to
     build those images
-  version: 1.5.0-alpha.8-SNAPSHOT
+  version: 1.5.0-alpha.9-SNAPSHOT
   title: Dockstore API
   termsOfService: TBD
   contact:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.5.0-alpha.8-SNAPSHOT"
+  version: "1.5.0-alpha.9-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/InMemoryPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/InMemoryPermissionsImplTest.java
@@ -69,13 +69,13 @@ public class InMemoryPermissionsImplTest {
         Assert.assertEquals(inMemoryPermissions.workflowsSharedWithUser(johnDoeUser).size(), 0);
         final Permission permission = new Permission();
         permission.setRole(Role.WRITER);
-        permission.setEmail(JOHN_DOE_EXAMPLE_COM);
+        permission.setEmail(janeDoeUser.getUsername());
         inMemoryPermissions.setPermission(johnDoeUser, fooWorkflow, permission);
         inMemoryPermissions.setPermission(johnDoeUser, gooWorkflow, permission);
-        Assert.assertEquals(1, inMemoryPermissions.workflowsSharedWithUser(johnDoeUser).size());
+        Assert.assertEquals(1, inMemoryPermissions.workflowsSharedWithUser(janeDoeUser).size());
         permission.setRole(Role.READER);
         inMemoryPermissions.setPermission(johnDoeUser, dockstoreOrgWorkflow, permission);
-        final Map<Role, List<String>> roleListMap = inMemoryPermissions.workflowsSharedWithUser(johnDoeUser);
+        final Map<Role, List<String>> roleListMap = inMemoryPermissions.workflowsSharedWithUser(janeDoeUser);
         Assert.assertEquals(2, roleListMap.size());
         Assert.assertEquals(DOCKSTORE_ORG_JOHN_MYWORKFLOW, roleListMap.get(Role.READER).get(0));
     }
@@ -98,10 +98,10 @@ public class InMemoryPermissionsImplTest {
     @Test
     public void canDoAction() {
         Assert.assertEquals(inMemoryPermissions.workflowsSharedWithUser(johnDoeUser).size(), 0);
-        final Permission permission = new Permission(JOHN_DOE_EXAMPLE_COM, Role.READER);
+        final Permission permission = new Permission(janeDoeUser.getUsername(), Role.READER);
         inMemoryPermissions.setPermission(johnDoeUser, fooWorkflow, permission);
-        Assert.assertTrue(inMemoryPermissions.canDoAction(johnDoeUser, fooWorkflow, Role.Action.READ));
-        Assert.assertFalse(inMemoryPermissions.canDoAction(johnDoeUser, fooWorkflow, Role.Action.WRITE));
+        Assert.assertTrue(inMemoryPermissions.canDoAction(janeDoeUser, fooWorkflow, Role.Action.READ));
+        Assert.assertFalse(inMemoryPermissions.canDoAction(janeDoeUser, fooWorkflow, Role.Action.WRITE));
     }
 
     @Test

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/PermissionsInterfaceTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/PermissionsInterfaceTest.java
@@ -24,10 +24,10 @@ public class PermissionsInterfaceTest {
 
     public static final String JOHN_DOE_EXAMPLE_COM = "john.doe@example.com";
     public static final String JANE_DOE_EXAMPLE_COM = "jane.doe@example.com";
-    private User user1;
+    private User userJohn;
     private Permission janeDoeOwnerPermission;
     private Permission janeDoeWriterPermission;
-    private User user2;
+    private User userJane;
     private PermissionsInterface permissionsInterface;
 
     private Workflow workflow = Mockito.mock(Workflow.class);
@@ -37,17 +37,17 @@ public class PermissionsInterfaceTest {
 
     @Before
     public void setup() {
-        user1 = new User();
-        user1.setUsername(JOHN_DOE_EXAMPLE_COM);
+        userJohn = new User();
+        userJohn.setUsername(JOHN_DOE_EXAMPLE_COM);
         final User.Profile profile1 = new User.Profile();
         profile1.email = JOHN_DOE_EXAMPLE_COM;
-        user1.getUserProfiles().put(TokenType.GOOGLE_COM.toString(), profile1);
+        userJohn.getUserProfiles().put(TokenType.GOOGLE_COM.toString(), profile1);
 
-        user2 = new User();
-        user2.setUsername(JANE_DOE_EXAMPLE_COM);
+        userJane = new User();
+        userJane.setUsername(JANE_DOE_EXAMPLE_COM);
         final User.Profile profile2 = new User.Profile();
         profile2.email = JANE_DOE_EXAMPLE_COM;
-        user2.getUserProfiles().put(TokenType.GOOGLE_COM.toString(), profile2);
+        userJane.getUserProfiles().put(TokenType.GOOGLE_COM.toString(), profile2);
 
         janeDoeOwnerPermission = new Permission();
         janeDoeOwnerPermission.setRole(Role.OWNER);
@@ -91,7 +91,7 @@ public class PermissionsInterfaceTest {
 
     @Test
     public void getOriginalOwnersForWorkflow() {
-        final Set<User> users = new HashSet<>(Arrays.asList(user1));
+        final Set<User> users = new HashSet<>(Arrays.asList(userJohn));
         workflow = Mockito.mock(Workflow.class);
         when(workflow.getUsers()).thenReturn(users);
 
@@ -100,14 +100,18 @@ public class PermissionsInterfaceTest {
 
     @Test
     public void unauthorizedGetPermissionsForWorkflow() {
-        final Set<User> users = new HashSet<>(Arrays.asList(user1));
+        final Set<User> users = new HashSet<>(Arrays.asList(userJohn));
         when(workflow.getUsers()).thenReturn(users);
         thrown.expect(CustomWebApplicationException.class);
-        permissionsInterface.getPermissionsForWorkflow(user2, workflow);
+        permissionsInterface.getPermissionsForWorkflow(userJane, workflow);
     }
 
     @Test
     public void checkUserNotOriginalOwner() {
-
+        final Set<User> users = new HashSet<>(Arrays.asList(userJohn));
+        when(workflow.getUsers()).thenReturn(users);
+        thrown.expect(CustomWebApplicationException.class);
+        PermissionsInterface.checkUserNotOriginalOwner(JOHN_DOE_EXAMPLE_COM, workflow);
+        PermissionsInterface.checkUserNotOriginalOwner(JANE_DOE_EXAMPLE_COM, workflow);
     }
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
@@ -50,6 +50,7 @@ public class SamPermissionsImplTest {
     public static final String GOO_WORKFLOW_NAME = "goo";
     public static final String DOCKSTORE_ORG_WORKFLOW_NAME = "dockstore.org/john/myworkflow";
     public static final String JANE_DOE_GMAIL_COM = "jane.doe@gmail.com";
+    public static final String JANE_DOE_GITHUB_ID = "jdoe";
     private AccessPolicyResponseEntry ownerPolicy;
     private AccessPolicyResponseEntry writerPolicy;
     private AccessPolicyResponseEntry readerPolicy;
@@ -396,6 +397,15 @@ public class SamPermissionsImplTest {
         final Map<Role, List<String>> sharedWithUser2 = samPermissionsImpl.workflowsSharedWithUser(userMock);
         Assert.assertEquals(1, sharedWithUser.size());
         Assert.assertEquals(Role.WRITER, sharedWithUser.entrySet().iterator().next().getKey());
+    }
+
+    @Test
+    public void testNotOriginalOwnerWithEmailNotUsername() {
+        when(userMock.getUsername()).thenReturn(JANE_DOE_GITHUB_ID);
+        when(fooWorkflow.getUsers()).thenReturn(new HashSet<>(Arrays.asList(userMock)));
+        thrown.expect(CustomWebApplicationException.class);
+        samPermissionsImpl.checkEmailNotOriginalOwner(JANE_DOE_GMAIL_COM, fooWorkflow);
+        samPermissionsImpl.checkEmailNotOriginalOwner("johndoe@example.com", fooWorkflow);
     }
 
     private void setupInitializePermissionsMocks(String encodedPath) {


### PR DESCRIPTION
#1657

Problem was that I was comparing email with User.username, which
will not be the Google email, if the user first
signed in with GitHub. Now also check profile for an email in there.

Also:

* Add the check when adding a permission; originally only checked
when removing a permission. Basically we shouldn't let you muck
with an original owner's permissions at all.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
