### PR TITLE
Try random order for some modules and re-run flaky tests once

### DIFF
--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -15,7 +15,8 @@
   ~    limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.dockstore</groupId>
@@ -149,11 +150,21 @@
 
     <build>
         <plugins>
-	    <plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- seems like some form of Jackson fork issue for this module with random order -->
+                    <runOrder>filesystem</runOrder>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <skipTests>${skipITs}</skipTests>
+                    <!-- seems like some form of Jackson fork issue for this module with random order -->
+                    <runOrder>filesystem</runOrder>
                 </configuration>
             </plugin>
             <plugin>

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
@@ -33,7 +33,12 @@ import org.glassfish.jersey.client.ClientProperties;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
+import org.junit.rules.ExpectedException;
 
 import static io.dockstore.common.CommonTestUtilities.WAIT_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,6 +53,18 @@ public abstract class GA4GHIT {
             DockstoreWebserviceApplication.class, CommonTestUtilities.CONFIG_PATH);
     protected static javax.ws.rs.client.Client client;
     final String basePath = String.format("http://localhost:%d/" + getApiVersion(), SUPPORT.getLocalPort());
+
+    @Rule
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+
+    @Rule
+    public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
+
+    @Rule
+    public ExpectedException thrown= ExpectedException.none();
 
     @BeforeClass
     public static void dropAndRecreateDB() throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -857,6 +857,10 @@
                     <configuration>
                         <excludedGroups>${excludeGroups}</excludedGroups>
                         <skipTests>${skipTests}</skipTests>
+                        <!-- enforce that tests should be independent -->
+                        <runOrder>random</runOrder>
+                        <!-- re-run flaky tests once -->
+                        <rerunFailingTestsCount>1</rerunFailingTestsCount>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -865,6 +869,10 @@
                     <version>${maven-failsafe.version}</version>
                     <configuration>
                         <excludedGroups>${excludeGroups}</excludedGroups>
+                        <!-- enforce that tests should be independent -->
+                        <runOrder>random</runOrder>
+                        <!-- re-run flaky tests once -->
+                        <rerunFailingTestsCount>1</rerunFailingTestsCount>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -870,7 +870,7 @@
                     <configuration>
                         <excludedGroups>${excludeGroups}</excludedGroups>
                         <!-- enforce that tests should be independent -->
-			            <runOrder>random</runOrder>
+                        <runOrder>random</runOrder>
                         <!-- re-run flaky tests once -->
                         <rerunFailingTestsCount>1</rerunFailingTestsCount>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -858,7 +858,7 @@
                         <excludedGroups>${excludeGroups}</excludedGroups>
                         <skipTests>${skipTests}</skipTests>
                         <!-- enforce that tests should be independent -->
-			<!-- <runOrder>random</runOrder> -->
+                        <runOrder>random</runOrder>
                         <!-- re-run flaky tests once -->
                         <rerunFailingTestsCount>1</rerunFailingTestsCount>
                     </configuration>
@@ -870,7 +870,7 @@
                     <configuration>
                         <excludedGroups>${excludeGroups}</excludedGroups>
                         <!-- enforce that tests should be independent -->
-			<!-- <runOrder>random</runOrder> -->
+			            <runOrder>random</runOrder>
                         <!-- re-run flaky tests once -->
                         <rerunFailingTestsCount>1</rerunFailingTestsCount>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -858,7 +858,7 @@
                         <excludedGroups>${excludeGroups}</excludedGroups>
                         <skipTests>${skipTests}</skipTests>
                         <!-- enforce that tests should be independent -->
-                        <runOrder>random</runOrder>
+			<!-- <runOrder>random</runOrder> -->
                         <!-- re-run flaky tests once -->
                         <rerunFailingTestsCount>1</rerunFailingTestsCount>
                     </configuration>
@@ -870,7 +870,7 @@
                     <configuration>
                         <excludedGroups>${excludeGroups}</excludedGroups>
                         <!-- enforce that tests should be independent -->
-                        <runOrder>random</runOrder>
+			<!-- <runOrder>random</runOrder> -->
                         <!-- re-run flaky tests once -->
                         <rerunFailingTestsCount>1</rerunFailingTestsCount>
                     </configuration>


### PR DESCRIPTION
Enforcing random test order for some tests
Integration spinning up of webservice seems to have issues with Jackson and JUnit 