### PR TITLE
WIP: Properly look up user for calls with Google token

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/SimpleAuthenticator.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/SimpleAuthenticator.java
@@ -68,7 +68,7 @@ public class SimpleAuthenticator implements Authenticator<String, User> {
             return userinfoPlusFromToken(credentials)
                     .map(userinfoPlus -> {
                         final String email = userinfoPlus.getEmail();
-                        User user = userDAO.findByUsername(email);
+                        User user = userDAO.findByGoogleEmail(email);
                         if (user != null) {
                             updateGoogleToken(credentials, user);
                         } else {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -70,7 +70,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 @Entity
 @Table(name = "enduser")
 @NamedQueries({ @NamedQuery(name = "io.dockstore.webservice.core.User.findAll", query = "SELECT t FROM User t"),
-        @NamedQuery(name = "io.dockstore.webservice.core.User.findByUsername", query = "SELECT t FROM User t WHERE t.username = :username") })
+        @NamedQuery(name = "io.dockstore.webservice.core.User.findByUsername", query = "SELECT t FROM User t WHERE t.username = :username"),
+        @NamedQuery(name = "io.dockstore.webservice.core.User.findByGoogleEmail", query = "SELECT t FROM User t JOIN t.userProfiles p where( KEY(p) = 'google.com' AND p.email = :email)")})
 @SuppressWarnings("checkstyle:magicnumber")
 public class User implements Principal, Comparable<User> {
     @Id

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/UserDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/UserDAO.java
@@ -51,4 +51,10 @@ public class UserDAO extends AbstractDockstoreDAO<User> {
         Query query = namedQuery("io.dockstore.webservice.core.User.findByUsername").setParameter("username", username);
         return (User)query.uniqueResult();
     }
+
+    public User findByGoogleEmail(String email) {
+        final Query query = namedQuery("io.dockstore.webservice.core.User.findByGoogleEmail")
+                .setParameter("email", email);
+        return (User)query.uniqueResult();
+    }
 }

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ info:
     This describes the dockstore API, a webservice that manages pairs of Docker
     images and associated metadata such as CWL documents and Dockerfiles used to
     build those images
-  version: 1.5.0-alpha.9-SNAPSHOT
+  version: 1.5.0-alpha.10-SNAPSHOT
   title: Dockstore API
   termsOfService: TBD
   contact:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.5.0-alpha.9-SNAPSHOT"
+  version: "1.5.0-alpha.10-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/SimpleAuthenticatorTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/SimpleAuthenticatorTest.java
@@ -52,7 +52,7 @@ public class SimpleAuthenticatorTest {
         when(tokenDAO.findByContent(credentials)).thenReturn(null);
         doReturn(Optional.of(userinfoplus)).when(simpleAuthenticator).userinfoPlusFromToken(credentials);
         when(userinfoplus.getEmail()).thenReturn(USER_EMAIL);
-        when(userDAO.findByUsername(USER_EMAIL)).thenReturn(user);
+        when(userDAO.findByGoogleEmail(USER_EMAIL)).thenReturn(user);
         Assert.assertEquals(user, simpleAuthenticator.authenticate(credentials).get());
     }
 


### PR DESCRIPTION
#1684

When web service gets a call with a Google token, look for an existing
user by searching User.Profile for that email address.

In progress, because:

1. The query is very inefficient. I think we would want indexes
on token_type and email columns in user_profile. I need to figure out
how to do that with Liquibase, but I don't want to pursue until we
get agreement on the next item, or some different approach.
2. If we allow for multiple Dockstore accounts pointing to the same
Google account then there will be no way to have this work reliably,
as there would be no way to know which Dockstore account to
associate the call with.

