### PR TITLE
Feature/1370/token check

### DIFF
--- a/dockstore-common/src/test/java/io/dockstore/common/BasicPostgreSQL.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/BasicPostgreSQL.java
@@ -104,8 +104,8 @@ public class BasicPostgreSQL {
         runUpdateStatement("delete from user_entry;");
         runUpdateStatement("delete from endusergroup;");
         runUpdateStatement("delete from starred;");
-        runUpdateStatement("delete from enduser;");
         runUpdateStatement("delete from token;");
+        runUpdateStatement("delete from enduser;");
         runUpdateStatement("delete from version_sourcefile;");
         runUpdateStatement("delete from sourcefile;");
         runUpdateStatement("delete from tool_tag;");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MigrationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MigrationIT.java
@@ -106,7 +106,9 @@ public class MigrationIT {
         final long count = testingPostgres.runSelectStatement("select count(funkfile) from tool", new ScalarHandler<>());
         // count will be zero, but there should be no exception
         Assert.assertTrue("could select from new column", count == 0);
-
+        final long orphanedTokensCount = testingPostgres
+                .runSelectStatement("select count(*) from token where userid not in (select id from enduser)", new ScalarHandler<>());
+        Assert.assertEquals(0, orphanedTokensCount);
         // reset state
         testingPostgres.runUpdateStatement("alter table tool drop funkfile");
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
@@ -80,10 +80,10 @@ public class TokenResourceIT extends BaseIT {
 
     private TokenDAO tokenDAO;
     private UserDAO userDAO;
-    private static long initialTokenCount;
+    private long initialTokenCount;
     private final String satellizerJSON = "{\n" + "  \"code\": \"fakeCode\",\n" + "  \"redirectUri\": \"fakeRedirectUri\"\n" + "}\n";
     private final static String GOOGLE_ACCOUNT_USERNAME = "potato@gmail.com";
-    private final static String GITHUB_ACCOUNT_USERNAME = "user1@user.com";
+    private final static String GITHUB_ACCOUNT_USERNAME = "potato";
 
     private static TokenResponse getFakeTokenResponse() {
         TokenResponse fakeTokenResponse = new TokenResponse();
@@ -177,18 +177,19 @@ public class TokenResourceIT extends BaseIT {
 
     /**
      * Covers case 1, 3, and 5 of the 6 cases listed below. It checks that the user to be logged into is correct.
+     * Below table indicates what happens when the "Login with Google" button in the UI2 is clicked
      * <table border="1">
      * <tr>
      * <td></td> <td><b> Have GitHub account no Google Token (no GitHub account)</td> <td><b>Have GitHub account with Google token</td>
      * </tr>
      * <tr>
-     * <td> <b>Have Google Account no Google token</td> <td>Login with Google (1)</td> <td>Login with GitHub (2)</td>
+     * <td> <b>Have Google Account no Google token</td> <td>Login with Google account (1)</td> <td>Login with GitHub account(2)</td>
      * </tr>
      * <tr>
-     * <td> <b>Have Google Account with Google token</td> <td>Login with Google (3)</td> <td> Login with Google (4)</td>
+     * <td> <b>Have Google Account with Google token</td> <td>Login with Google account (3)</td> <td> Login with Google account (4)</td>
      * </tr>
      * <tr>
-     * <td> <b>No Google Account</td> <td> Create Google account (5)</td> <td>Login with GitHub (6)</td>
+     * <td> <b>No Google Account</td> <td> Create Google account (5)</td> <td>Login with GitHub account (6)</td>
      * </tr>
      * </table>
      */
@@ -218,18 +219,19 @@ public class TokenResourceIT extends BaseIT {
 
     /**
      * Covers case 2 and 4 of the 6 cases listed below. It checks that the user to be logged into is correct.
+     * Below table indicates what happens when the "Login with Google" button in the UI2 is clicked
      * <table border="1">
      * <tr>
      * <td></td> <td><b> Have GitHub account no Google Token (no GitHub account)</td> <td><b>Have GitHub account with Google token</td>
      * </tr>
      * <tr>
-     * <td> <b>Have Google Account no Google token</td> <td>Login with Google (1)</td> <td>Login with GitHub (2)</td>
+     * <td> <b>Have Google Account no Google token</td> <td>Login with Google account (1)</td> <td>Login with GitHub account(2)</td>
      * </tr>
      * <tr>
-     * <td> <b>Have Google Account with Google token</td> <td>Login with Google (3)</td> <td> Login with Google (4)</td>
+     * <td> <b>Have Google Account with Google token</td> <td>Login with Google account (3)</td> <td> Login with Google account (4)</td>
      * </tr>
      * <tr>
-     * <td> <b>No Google Account</td> <td> Create Google account (5)</td> <td>Login with GitHub (6)</td>
+     * <td> <b>No Google Account</td> <td> Create Google account (5)</td> <td>Login with GitHub account (6)</td>
      * </tr>
      * </table>
      */
@@ -271,18 +273,19 @@ public class TokenResourceIT extends BaseIT {
 
     /**
      * Covers case 6 of the 6 cases listed below. It checks that the user to be logged into is correct.
+     * Below table indicates what happens when the "Login with Google" button in the UI2 is clicked
      * <table border="1">
      * <tr>
      * <td></td> <td><b> Have GitHub account no Google Token (no GitHub account)</td> <td><b>Have GitHub account with Google token</td>
      * </tr>
      * <tr>
-     * <td> <b>Have Google Account no Google token</td> <td>Login with Google (1)</td> <td>Login with GitHub (2)</td>
+     * <td> <b>Have Google Account no Google token</td> <td>Login with Google account (1)</td> <td>Login with GitHub account(2)</td>
      * </tr>
      * <tr>
-     * <td> <b>Have Google Account with Google token</td> <td>Login with Google (3)</td> <td> Login with Google (4)</td>
+     * <td> <b>Have Google Account with Google token</td> <td>Login with Google account (3)</td> <td> Login with Google account (4)</td>
      * </tr>
      * <tr>
-     * <td> <b>No Google Account</td> <td> Create Google account (5)</td> <td>Login with GitHub (6)</td>
+     * <td> <b>No Google Account</td> <td> Create Google account (5)</td> <td>Login with GitHub account (6)</td>
      * </tr>
      * </table>
      */

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
@@ -32,6 +32,7 @@ import io.dockstore.webservice.helpers.GoogleHelper;
 import io.dockstore.webservice.jdbi.TokenDAO;
 import io.dockstore.webservice.jdbi.UserDAO;
 import io.swagger.client.api.TokensApi;
+import org.apache.commons.dbutils.handlers.ScalarHandler;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.context.internal.ManagedSessionContext;
@@ -59,10 +60,10 @@ import static org.powermock.api.easymock.PowerMock.verify;
  * @since 24/07/18
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest( { GoogleHelper.class })
+@PrepareForTest({ GoogleHelper.class })
 @Category(ConfidentialTest.class)
-@PowerMockIgnore( { "javax.security.*", "org.apache.http.conn.ssl.*", "javax.net.ssl.*", "javax.crypto.*", "javax.management.*",
-    "javax.net.*", "org.apache.http.impl.client.*", "org.apache.http.protocol.*", "org.apache.http.*" })
+@PowerMockIgnore({ "javax.security.*", "org.apache.http.conn.ssl.*", "javax.net.ssl.*", "javax.crypto.*", "javax.management.*",
+        "javax.net.*", "org.apache.http.impl.client.*", "org.apache.http.protocol.*", "org.apache.http.*" })
 public class TokenResourceIT extends BaseIT {
 
     @Rule
@@ -79,6 +80,10 @@ public class TokenResourceIT extends BaseIT {
 
     private TokenDAO tokenDAO;
     private UserDAO userDAO;
+    private static long initialTokenCount;
+    private final String satellizerJSON = "{\n" + "  \"code\": \"fakeCode\",\n" + "  \"redirectUri\": \"fakeRedirectUri\"\n" + "}\n";
+    private final static String GOOGLE_ACCOUNT_USERNAME = "potato@gmail.com";
+    private final static String GITHUB_ACCOUNT_USERNAME = "user1@user.com";
 
     private static TokenResponse getFakeTokenResponse() {
         TokenResponse fakeTokenResponse = new TokenResponse();
@@ -90,7 +95,7 @@ public class TokenResourceIT extends BaseIT {
 
     private static Userinfoplus getFakeUserinfoplus() {
         Userinfoplus fakeUserinfoplus = new Userinfoplus();
-        fakeUserinfoplus.setEmail("potato@gmail.com");
+        fakeUserinfoplus.setEmail(GOOGLE_ACCOUNT_USERNAME);
         fakeUserinfoplus.setGivenName("Beef");
         fakeUserinfoplus.setFamilyName("Stew");
         fakeUserinfoplus.setName("Beef Stew");
@@ -114,14 +119,14 @@ public class TokenResourceIT extends BaseIT {
         fakeToken.setContent("fakeContent");
         fakeToken.setTokenSource(TokenType.GOOGLE_COM);
         fakeToken.setUserId(1);
-        fakeToken.setUsername("potato@gmail.com");
+        fakeToken.setUsername(GOOGLE_ACCOUNT_USERNAME);
         return fakeToken;
     }
 
     private static User getFakeUser() {
         // user is user from test data database
         User fakeUser = new User();
-        fakeUser.setUsername("user1@user.com");
+        fakeUser.setUsername(GITHUB_ACCOUNT_USERNAME);
         fakeUser.setId(1);
         return fakeUser;
     }
@@ -140,14 +145,9 @@ public class TokenResourceIT extends BaseIT {
         // used to allow us to use tokenDAO outside of the web service
         Session session = application.getHibernate().getSessionFactory().openSession();
         ManagedSessionContext.bind(session);
+        mockGoogleHelper();
+        initialTokenCount = CommonTestUtilities.getTestingPostgres().runSelectStatement("select count(*) from token", new ScalarHandler<>());
 
-        // mark which static class methods you need to mock here while leaving the others to work normally
-        mockStaticStrict(GoogleHelper.class, GoogleHelper.class.getMethod("getTokenResponse", String.class, String. class, String.class, String.class), GoogleHelper.class.getMethod("userinfoplusFromToken", String.class));
-        expect(GoogleHelper.getTokenResponse("<fill me in>", "<fill me in>", "fakeCode", "fakeRedirectUri"))
-            .andReturn(getFakeTokenResponse());
-        expect(GoogleHelper.userinfoplusFromToken("fakeAccessToken")).andReturn(Optional.of(getFakeUserinfoplus()));
-        // kick off the mock and have it start to expect things
-        replay(GoogleHelper.class);
     }
 
     /**
@@ -157,7 +157,7 @@ public class TokenResourceIT extends BaseIT {
     public void getGoogleTokenNewUser() {
         TokensApi tokensApi = new TokensApi(getWebClient(false, "n/a"));
         io.swagger.client.model.Token token = tokensApi
-            .addGoogleToken("{\n" + "  \"code\": \"fakeCode\",\n" + "  \"redirectUri\": \"fakeRedirectUri\"\n" + "}\n");
+                .addGoogleToken(satellizerJSON);
 
         // check that the user has the correct two tokens
         List<Token> byUserId = tokenDAO.findByUserId(token.getUserId());
@@ -168,11 +168,164 @@ public class TokenResourceIT extends BaseIT {
         // Check that the token has the right info but ignore randomly generated content
         Token fakeExistingDockstoreToken = getFakeExistingDockstoreToken();
         // looks like we take on the gmail username when no other is provided
-        Assert.assertEquals("potato@gmail.com", token.getUsername());
+        Assert.assertEquals(GOOGLE_ACCOUNT_USERNAME, token.getUsername());
         Assert.assertEquals(fakeExistingDockstoreToken.getTokenSource().toString(), token.getTokenSource());
         Assert.assertEquals(100, token.getId().longValue());
         checkUserProfiles(token.getUserId(), Arrays.asList(TokenType.GOOGLE_COM.toString()));
         verify(GoogleHelper.class);
+    }
+
+    /**
+     * Covers case 1, 3, and 5 of the 6 cases listed below. It checks that the user to be logged into is correct.
+     * <table border="1">
+     * <tr>
+     * <td></td> <td><b> Have GitHub account no Google Token (no GitHub account)</td> <td><b>Have GitHub account with Google token</td>
+     * </tr>
+     * <tr>
+     * <td> <b>Have Google Account no Google token</td> <td>Login with Google (1)</td> <td>Login with GitHub (2)</td>
+     * </tr>
+     * <tr>
+     * <td> <b>Have Google Account with Google token</td> <td>Login with Google (3)</td> <td> Login with Google (4)</td>
+     * </tr>
+     * <tr>
+     * <td> <b>No Google Account</td> <td> Create Google account (5)</td> <td>Login with GitHub (6)</td>
+     * </tr>
+     * </table>
+     */
+    @Test
+    public void getGoogleTokenCase135() {
+        TokensApi tokensApi = new TokensApi(getWebClient(false, "n/a"));
+        io.swagger.client.model.Token case5Token = tokensApi
+                .addGoogleToken(satellizerJSON);
+        // Case 5 check (No Google account, no GitHub account)
+        Assert.assertEquals(GOOGLE_ACCOUNT_USERNAME, case5Token.getUsername());
+        mockGoogleHelper();
+        // Google account dockstore token + Google account Google token
+        checkTokenCount(initialTokenCount + 2);
+        io.swagger.client.model.Token case3Token = tokensApi.addGoogleToken(satellizerJSON);
+        // Case 3 check (Google account with Google token, no GitHub account)
+        Assert.assertEquals(GOOGLE_ACCOUNT_USERNAME, case3Token.getUsername());
+        TokensApi googleTokensApi = new TokensApi(getWebClient(true, GOOGLE_ACCOUNT_USERNAME));
+        googleTokensApi.deleteToken(case3Token.getId());
+        mockGoogleHelper();
+        // Google account dockstore token
+        checkTokenCount(initialTokenCount + 1);
+        io.swagger.client.model.Token case1Token = tokensApi.addGoogleToken(satellizerJSON);
+        // Case 1 check (Google account without Google token, no GitHub account)
+        Assert.assertEquals(GOOGLE_ACCOUNT_USERNAME, case1Token.getUsername());
+        verify(GoogleHelper.class);
+    }
+
+    /**
+     * Covers case 2 and 4 of the 6 cases listed below. It checks that the user to be logged into is correct.
+     * <table border="1">
+     * <tr>
+     * <td></td> <td><b> Have GitHub account no Google Token (no GitHub account)</td> <td><b>Have GitHub account with Google token</td>
+     * </tr>
+     * <tr>
+     * <td> <b>Have Google Account no Google token</td> <td>Login with Google (1)</td> <td>Login with GitHub (2)</td>
+     * </tr>
+     * <tr>
+     * <td> <b>Have Google Account with Google token</td> <td>Login with Google (3)</td> <td> Login with Google (4)</td>
+     * </tr>
+     * <tr>
+     * <td> <b>No Google Account</td> <td> Create Google account (5)</td> <td>Login with GitHub (6)</td>
+     * </tr>
+     * </table>
+     */
+    @Test
+    public void getGoogleTokenCase24() {
+        TokensApi unauthenticatedTokensApi = new TokensApi(getWebClient(false, "n/a"));
+        io.swagger.client.model.Token token = unauthenticatedTokensApi
+                .addGoogleToken(satellizerJSON);
+        // Check token properly added (redundant assertion)
+        long googleUserID = token.getUserId();
+        Assert.assertEquals(token.getUsername(), GOOGLE_ACCOUNT_USERNAME);
+
+        TokensApi gitHubTokensApi = new TokensApi(getWebClient(true, GITHUB_ACCOUNT_USERNAME));
+        mockGoogleHelper();
+        // Google account dockstore token + Google account Google token
+        checkTokenCount(initialTokenCount + 2);
+        gitHubTokensApi.addGoogleToken(satellizerJSON);
+        mockGoogleHelper();
+        // GitHub account Google token, Google account dockstore token, Google account Google token
+        checkTokenCount(initialTokenCount + 3);
+        io.swagger.client.model.Token case4Token = unauthenticatedTokensApi
+                .addGoogleToken(satellizerJSON);
+        // Case 4 (Google account with Google token, GitHub account with Google token)
+        Assert.assertEquals(GOOGLE_ACCOUNT_USERNAME, case4Token.getUsername());
+        TokensApi googleUserTokensApi = new TokensApi(getWebClient(true, GOOGLE_ACCOUNT_USERNAME));
+
+        List<Token> googleByUserId = tokenDAO.findGoogleByUserId(googleUserID);
+
+
+        mockGoogleHelper();
+        googleUserTokensApi.deleteToken(googleByUserId.get(0).getId());
+        mockGoogleHelper();
+        io.swagger.client.model.Token case2Token = unauthenticatedTokensApi
+                .addGoogleToken(satellizerJSON);
+        // Case 2 Google account without Google token, GitHub account with Google token
+        Assert.assertEquals(GITHUB_ACCOUNT_USERNAME, case2Token.getUsername());
+        verify(GoogleHelper.class);
+    }
+
+    /**
+     * Covers case 6 of the 6 cases listed below. It checks that the user to be logged into is correct.
+     * <table border="1">
+     * <tr>
+     * <td></td> <td><b> Have GitHub account no Google Token (no GitHub account)</td> <td><b>Have GitHub account with Google token</td>
+     * </tr>
+     * <tr>
+     * <td> <b>Have Google Account no Google token</td> <td>Login with Google (1)</td> <td>Login with GitHub (2)</td>
+     * </tr>
+     * <tr>
+     * <td> <b>Have Google Account with Google token</td> <td>Login with Google (3)</td> <td> Login with Google (4)</td>
+     * </tr>
+     * <tr>
+     * <td> <b>No Google Account</td> <td> Create Google account (5)</td> <td>Login with GitHub (6)</td>
+     * </tr>
+     * </table>
+     */
+    @Test
+    public void getGoogleTokenCase6() {
+        TokensApi tokensApi = new TokensApi(getWebClient(true, GITHUB_ACCOUNT_USERNAME));
+        tokensApi
+                .addGoogleToken(satellizerJSON);
+        TokensApi unauthenticatedTokensApi = new TokensApi(getWebClient(false, "n/a"));
+        mockGoogleHelper();
+        // GitHub account Google token
+        checkTokenCount(initialTokenCount + 1);
+        io.swagger.client.model.Token case6Token = unauthenticatedTokensApi.addGoogleToken(satellizerJSON);
+
+        // Case 6 check (No Google account, have GitHub account with Google token)
+        Assert.assertEquals(GITHUB_ACCOUNT_USERNAME, case6Token.getUsername());
+        verify(GoogleHelper.class);
+    }
+
+
+    private void mockGoogleHelper() {
+        try {
+            // mark which static class methods you need to mock here while leaving the others to work normally
+            mockStaticStrict(GoogleHelper.class,
+                    GoogleHelper.class.getMethod("getTokenResponse", String.class, String.class, String.class, String.class),
+                    GoogleHelper.class.getMethod("userinfoplusFromToken", String.class));
+        } catch (NoSuchMethodException e) {
+            Assert.fail();
+        }
+        expect(GoogleHelper.getTokenResponse("<fill me in>", "<fill me in>", "fakeCode", "fakeRedirectUri"))
+                .andReturn(getFakeTokenResponse());
+        expect(GoogleHelper.userinfoplusFromToken("fakeAccessToken")).andReturn(Optional.of(getFakeUserinfoplus()));
+        // kick off the mock and have it start to expect things
+        replay(GoogleHelper.class);
+    }
+
+    /**
+     * This is only to double-check that the precondition is sane.
+     * @param size
+     */
+    private void checkTokenCount(long size) {
+        long tokenCount = CommonTestUtilities.getTestingPostgres().runSelectStatement("select count(*) from token", new ScalarHandler<>());
+        Assert.assertEquals(size, tokenCount);
     }
 
     /**
@@ -185,9 +338,9 @@ public class TokenResourceIT extends BaseIT {
         Assert.assertEquals(1, byUserId.size());
         Assert.assertTrue(byUserId.stream().anyMatch(t -> t.getTokenSource() == TokenType.DOCKSTORE));
 
-        TokensApi tokensApi = new TokensApi(getWebClient(true, "user1@user.com"));
+        TokensApi tokensApi = new TokensApi(getWebClient(true, GITHUB_ACCOUNT_USERNAME));
         io.swagger.client.model.Token token = tokensApi
-            .addGoogleToken("{\n" + "  \"code\": \"fakeCode\",\n" + "  \"redirectUri\": \"fakeRedirectUri\"\n" + "}\n");
+                .addGoogleToken(satellizerJSON);
 
         // check that the user ends up with the correct two tokens
         byUserId = tokenDAO.findByUserId(token.getUserId());
@@ -198,7 +351,7 @@ public class TokenResourceIT extends BaseIT {
         // Check that the token has the right info but ignore randomly generated content
         Token fakeExistingDockstoreToken = getFakeExistingDockstoreToken();
         // looks like we retain the old github username when no other is provided
-        Assert.assertEquals("user1@user.com", token.getUsername());
+        Assert.assertEquals(GITHUB_ACCOUNT_USERNAME, token.getUsername());
         Assert.assertEquals(fakeExistingDockstoreToken.getTokenSource().toString(), token.getTokenSource());
         Assert.assertEquals(2, token.getId().longValue());
         checkUserProfiles(token.getUserId(), Arrays.asList(TokenType.GOOGLE_COM.toString(), TokenType.GITHUB_COM.toString()));
@@ -218,9 +371,9 @@ public class TokenResourceIT extends BaseIT {
         // give the user a Google token in advance
         tokenDAO.create(getFakeGoogleToken());
 
-        TokensApi tokensApi = new TokensApi(getWebClient(true, "user1@user.com"));
+        TokensApi tokensApi = new TokensApi(getWebClient(true, GITHUB_ACCOUNT_USERNAME));
         io.swagger.client.model.Token token = tokensApi
-            .addGoogleToken("{\n" + "  \"code\": \"fakeCode\",\n" + "  \"redirectUri\": \"fakeRedirectUri\"\n" + "}\n");
+                .addGoogleToken(satellizerJSON);
 
         // check that the user ends up with the correct two tokens
         byUserId = tokenDAO.findByUserId(token.getUserId());
@@ -231,7 +384,7 @@ public class TokenResourceIT extends BaseIT {
         // Check that the token has the right info but ignore randomly generated content
         Token fakeExistingDockstoreToken = getFakeExistingDockstoreToken();
         // looks like we retain the old github username when no other is provided
-        Assert.assertEquals("user1@user.com", token.getUsername());
+        Assert.assertEquals(GITHUB_ACCOUNT_USERNAME, token.getUsername());
         Assert.assertEquals(fakeExistingDockstoreToken.getTokenSource().toString(), token.getTokenSource());
         Assert.assertEquals(2, token.getId().longValue());
         checkUserProfiles(token.getUserId(), Arrays.asList(TokenType.GOOGLE_COM.toString(), TokenType.GITHUB_COM.toString()));
@@ -240,8 +393,9 @@ public class TokenResourceIT extends BaseIT {
 
     /**
      * Checks that the user profiles exist
-     * @param userId        Id of the user
-     * @param profileKeys   Profiles to check that it exists
+     *
+     * @param userId      Id of the user
+     * @param profileKeys Profiles to check that it exists
      */
     private void checkUserProfiles(Long userId, List<String> profileKeys) {
         User user = userDAO.findById(userId);
@@ -254,11 +408,12 @@ public class TokenResourceIT extends BaseIT {
 
     /**
      * Checks that the Google user profile matches the Google Userinfoplus
+     *
      * @param userProfiles
      */
     private void checkGoogleUserProfile(Map<String, User.Profile> userProfiles) {
         User.Profile googleProfile = userProfiles.get(TokenType.GOOGLE_COM.toString());
-        Assert.assertTrue(googleProfile.email.equals("potato@gmail.com") && googleProfile.avatarURL
+        Assert.assertTrue(googleProfile.email.equals(GOOGLE_ACCOUNT_USERNAME) && googleProfile.avatarURL
                 .equals("https://dockstore.org/assets/images/dockstore/logo.png") && googleProfile.company == null
                 && googleProfile.location == null && googleProfile.name.equals("Beef Stew"));
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
@@ -113,7 +113,7 @@ public class TokenResourceIT extends BaseIT {
         Token fakeToken = new Token();
         fakeToken.setContent("fakeContent");
         fakeToken.setTokenSource(TokenType.GOOGLE_COM);
-        fakeToken.setUserId(100);
+        fakeToken.setUserId(1);
         fakeToken.setUsername("potato@gmail.com");
         return fakeToken;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -294,19 +294,19 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
 
     /**
      * Adds a Google token to the existing user if user is authenticated already.
-     * Otherwise, create a new Dockstore account too and also add token
+     * Otherwise, see table below on what should happen.
      * <table border="1">
      * <tr>
-     * <td>  </td> <td><b> Have GitHub account no Google Token </td><td> <b>Have GitHub account with Google token </td> <td> <b>No GitHub Account </td>
+     * <td>  </td> <td><b> Have GitHub account no Google Token (no GitHub account) </td><td> <b>Have GitHub account with Google token </td>
      * </tr>
      * <tr>
-     * <td> <b>Have Google Account no Google token </td> <td> Login with Google </td><td> Login with GitHub </td> <td> Login with Google </td>
+     * <td> <b>Have Google Account no Google token </td> <td> Login with Google </td><td> Login with GitHub </td>
      * </tr>
      * <tr>
-     * <td> <b>Have Google Account with Google token </td> <td> Login with Google </td><td> Login with Google </td> <td> Login with Google </td>
+     * <td> <b>Have Google Account with Google token </td> <td> Login with Google </td><td> Login with Google </td>
      * </tr>
      * <tr>
-     * <td> <b>No Google Account </td> <td> Create Google account </td><td> Login with GitHub </td> <td> Create Google Account  </td>
+     * <td> <b>No Google Account </td> <td> Create Google account </td><td> Login with GitHub </td>
      * </tr>
      * </table>
      *

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -297,16 +297,16 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
      * Otherwise, see table below on what should happen.
      * <table border="1">
      * <tr>
-     * <td>  </td> <td><b> Have GitHub account no Google Token (no GitHub account) </td><td> <b>Have GitHub account with Google token </td>
+     * <td></td> <td><b> Have GitHub account no Google Token (no GitHub account)</td> <td><b>Have GitHub account with Google token</td>
      * </tr>
      * <tr>
-     * <td> <b>Have Google Account no Google token </td> <td> Login with Google </td><td> Login with GitHub </td>
+     * <td> <b>Have Google Account no Google token</td> <td>Login with Google (1)</td> <td>Login with GitHub (2)</td>
      * </tr>
      * <tr>
-     * <td> <b>Have Google Account with Google token </td> <td> Login with Google </td><td> Login with Google </td>
+     * <td> <b>Have Google Account with Google token</td> <td>Login with Google (3)</td> <td> Login with Google (4)</td>
      * </tr>
      * <tr>
-     * <td> <b>No Google Account </td> <td> Create Google account </td><td> Login with GitHub </td>
+     * <td> <b>No Google Account</td> <td> Create Google account (5)</td> <td>Login with GitHub (6)</td>
      * </tr>
      * </table>
      *

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -294,19 +294,19 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
 
     /**
      * Adds a Google token to the existing user if user is authenticated already.
-     * Otherwise, see table below on what should happen.
+     * Otherwise, below table indicates what happens when the "Login with Google" button in the UI2 is clicked
      * <table border="1">
      * <tr>
      * <td></td> <td><b> Have GitHub account no Google Token (no GitHub account)</td> <td><b>Have GitHub account with Google token</td>
      * </tr>
      * <tr>
-     * <td> <b>Have Google Account no Google token</td> <td>Login with Google (1)</td> <td>Login with GitHub (2)</td>
+     * <td> <b>Have Google Account no Google token</td> <td>Login with Google account (1)</td> <td>Login with GitHub account(2)</td>
      * </tr>
      * <tr>
-     * <td> <b>Have Google Account with Google token</td> <td>Login with Google (3)</td> <td> Login with Google (4)</td>
+     * <td> <b>Have Google Account with Google token</td> <td>Login with Google account (3)</td> <td> Login with Google account (4)</td>
      * </tr>
      * <tr>
-     * <td> <b>No Google Account</td> <td> Create Google account (5)</td> <td>Login with GitHub (6)</td>
+     * <td> <b>No Google Account</td> <td> Create Google account (5)</td> <td>Login with GitHub account (6)</td>
      * </tr>
      * </table>
      *
@@ -336,13 +336,13 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
         Token googleToken = null;
         String googleLoginName = userinfo.getEmail();
         User user;
-        User googleUser;
-        googleUser = userDAO.findByUsername(googleLoginName);
-        List<Token> tokensByGoogleUsername = tokenDAO.findTokenByUsername(userinfo.getEmail(), TokenType.GOOGLE_COM);
+
         if (authUser.isPresent()) {
             // Just linking token
             userID = authUser.get().getId();
         } else {
+            User googleUser = userDAO.findByUsername(googleLoginName);
+            List<Token> tokensByGoogleUsername = tokenDAO.findTokenByUsername(userinfo.getEmail(), TokenType.GOOGLE_COM);
             // Determining which account to login to
             if (googleUser == null) {
                 if (tokensByGoogleUsername.size() == 0) {

--- a/dockstore-webservice/src/main/resources/migrations.1.5.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.5.0.xml
@@ -179,7 +179,7 @@
             v.verified='true' and (s.type='CWL_TEST_JSON' OR s.type='WDL_TEST_JSON')
         </sql>
     </changeSet>
-    <changeSet author="gluu" id="">
+    <changeSet author="gluu" id="no-orphaned-tokens">
         <sql dbms="postgresql">
             <comment>Delete tokens that do not belong to any users</comment>
             DELETE from token where userid not in (select id from enduser)

--- a/dockstore-webservice/src/main/resources/migrations.1.5.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.5.0.xml
@@ -179,4 +179,11 @@
             v.verified='true' and (s.type='CWL_TEST_JSON' OR s.type='WDL_TEST_JSON')
         </sql>
     </changeSet>
+    <changeSet author="gluu" id="">
+        <sql dbms="postgresql">
+            <comment>Delete tokens that do not belong to any users</comment>
+            DELETE from token where userid not in (select id from enduser)
+        </sql>
+        <addForeignKeyConstraint baseTableName="token" baseColumnNames="userid" constraintName="fk_userid_with_enduser" referencedTableName="enduser" referencedColumnNames="id"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.test.xml
+++ b/dockstore-webservice/src/main/resources/migrations.test.xml
@@ -36,7 +36,7 @@
             <column name="email"/>
             <column name="isadmin" valueBoolean="false"/>
             <column name="location"/>
-            <column name="username" value="user1@user.com"/>
+            <column name="username" value="potato"/>
         </insert>
     </changeSet>
     <changeSet author="dyuen (generated)" id="1511389821166-4">
@@ -90,7 +90,7 @@
             <column name="refreshtoken"/>
             <column name="tokensource" value="dockstore"/>
             <column name="userid" valueNumeric="2"/>
-            <column name="username" value="user1@user.com"/>
+            <column name="username" value="potato"/>
         </insert>
     </changeSet>
     <changeSet author="dyuen (generated)-edited" id="1511389821166-6">


### PR DESCRIPTION
- Add constraint to prevent orphaned tokens
- Change google login logic.  Choosing which account to log into with "Login with Google" is now somewhat possible.  Basically...in order of priority: goes to account with google token, if both have token or both have no google token, then choose Google account. See the table in the code comments for more info.

For end users: "Login with Google" will prioritize logging into an existing account that has a Google token
For issue #1370 followup