### PR TITLE
Add Data Object Service File plugin

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/common/FileProvisionUtil.java
+++ b/dockstore-client/src/main/java/io/dockstore/common/FileProvisionUtil.java
@@ -119,8 +119,11 @@ public final class FileProvisionUtil {
             // a larger buffer improves copy performance
             // we can also split this (local file copy) out into a plugin later
             final int largeBuffer = 100;
-            Util.copyStream(inputStream, outputStream, Util.DEFAULT_COPY_BUFFER_SIZE * largeBuffer, size, size > 0 ? listener : null);
+            Util.copyStream(inputStream, outputStream, Util.DEFAULT_COPY_BUFFER_SIZE * largeBuffer, size, listener);
         } finally {
+            if (size == CopyStreamEvent.UNKNOWN_STREAM_SIZE) {
+                System.out.println('\r' + "100%                                                                ");
+            }
             // finalize output from the printer
             System.out.println();
         }

--- a/dockstore-client/src/main/resources/plugins.json
+++ b/dockstore-client/src/main/resources/plugins.json
@@ -7,4 +7,9 @@
   },{
     "name": "dockstore-file-synapse-plugin",
     "version": "0.0.5"
-  }]
+  }, {
+    "name": "dockstore-datastore-object-service-plugin",
+    "version": "0.0.1",
+    "location": "https://github.com/dockstore/data-object-service-plugin/releases/download/0.0.1/dockstore-file-dos-plugin-0.0.1.zip"
+  }
+  ]


### PR DESCRIPTION
Added release 0.0.1 to plugins.json.

Download didn't work, because... HEAD call to

https://github.com/dockstore/data-object-service-plugin/releases/
download/0.0.1/dockstore-file-dos-plugin-0.0.1.zip

was failing(!).

This is because when calling srcContent.getSize(), it would ultimately
call org.apache.commons.vfs2.provider.http.HttpFileObject.doGetType,
which would do a HEAD, and the GitHub API returns a 403.

So wrapped call to get the size in a try...catch. If the size
doesn't come back, then don't display a progress bar.

I believe this could fix hypothetical cases where there is no
size in the header, e.g, if there is a chunked response.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
