### PR TITLE
Feature/second security pass

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
@@ -17,21 +17,15 @@
 package io.dockstore.client.cli;
 
 import java.io.IOException;
-import java.net.URL;
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeoutException;
 
-import com.google.common.io.Resources;
+import com.google.common.collect.Lists;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
 import io.dockstore.common.WorkflowTest;
-import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
-import io.swagger.client.api.UsersApi;
 import io.swagger.client.api.WorkflowsApi;
-import io.swagger.client.model.PublishRequest;
 import io.swagger.client.model.Workflow;
 import io.swagger.client.model.WorkflowVersion;
 import org.junit.Assert;
@@ -43,11 +37,10 @@ import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
 
-
 /**
  * Created by jpatricia on 24/06/16.
  */
-@Category({ConfidentialTest.class, WorkflowTest.class})
+@Category( { ConfidentialTest.class, WorkflowTest.class })
 public class DAGWorkflowTestIT extends BaseIT {
 
     @Before
@@ -62,37 +55,26 @@ public class DAGWorkflowTestIT extends BaseIT {
     @Rule
     public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
 
-    private WorkflowsApi setupWebService() throws ApiException {
-        ApiClient webClient = WorkflowIT.getWebClient(USER_1_USERNAME);
-        WorkflowsApi workflowApi = new WorkflowsApi(webClient);
-        return workflowApi;
-    }
-
-    private List<String> getJSON(String repo, String fileName, String descType, String branch)
-            throws IOException, ApiException {
+    private List<String> getJSON(String repo, String fileName, String descType, String branch) throws ApiException {
         final String TEST_WORKFLOW_NAME = "test-workflow";
-        WorkflowsApi workflowApi = setupWebService();
+        WorkflowsApi workflowApi = new WorkflowsApi(getWebClient(USER_1_USERNAME));
         Workflow githubWorkflow = workflowApi.manualRegister("github", repo, fileName, TEST_WORKFLOW_NAME, descType, "/test.json");
 
-
         // This checks if a workflow whose default name was manually registered as test-workflow remains as test-workflow and not null or empty string
-        Assert.assertTrue(githubWorkflow.getWorkflowName().equals(TEST_WORKFLOW_NAME));
+        Assert.assertEquals(githubWorkflow.getWorkflowName(), TEST_WORKFLOW_NAME);
 
         // Publish github workflow
         Workflow refresh = workflowApi.refresh(githubWorkflow.getId());
 
         // This checks if a workflow whose default name is test-workflow remains as test-workflow and not null or empty string after refresh
-        Assert.assertTrue(refresh.getWorkflowName().equals(TEST_WORKFLOW_NAME));
+        Assert.assertEquals(refresh.getWorkflowName(), TEST_WORKFLOW_NAME);
 
         Optional<WorkflowVersion> master = refresh.getWorkflowVersions().stream().filter(workflow -> workflow.getName().equals(branch))
-                .findFirst();
+            .findFirst();
 
         //getting the dag json string
-        final String basePath = WorkflowIT.getWebClient(USER_1_USERNAME).getBasePath();
-        URL url = new URL(basePath + "/workflows/" + githubWorkflow.getId() + "/dag/" + master.get().getId());
-        List<String> strings = Resources.readLines(url, Charset.forName("UTF-8"));
-
-        return strings;
+        String workflowDag = workflowApi.getWorkflowDag(githubWorkflow.getId(), master.get().getId());
+        return Lists.newArrayList(workflowDag);
     }
 
     private int countNodeInJSON(List<String> strings) {
@@ -130,7 +112,7 @@ public class DAGWorkflowTestIT extends BaseIT {
         Assert.assertTrue("node data should have untar as tool", strings.get(0).contains("untar"));
         Assert.assertTrue("node data should have compile as tool", strings.get(0).contains("compile"));
         Assert.assertTrue("edge should connect untar and compile",
-                strings.get(0).contains("\"source\":\"dockstore_untar\",\"target\":\"dockstore_compile\""));
+            strings.get(0).contains("\"source\":\"dockstore_untar\",\"target\":\"dockstore_compile\""));
 
     }
 
@@ -148,14 +130,14 @@ public class DAGWorkflowTestIT extends BaseIT {
         Assert.assertTrue("JSON should not be blank", strings.size() > 0);
         Assert.assertEquals("JSON should have four nodes (including start and end)", countNode, 4);
         Assert.assertTrue("node data should have hello as task", strings.get(0).contains("hello"));
-        Assert.assertTrue("should have first edge", strings.get(0).contains(
-                "{\"data\":{\"source\":\"UniqueBeginKey\",\"target\":\"dockstore_hello\"}}"));
-        Assert.assertTrue("should have second edge", strings.get(0).contains(
-                "{\"data\":{\"source\":\"UniqueBeginKey\",\"target\":\"dockstore_helper\"}}"));
-        Assert.assertTrue("should have third edge", strings.get(0).contains(
-                "{\"data\":{\"source\":\"dockstore_helper\",\"target\":\"UniqueEndKey\"}}"));
-        Assert.assertTrue("should have fourth edge", strings.get(0).contains(
-                "{\"data\":{\"source\":\"dockstore_hello\",\"target\":\"UniqueEndKey\"}}"));
+        Assert.assertTrue("should have first edge",
+            strings.get(0).contains("{\"data\":{\"source\":\"UniqueBeginKey\",\"target\":\"dockstore_hello\"}}"));
+        Assert.assertTrue("should have second edge",
+            strings.get(0).contains("{\"data\":{\"source\":\"UniqueBeginKey\",\"target\":\"dockstore_helper\"}}"));
+        Assert.assertTrue("should have third edge",
+            strings.get(0).contains("{\"data\":{\"source\":\"dockstore_helper\",\"target\":\"UniqueEndKey\"}}"));
+        Assert.assertTrue("should have fourth edge",
+            strings.get(0).contains("{\"data\":{\"source\":\"dockstore_hello\",\"target\":\"UniqueEndKey\"}}"));
 
     }
 
@@ -175,16 +157,16 @@ public class DAGWorkflowTestIT extends BaseIT {
         Assert.assertTrue("node data should have ps as tool", strings.get(0).contains("ps"));
         Assert.assertTrue("node data should have cgrep as tool", strings.get(0).contains("cgrep"));
         Assert.assertTrue("node data should have wc as tool", strings.get(0).contains("wc"));
-        Assert.assertTrue("should have first edge", strings.get(0).contains(
-                "{\"data\":{\"source\":\"UniqueBeginKey\",\"target\":\"dockstore_ps\"}}"));
-        Assert.assertTrue("should have second edge", strings.get(0).contains(
-                "{\"data\":{\"source\":\"dockstore_ps\",\"target\":\"dockstore_cgrep\"}}"));
-        Assert.assertTrue("should have third edge", strings.get(0).contains(
-                "{\"data\":{\"source\":\"dockstore_ps\",\"target\":\"dockstore_wc\"}}"));
-        Assert.assertTrue("should have fourth edge", strings.get(0).contains(
-                "{\"data\":{\"source\":\"dockstore_wc\",\"target\":\"UniqueEndKey\"}}"));
-        Assert.assertTrue("should have fifth edge", strings.get(0).contains(
-                "{\"data\":{\"source\":\"dockstore_cgrep\",\"target\":\"UniqueEndKey\"}}"));
+        Assert.assertTrue("should have first edge",
+            strings.get(0).contains("{\"data\":{\"source\":\"UniqueBeginKey\",\"target\":\"dockstore_ps\"}}"));
+        Assert.assertTrue("should have second edge",
+            strings.get(0).contains("{\"data\":{\"source\":\"dockstore_ps\",\"target\":\"dockstore_cgrep\"}}"));
+        Assert.assertTrue("should have third edge",
+            strings.get(0).contains("{\"data\":{\"source\":\"dockstore_ps\",\"target\":\"dockstore_wc\"}}"));
+        Assert.assertTrue("should have fourth edge",
+            strings.get(0).contains("{\"data\":{\"source\":\"dockstore_wc\",\"target\":\"UniqueEndKey\"}}"));
+        Assert.assertTrue("should have fifth edge",
+            strings.get(0).contains("{\"data\":{\"source\":\"dockstore_cgrep\",\"target\":\"UniqueEndKey\"}}"));
 
     }
 
@@ -233,7 +215,7 @@ public class DAGWorkflowTestIT extends BaseIT {
         Assert.assertTrue("node data should have untar as tool", strings.get(0).contains("untar"));
         Assert.assertTrue("node data should have compile as tool", strings.get(0).contains("compile"));
         Assert.assertTrue("edge should connect untar and compile",
-                strings.get(0).contains("\"source\":\"dockstore_untar\",\"target\":\"dockstore_compile\""));
+            strings.get(0).contains("\"source\":\"dockstore_untar\",\"target\":\"dockstore_compile\""));
     }
 
     @Test
@@ -262,18 +244,18 @@ public class DAGWorkflowTestIT extends BaseIT {
         // Return: DAG with 19 nodes
 
         final List<String> strings = getJSON("DockstoreTestUser2/OxoG-Dockstore-Tools", "/preprocess_vcf.cwl", "cwl",
-                "hints_ExpressionTool");
+            "hints_ExpressionTool");
         int countNode = countNodeInJSON(strings);
 
         Assert.assertTrue("JSON should not be blank", strings.size() > 0);
         Assert.assertEquals("JSON should have 19 nodes", countNode, 19);
         Assert.assertTrue("should have end with gather_sanger_indels and merge_vcfs",
-                strings.get(0).contains("\"source\":\"dockstore_gather_sanger_indels\",\"target\":\"dockstore_merge_vcfs\""));
+            strings.get(0).contains("\"source\":\"dockstore_gather_sanger_indels\",\"target\":\"dockstore_merge_vcfs\""));
         Assert.assertTrue("should have end with filter and normalize",
-                strings.get(0).contains("\"source\":\"dockstore_filter\",\"target\":\"dockstore_normalize\""));
+            strings.get(0).contains("\"source\":\"dockstore_filter\",\"target\":\"dockstore_normalize\""));
         Assert.assertTrue("should have docker requirement for vcf_merge", strings.get(0).contains(
-                "\"name\":\"merge_vcfs\",\"run\":\"vcf_merge.cwl\",\"id\":\"dockstore_merge_vcfs\",\"type\":\"tool\",\"tool\":\"https://hub.docker.com/r/pancancer/pcawg-oxog-tools\",\"docker\":\"pancancer/pcawg-oxog-tools\""));
+            "\"name\":\"merge_vcfs\",\"run\":\"vcf_merge.cwl\",\"id\":\"dockstore_merge_vcfs\",\"type\":\"tool\",\"tool\":\"https://hub.docker.com/r/pancancer/pcawg-oxog-tools\",\"docker\":\"pancancer/pcawg-oxog-tools\""));
         Assert.assertTrue("should have docker requirement for clean", strings.get(0).contains(
-                "\"name\":\"clean\",\"run\":\"clean_vcf.cwl\",\"id\":\"dockstore_clean\",\"type\":\"tool\",\"tool\":\"https://hub.docker.com/r/pancancer/pcawg-oxog-tools\",\"docker\":\"pancancer/pcawg-oxog-tools:1.0.0\""));
+            "\"name\":\"clean\",\"run\":\"clean_vcf.cwl\",\"id\":\"dockstore_clean\",\"type\":\"tool\",\"tool\":\"https://hub.docker.com/r/pancancer/pcawg-oxog-tools\",\"docker\":\"pancancer/pcawg-oxog-tools:1.0.0\""));
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
@@ -16,7 +16,6 @@
 
 package io.dockstore.client.cli;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
@@ -97,7 +96,7 @@ public class DAGWorkflowTestIT extends BaseIT {
     }
 
     @Test
-    public void testWorkflowDAGCWL() throws IOException, ApiException {
+    public void testWorkflowDAGCWL() throws ApiException {
         // Input: 1st-workflow.cwl
         // Repo: test_workflow_cwl
         // Branch: master
@@ -117,7 +116,7 @@ public class DAGWorkflowTestIT extends BaseIT {
     }
 
     @Test
-    public void testWorkflowDAGWDLSingleNode() throws IOException, ApiException {
+    public void testWorkflowDAGWDLSingleNode() throws ApiException {
         // Input: hello.wdl
         // Repo: test_workflow_wdl
         // Branch: master
@@ -142,7 +141,7 @@ public class DAGWorkflowTestIT extends BaseIT {
     }
 
     @Test
-    public void testWorkflowDAGWDLMultipleNodes() throws IOException, ApiException {
+    public void testWorkflowDAGWDLMultipleNodes() throws ApiException {
         // Input: hello.wdl
         // Repo: hello-dockstore-workflow
         // Branch: master
@@ -171,7 +170,7 @@ public class DAGWorkflowTestIT extends BaseIT {
     }
 
     @Test
-    public void testWorkflowDAGCWLMissingTool() throws IOException, ApiException {
+    public void testWorkflowDAGCWLMissingTool() throws ApiException {
         // Input: Dockstore.cwl
         // Repo: hello-dockstore-workflow
         // Branch: testCWL
@@ -186,7 +185,7 @@ public class DAGWorkflowTestIT extends BaseIT {
 
     @Test
     @Ignore("This test will fail as long as we are not using validation on WDL workflows and are assuming that if the file exists it is valid")
-    public void testWorkflowDAGWDLMissingTask() throws IOException, ApiException {
+    public void testWorkflowDAGWDLMissingTask() throws ApiException {
         // Input: hello.wdl
         // Repo: test_workflow_wdl
         // Branch: missing_docker
@@ -200,7 +199,7 @@ public class DAGWorkflowTestIT extends BaseIT {
     }
 
     @Test
-    public void testDAGImportSyntax() throws IOException, ApiException {
+    public void testDAGImportSyntax() throws ApiException {
         // Input: Dockstore.cwl
         // Repo: dockstore-whalesay-imports
         // Branch: master
@@ -219,7 +218,7 @@ public class DAGWorkflowTestIT extends BaseIT {
     }
 
     @Test
-    public void testDAGCWL1Syntax() throws IOException, ApiException {
+    public void testDAGCWL1Syntax() throws ApiException {
         // Input: preprocess_vcf.cwl
         // Repo: OxoG-Dockstore-Tools
         // Branch: develop
@@ -236,7 +235,7 @@ public class DAGWorkflowTestIT extends BaseIT {
     }
 
     @Test
-    public void testHintsExpressionTool() throws IOException, ApiException {
+    public void testHintsExpressionTool() throws ApiException {
         // Input: preprocess_vcf.cwl
         // Repo: OxoG-Dockstore-Tools
         // Branch: hints_ExpressionTool

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
@@ -17,16 +17,13 @@
 package io.dockstore.client.cli;
 
 import java.io.IOException;
-import java.net.URL;
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Optional;
 
-import com.google.common.io.Resources;
+import com.google.common.collect.Lists;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
 import io.dockstore.common.WorkflowTest;
-import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
 import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.model.Workflow;
@@ -59,15 +56,10 @@ public class ToolsWorkflowTestIT extends BaseIT {
     @Rule
     public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
 
-    private WorkflowsApi setupWebService() throws ApiException {
-        ApiClient webClient = WorkflowIT.getWebClient(USER_1_USERNAME);
-        return new WorkflowsApi(webClient);
-    }
-
     private List<String> getJSON(String repo, String fileName, String descType, String branch)
             throws IOException, ApiException {
         final String TEST_WORKFLOW_NAME = "test-workflow";
-        WorkflowsApi workflowApi = setupWebService();
+        WorkflowsApi workflowApi = new WorkflowsApi(getWebClient(USER_1_USERNAME));
         Workflow githubWorkflow = workflowApi.manualRegister("github", repo, fileName, TEST_WORKFLOW_NAME, descType, "/test.json");
 
         // This checks if a workflow whose default name was manually registered as test-workflow remains as test-workflow and not null or empty string
@@ -83,10 +75,7 @@ public class ToolsWorkflowTestIT extends BaseIT {
                 .findFirst();
 
         //getting the dag json string
-        final String basePath = WorkflowIT.getWebClient(USER_1_USERNAME).getBasePath();
-        URL url = new URL(basePath + "/workflows/" + githubWorkflow.getId() + "/tools/" + master.get().getId());
-
-        return Resources.readLines(url, Charset.forName("UTF-8"));
+        return Lists.newArrayList(workflowApi.getTableToolContent(githubWorkflow.getId(), master.get().getId()));
     }
 
     private int countToolInJSON(List<String> strings) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ExtendedUserData.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ExtendedUserData.java
@@ -30,7 +30,7 @@ public class ExtendedUserData {
 
     public ExtendedUserData(User user) {
         Hibernate.initialize(user.getEntries());
-        this.canChangeUsername = !user.getEntries().stream().anyMatch(Entry::getIsPublished);
+        this.canChangeUsername = user.getEntries().stream().noneMatch(Entry::getIsPublished);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AuthenticatedResourceInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AuthenticatedResourceInterface.java
@@ -51,6 +51,18 @@ public interface AuthenticatedResourceInterface {
     }
 
     /**
+     * Check if admin
+     *
+     * @param user
+     */
+    default void checkAdmin(User user) {
+        if (!user.getIsAdmin()) {
+            throw new CustomWebApplicationException("Forbidden: you need to be an admin to perform this operation.",
+                HttpStatus.SC_FORBIDDEN);
+        }
+    }
+
+    /**
      * Check if admin or if tool belongs to user
      *
      * @param user

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AuthenticatedResourceInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AuthenticatedResourceInterface.java
@@ -16,6 +16,7 @@
 package io.dockstore.webservice.resources;
 
 import java.util.List;
+import java.util.Optional;
 
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.Entry;
@@ -149,4 +150,36 @@ public interface AuthenticatedResourceInterface {
         checkUser(user, entry);
     }
 
+    /**
+     * Override for resources that are permissions aware.
+     * Currently done for WorkflowResource
+     * @param user
+     * @param workflow
+     */
+    default void checkCanRead(User user, Entry workflow) {
+        throw new CustomWebApplicationException("Forbidden: you do not have the credentials required to access this entry.",
+            HttpStatus.SC_FORBIDDEN);
+    }
+
+    /**
+     * This method checks that a workflow can be read in two situations
+     * 1) A published workflow
+     * 2) A workflow that is unpublished but that I have access to
+     *
+     * @param user
+     * @param entry
+     */
+    default void checkOptionalAuthRead(Optional<User> user, Entry entry) {
+        if (entry.getIsPublished()) {
+            checkEntry(entry);
+        } else {
+            checkEntry(entry);
+            if (user.isPresent()) {
+                checkCanRead(user.get(), entry);
+            } else {
+                throw new CustomWebApplicationException("Forbidden: you do not have the credentials required to access this entry.",
+                    HttpStatus.SC_FORBIDDEN);
+            }
+        }
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -107,7 +107,7 @@ public class DockerRepoResource
 
     private static final Logger LOG = LoggerFactory.getLogger(DockerRepoResource.class);
     private static final String PAGINATION_LIMIT = "100";
-    private static final String OPTIONAL_AUTH_MESSAGE = "Does not require authentication for published workflows, authentication can be provided for restricted tools";
+    private static final String OPTIONAL_AUTH_MESSAGE = "Does not require authentication for published tools, authentication can be provided for restricted tools";
 
     @Context
     private javax.ws.rs.container.ResourceContext rc;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -711,9 +711,10 @@ public class DockerRepoResource
     @UnitOfWork
     @Path("/{containerId}/dockerfile")
     @ApiOperation(value = "Get the corresponding Dockerfile on Github.", tags = {
-        "containers" }, notes = "Does not need authentication", response = SourceFile.class)
-    public SourceFile dockerfile(@ApiParam(hidden = true) @Auth Optional<User> user, @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId,
-        @QueryParam("tag") String tag) {
+        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
+    public SourceFile dockerfile(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag) {
 
         return getSourceFile(containerId, tag, FileType.DOCKERFILE, user);
     }
@@ -722,7 +723,7 @@ public class DockerRepoResource
     @Timed
     @UnitOfWork
     @Path("/{containerId}/verifiedSources")
-    @ApiOperation(value = "Get the corresponding Dockstore.cwl file on Github.", tags = {
+    @ApiOperation(value = "Get the sources that verified a particular tool.", tags = {
         "containers" }, notes = "Does not need authentication", response = String.class)
     public String verifiedSources(@ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId) {
         Tool tool = toolDAO.findById(containerId);
@@ -748,7 +749,8 @@ public class DockerRepoResource
     @UnitOfWork
     @Path("/{containerId}/cwl")
     @ApiOperation(value = "Get the corresponding Dockstore.cwl file on Github.", tags = {
-        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public SourceFile cwl(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag) {
         return getSourceFile(containerId, tag, FileType.DOCKSTORE_CWL, user);
@@ -759,7 +761,8 @@ public class DockerRepoResource
     @UnitOfWork
     @Path("/{containerId}/wdl")
     @ApiOperation(value = "Get the corresponding Dockstore.wdl file on Github.", tags = {
-        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public SourceFile wdl(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag) {
         return getSourceFile(containerId, tag, FileType.DOCKSTORE_WDL, user);
@@ -770,7 +773,8 @@ public class DockerRepoResource
     @UnitOfWork
     @Path("/{containerId}/cwl/{relative-path}")
     @ApiOperation(value = "Get the corresponding Dockstore.cwl file on Github.", tags = {
-        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public SourceFile secondaryCwlPath(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
         @PathParam("relative-path") String path) {
@@ -782,7 +786,8 @@ public class DockerRepoResource
     @UnitOfWork
     @Path("/{containerId}/wdl/{relative-path}")
     @ApiOperation(value = "Get the corresponding Dockstore.wdl file on Github.", tags = {
-        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public SourceFile secondaryWdlPath(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
         @PathParam("relative-path") String path) {
@@ -794,7 +799,8 @@ public class DockerRepoResource
     @UnitOfWork
     @Path("/{containerId}/secondaryCwl")
     @ApiOperation(value = "Get a list of secondary CWL files from Git.", tags = {
-        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List")
+        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public List<SourceFile> secondaryCwl(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag) {
         return getAllSecondaryFiles(containerId, tag, FileType.DOCKSTORE_CWL, user);
@@ -805,7 +811,8 @@ public class DockerRepoResource
     @UnitOfWork
     @Path("/{containerId}/secondaryWdl")
     @ApiOperation(value = "Get a list of secondary WDL files from Git.", tags = {
-        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List")
+        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public List<SourceFile> secondaryWdl(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag) {
         return getAllSecondaryFiles(containerId, tag, FileType.DOCKSTORE_WDL, user);
@@ -816,7 +823,8 @@ public class DockerRepoResource
     @UnitOfWork
     @Path("/{containerId}/testParameterFiles")
     @ApiOperation(value = "Get the corresponding wdl test parameter files.", tags = {
-        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List")
+        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public List<SourceFile> getTestParameterFiles(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
         @ApiParam(value = "Descriptor Type", required = true, allowableValues = "CWL, WDL, NFL") @QueryParam("descriptorType") String descriptorType) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -97,13 +97,17 @@ import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
 /**
  * @author dyuen
  */
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Path("/containers")
 @Api("containers")
 @Produces(MediaType.APPLICATION_JSON)
-public class DockerRepoResource implements AuthenticatedResourceInterface, EntryVersionHelper<Tool, Tag, ToolDAO>, StarrableResourceInterface, SourceControlResourceInterface  {
+public class DockerRepoResource
+    implements AuthenticatedResourceInterface, EntryVersionHelper<Tool, Tag, ToolDAO>, StarrableResourceInterface,
+    SourceControlResourceInterface {
 
     private static final Logger LOG = LoggerFactory.getLogger(DockerRepoResource.class);
     private static final String PAGINATION_LIMIT = "100";
+    private static final String OPTIONAL_AUTH_MESSAGE = "Does not require authentication for published workflows, authentication can be provided for restricted tools";
 
     @Context
     private javax.ws.rs.container.ResourceContext rc;
@@ -122,7 +126,8 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     private final ElasticManager elasticManager;
     private final WorkflowResource workflowResource;
 
-    public DockerRepoResource(ObjectMapper mapper, HttpClient client, SessionFactory sessionFactory, String bitbucketClientID, String bitbucketClientSecret, WorkflowResource workflowResource) {
+    public DockerRepoResource(ObjectMapper mapper, HttpClient client, SessionFactory sessionFactory, String bitbucketClientID,
+        String bitbucketClientSecret, WorkflowResource workflowResource) {
         objectMapper = mapper;
         this.userDAO = new UserDAO(sessionFactory);
         this.tokenDAO = new TokenDAO(sessionFactory);
@@ -169,7 +174,8 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
             LOG.info("Grabbing " + registry.getFriendlyName() + " repos");
 
             updatedTools.addAll(abstractImageRegistry
-                .refreshTools(userId, userDAO, toolDAO, tagDAO, fileDAO, fileFormatDAO, client, githubToken, bitbucketToken, gitlabToken, organization));
+                .refreshTools(userId, userDAO, toolDAO, tagDAO, fileDAO, fileFormatDAO, client, githubToken, bitbucketToken, gitlabToken,
+                    organization));
         }
         return updatedTools;
     }
@@ -194,9 +200,10 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @Path("/{containerId}/refresh")
     @Timed
     @UnitOfWork
-    @ApiOperation(value = "Refresh one particular repo", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tool.class)
+    @ApiOperation(value = "Refresh one particular repo", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tool.class)
     public Tool refresh(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Tool ID", required = true) @PathParam("containerId") Long containerId) {
+        @ApiParam(value = "Tool ID", required = true) @PathParam("containerId") Long containerId) {
         Tool c = toolDAO.findById(containerId);
         checkEntry(c);
         checkUser(user, c);
@@ -256,17 +263,17 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
             throw new CustomWebApplicationException("unable to establish connection to registry, check that you have linked your accounts",
                 HttpStatus.SC_NOT_FOUND);
         }
-        return abstractImageRegistry
-            .refreshTool(containerId, userId, userDAO, toolDAO, tagDAO, fileDAO, fileFormatDAO, sourceCodeRepo);
+        return abstractImageRegistry.refreshTool(containerId, userId, userDAO, toolDAO, tagDAO, fileDAO, fileFormatDAO, sourceCodeRepo);
     }
 
     @GET
     @Timed
     @UnitOfWork
     @Path("/{containerId}")
-    @ApiOperation(value = "Get a registered repo", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tool.class, notes = "This is one of the few endpoints that returns the user object with populated properties (minus the userProfiles property)")
+    @ApiOperation(value = "Get a registered repo", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tool.class, notes = "This is one of the few endpoints that returns the user object with populated properties (minus the userProfiles property)")
     public Tool getContainer(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Tool ID", required = true) @PathParam("containerId") Long containerId) {
+        @ApiParam(value = "Tool ID", required = true) @PathParam("containerId") Long containerId) {
         Tool c = toolDAO.findById(containerId);
         checkEntry(c);
         checkUser(user, c);
@@ -276,16 +283,16 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
         return c;
     }
 
-
     @PUT
     @Timed
     @UnitOfWork
     @Path("/{containerId}/labels")
-    @ApiOperation(value = "Update the labels linked to a container.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Labels are alphanumerical (case-insensitive and may contain internal hyphens), given in a comma-delimited list.", response = Tool.class)
+    @ApiOperation(value = "Update the labels linked to a container.", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Labels are alphanumerical (case-insensitive and may contain internal hyphens), given in a comma-delimited list.", response = Tool.class)
     public Tool updateLabels(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Tool to modify.", required = true) @PathParam("containerId") Long containerId,
-            @ApiParam(value = "Comma-delimited list of labels.", required = true) @QueryParam("labels") String labelStrings,
-            @ApiParam(value = "This is here to appease Swagger. It requires PUT methods to have a body, even if it is empty. Please leave it empty.") String emptyBody) {
+        @ApiParam(value = "Tool to modify.", required = true) @PathParam("containerId") Long containerId,
+        @ApiParam(value = "Comma-delimited list of labels.", required = true) @QueryParam("labels") String labelStrings,
+        @ApiParam(value = "This is here to appease Swagger. It requires PUT methods to have a body, even if it is empty. Please leave it empty.") String emptyBody) {
         return this.updateLabels(user, containerId, labelStrings, labelDAO, elasticManager);
     }
 
@@ -293,10 +300,11 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @Timed
     @UnitOfWork
     @Path("/{containerId}")
-    @ApiOperation(value = "Update the tool with the given tool.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tool.class)
+    @ApiOperation(value = "Update the tool with the given tool.", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tool.class)
     public Tool updateContainer(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Tool to modify.", required = true) @PathParam("containerId") Long containerId,
-            @ApiParam(value = "Tool with updated information", required = true) Tool tool) {
+        @ApiParam(value = "Tool to modify.", required = true) @PathParam("containerId") Long containerId,
+        @ApiParam(value = "Tool with updated information", required = true) Tool tool) {
         Tool c = toolDAO.findById(containerId);
         checkEntry(c);
         checkNotHosted(c);
@@ -322,10 +330,11 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @Timed
     @UnitOfWork
     @Path("/{toolId}/defaultVersion")
-    @ApiOperation(value = "Update the default version of the given tool.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tool.class, nickname = "updateToolDefaultVersion")
+    @ApiOperation(value = "Update the default version of the given tool.", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tool.class, nickname = "updateToolDefaultVersion")
     public Tool updateDefaultVersion(@ApiParam(hidden = true) @Auth User user,
-                                @ApiParam(value = "Tool to modify.", required = true) @PathParam("toolId") Long toolId,
-                                @ApiParam(value = "Tag name to set as default.", required = true) String version) {
+        @ApiParam(value = "Tool to modify.", required = true) @PathParam("toolId") Long toolId,
+        @ApiParam(value = "Tag name to set as default.", required = true) String version) {
         return (Tool)updateDefaultVersionHelper(version, toolId, user, elasticManager);
     }
 
@@ -333,7 +342,7 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
      * Updates information from given tool based on the new tool
      *
      * @param originalTool the original tool from the database
-     * @param newTool the new tool from the webservice
+     * @param newTool      the new tool from the webservice
      */
     private void updateInfo(Tool originalTool, Tool newTool) {
         // to do, this could probably be better handled better
@@ -363,10 +372,11 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @Timed
     @UnitOfWork
     @Path("/{containerId}/updateTagPaths")
-    @ApiOperation(value = "Change the workflow paths", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Tag correspond to each row of the versions table listing all information for a docker repo tag", response = Tool.class)
+    @ApiOperation(value = "Change the workflow paths", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Tag correspond to each row of the versions table listing all information for a docker repo tag", response = Tool.class)
     public Tool updateTagContainerPath(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Tool to modify.", required = true) @PathParam("containerId") Long containerId,
-            @ApiParam(value = "Tool with updated information", required = true) Tool tool) {
+        @ApiParam(value = "Tool to modify.", required = true) @PathParam("containerId") Long containerId,
+        @ApiParam(value = "Tool with updated information", required = true) Tool tool) {
 
         Tool c = toolDAO.findById(containerId);
 
@@ -392,9 +402,10 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @Timed
     @UnitOfWork
     @Path("/{containerId}/users")
-    @ApiOperation(value = "Get users of a container", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class, responseContainer = "List")
+    @ApiOperation(value = "Get users of a container", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class, responseContainer = "List")
     public List<User> getUsers(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Tool ID", required = true) @PathParam("containerId") Long containerId) {
+        @ApiParam(value = "Tool ID", required = true) @PathParam("containerId") Long containerId) {
         Tool c = toolDAO.findById(containerId);
         checkEntry(c);
 
@@ -419,7 +430,7 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @Path("/namespace/{namespace}/published")
     @ApiOperation(value = "List all published containers belonging to the specified namespace", notes = "NO authentication", response = Tool.class, responseContainer = "List")
     public List<Tool> getPublishedContainersByNamespace(
-            @ApiParam(value = "namespace", required = true) @PathParam("namespace") String namespace) {
+        @ApiParam(value = "namespace", required = true) @PathParam("namespace") String namespace) {
         List<Tool> tools = toolDAO.findPublishedByNamespace(namespace);
         filterContainersForHiddenTags(tools);
         return tools;
@@ -438,9 +449,10 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @Timed
     @UnitOfWork
     @Path("/registerManual")
-    @ApiOperation(value = "Register an image manually, along with tags", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Register an image manually.", response = Tool.class)
+    @ApiOperation(value = "Register an image manually, along with tags", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Register an image manually.", response = Tool.class)
     public Tool registerManual(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Tool to be registered", required = true) Tool tool) {
+        @ApiParam(value = "Tool to be registered", required = true) Tool tool) {
         // populate user in tool
         tool.addUser(user);
         // create dependent Tags before creating tool
@@ -474,14 +486,14 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
         if (tool.getRegistry().equals(Registry.QUAY_IO.toString()) && !checkContainerForTags(tool, user.getId())) {
             LOG.info(user.getUsername() + ": tool has no tags.");
             throw new CustomWebApplicationException(
-                    "Tool " + tool.getToolPath() + " has no tags. Quay containers must have at least one tag.", HttpStatus.SC_BAD_REQUEST);
+                "Tool " + tool.getToolPath() + " has no tags. Quay containers must have at least one tag.", HttpStatus.SC_BAD_REQUEST);
         }
 
         // Check if user owns repo, or if user is in the organization which owns the tool
         if (tool.getRegistry().equals(Registry.QUAY_IO.toString()) && !checkIfUserOwns(tool, user.getId())) {
             LOG.info(user.getUsername() + ": User does not own the given Quay Repo.");
             throw new CustomWebApplicationException("User does not own the tool " + tool.getPath()
-                    + ". You can only add Quay repositories that you own or are part of the organization", HttpStatus.SC_BAD_REQUEST);
+                + ". You can only add Quay repositories that you own or are part of the organization", HttpStatus.SC_BAD_REQUEST);
         }
 
         long id = toolDAO.create(tool);
@@ -491,7 +503,8 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
 
     /**
      * Look for the tags that a tool has using a user's own tokens
-     * @param tool the tool to examine
+     *
+     * @param tool   the tool to examine
      * @param userId the id for the user that is doing the checking
      * @return true if the container has tags
      */
@@ -501,7 +514,7 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
         if (quayToken == null) {
             // no quay token extracted
             throw new CustomWebApplicationException("no quay token found, please link your quay.io account to read from quay.io",
-                    HttpStatus.SC_NOT_FOUND);
+                HttpStatus.SC_NOT_FOUND);
         }
         ImageRegistryFactory factory = new ImageRegistryFactory(client, objectMapper, quayToken);
 
@@ -518,7 +531,7 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @ApiOperation(value = "Delete a tool", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     @ApiResponses(@ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = "Invalid "))
     public Response deleteContainer(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Tool id to delete", required = true) @PathParam("containerId") Long containerId) {
+        @ApiParam(value = "Tool id to delete", required = true) @PathParam("containerId") Long containerId) {
         Tool tool = toolDAO.findById(containerId);
         checkUser(user, tool);
         Tool deleteTool = new Tool();
@@ -540,17 +553,17 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @Timed
     @UnitOfWork
     @Path("/{containerId}/publish")
-    @ApiOperation(value = "Publish or unpublish a container", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "publish a container (public or private). Assumes that user is using quay.io and github.", response = Tool.class)
+    @ApiOperation(value = "Publish or unpublish a container", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "publish a container (public or private). Assumes that user is using quay.io and github.", response = Tool.class)
     public Tool publish(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Tool id to publish", required = true) @PathParam("containerId") Long containerId,
-            @ApiParam(value = "PublishRequest to refresh the list of repos for a user", required = true) PublishRequest request) {
+        @ApiParam(value = "Tool id to publish", required = true) @PathParam("containerId") Long containerId,
+        @ApiParam(value = "PublishRequest to refresh the list of repos for a user", required = true) PublishRequest request) {
         Tool c = toolDAO.findById(containerId);
         checkEntry(c);
 
         checkUser(user, c);
 
         Workflow checker = c.getCheckerWorkflow();
-
 
         if (request.getPublish()) {
             boolean validTag = false;
@@ -567,8 +580,7 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
                 // Check that either tool maintainer email or author email is not null
                 if (Strings.isNullOrEmpty(c.getToolMaintainerEmail()) && Strings.isNullOrEmpty(c.getEmail())) {
                     throw new CustomWebApplicationException(
-                            "Either a tool email or tool maintainer email is required to publish private tools.",
-                            HttpStatus.SC_BAD_REQUEST);
+                        "Either a tool email or tool maintainer email is required to publish private tools.", HttpStatus.SC_BAD_REQUEST);
                 }
             }
 
@@ -606,7 +618,8 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
         "containers" }, notes = "NO authentication", response = Tool.class, responseContainer = "List")
     public List<Tool> allPublishedContainers(
         @ApiParam(value = "Start index of paging. Pagination results can be based on numbers or other values chosen by the registry implementor (for example, SHA values). If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.") @QueryParam("offset") String offset,
-        @ApiParam(value = "Amount of records to return in a given page, limited to " + PAGINATION_LIMIT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
+        @ApiParam(value = "Amount of records to return in a given page, limited to "
+            + PAGINATION_LIMIT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
         @ApiParam(value = "Filter, this is a search string that filters the results.") @DefaultValue("") @QueryParam("filter") String filter,
         @ApiParam(value = "Sort column") @DefaultValue("stars") @QueryParam("sortCol") String sortCol,
         @ApiParam(value = "Sort order", allowableValues = "asc,desc") @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
@@ -626,7 +639,7 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @Path("/path/{repository}/published")
     @ApiOperation(value = "Get a list of published tools by path", notes = "NO authentication", response = Tool.class)
     public List<Tool> getPublishedContainerByPath(
-            @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
+        @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
         List<Tool> tools = toolDAO.findAllByPath(path, true);
         filterContainersForHiddenTags(tools);
         checkEntry(tools);
@@ -637,9 +650,10 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @Timed
     @UnitOfWork
     @Path("/path/{repository}")
-    @ApiOperation(value = "Get a list of tools by path", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Lists info of tool. Enter full path (include quay.io in path).", response = Tool.class, responseContainer = "List")
+    @ApiOperation(value = "Get a list of tools by path", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Lists info of tool. Enter full path (include quay.io in path).", response = Tool.class, responseContainer = "List")
     public List<Tool> getContainerByPath(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
+        @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
         List<Tool> tools = toolDAO.findAllByPath(path, false);
         checkEntry(tools);
         AuthenticatedResourceInterface.checkUser(user, tools);
@@ -650,9 +664,10 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @Timed
     @UnitOfWork
     @Path("/path/tool/{repository}")
-    @ApiOperation(value = "Get a tool by the specific tool path", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Lists info of tool. Enter full path (include quay.io in path).", response = Tool.class)
+    @ApiOperation(value = "Get a tool by the specific tool path", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Lists info of tool. Enter full path (include quay.io in path).", response = Tool.class)
     public Tool getContainerByToolPath(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
+        @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
         Tool tool = toolDAO.findByPath(path, false);
         checkEntry(tool);
         checkUser(user, tool);
@@ -665,7 +680,7 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @Path("/path/tool/{repository}/published")
     @ApiOperation(value = "Get a published tool by the specific tool path", notes = "Lists info of tool. Enter full path (include quay.io in path).", response = Tool.class)
     public Tool getPublishedContainerByToolPath(
-            @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
+        @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
         try {
             Tool tool = toolDAO.findByPath(path, true);
             checkEntry(tool);
@@ -680,7 +695,8 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @Timed
     @UnitOfWork
     @Path("/tags")
-    @ApiOperation(value = "List the tags for a registered container", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tag.class, responseContainer = "List", hidden = true)
+    @ApiOperation(value = "List the tags for a registered container", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tag.class, responseContainer = "List", hidden = true)
     public List<Tag> tags(@ApiParam(hidden = true) @Auth User user, @QueryParam("containerId") long containerId) {
         Tool repository = toolDAO.findById(containerId);
         checkEntry(repository);
@@ -695,11 +711,11 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @UnitOfWork
     @Path("/{containerId}/dockerfile")
     @ApiOperation(value = "Get the corresponding Dockerfile on Github.", tags = {
-            "containers" }, notes = "Does not need authentication", response = SourceFile.class)
-    public SourceFile dockerfile(@ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId,
-            @QueryParam("tag") String tag) {
+        "containers" }, notes = "Does not need authentication", response = SourceFile.class)
+    public SourceFile dockerfile(@ApiParam(hidden = true) @Auth Optional<User> user, @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId,
+        @QueryParam("tag") String tag) {
 
-        return getSourceFile(containerId, tag, FileType.DOCKERFILE);
+        return getSourceFile(containerId, tag, FileType.DOCKERFILE, user);
     }
 
     @GET
@@ -707,7 +723,7 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @UnitOfWork
     @Path("/{containerId}/verifiedSources")
     @ApiOperation(value = "Get the corresponding Dockstore.cwl file on Github.", tags = {
-            "containers" }, notes = "Does not need authentication", response = String.class)
+        "containers" }, notes = "Does not need authentication", response = String.class)
     public String verifiedSources(@ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId) {
         Tool tool = toolDAO.findById(containerId);
         checkEntry(tool);
@@ -720,7 +736,7 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
             jsonArray = new JSONArray(verifiedSourcesArray.toArray());
         } catch (JSONException ex) {
             throw new CustomWebApplicationException("There was an error converting the array of verified sources to a JSON array.",
-                    HttpStatus.SC_INTERNAL_SERVER_ERROR);
+                HttpStatus.SC_INTERNAL_SERVER_ERROR);
         }
 
         return jsonArray.toString();
@@ -732,10 +748,10 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @UnitOfWork
     @Path("/{containerId}/cwl")
     @ApiOperation(value = "Get the corresponding Dockstore.cwl file on Github.", tags = {
-            "containers" }, notes = "Does not need authentication", response = SourceFile.class)
-    public SourceFile cwl(@ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId,
-            @QueryParam("tag") String tag) {
-        return getSourceFile(containerId, tag, FileType.DOCKSTORE_CWL);
+        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+    public SourceFile cwl(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag) {
+        return getSourceFile(containerId, tag, FileType.DOCKSTORE_CWL, user);
     }
 
     @GET
@@ -743,10 +759,10 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @UnitOfWork
     @Path("/{containerId}/wdl")
     @ApiOperation(value = "Get the corresponding Dockstore.wdl file on Github.", tags = {
-            "containers" }, notes = "Does not need authentication", response = SourceFile.class)
-    public SourceFile wdl(@ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId,
-            @QueryParam("tag") String tag) {
-        return getSourceFile(containerId, tag, FileType.DOCKSTORE_WDL);
+        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+    public SourceFile wdl(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag) {
+        return getSourceFile(containerId, tag, FileType.DOCKSTORE_WDL, user);
     }
 
     @GET
@@ -754,10 +770,11 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @UnitOfWork
     @Path("/{containerId}/cwl/{relative-path}")
     @ApiOperation(value = "Get the corresponding Dockstore.cwl file on Github.", tags = {
-            "containers" }, notes = "Does not need authentication", response = SourceFile.class)
-    public SourceFile secondaryCwlPath(@ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId,
-            @QueryParam("tag") String tag, @PathParam("relative-path") String path) {
-        return getSourceFileByPath(containerId, tag, FileType.DOCKSTORE_CWL, path);
+        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+    public SourceFile secondaryCwlPath(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
+        @PathParam("relative-path") String path) {
+        return getSourceFileByPath(containerId, tag, FileType.DOCKSTORE_CWL, path, user);
     }
 
     @GET
@@ -765,10 +782,11 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @UnitOfWork
     @Path("/{containerId}/wdl/{relative-path}")
     @ApiOperation(value = "Get the corresponding Dockstore.wdl file on Github.", tags = {
-            "containers" }, notes = "Does not need authentication", response = SourceFile.class)
-    public SourceFile secondaryWdlPath(@ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId,
-            @QueryParam("tag") String tag, @PathParam("relative-path") String path) {
-        return getSourceFileByPath(containerId, tag, FileType.DOCKSTORE_WDL, path);
+        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+    public SourceFile secondaryWdlPath(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
+        @PathParam("relative-path") String path) {
+        return getSourceFileByPath(containerId, tag, FileType.DOCKSTORE_WDL, path, user);
     }
 
     @GET
@@ -776,10 +794,10 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @UnitOfWork
     @Path("/{containerId}/secondaryCwl")
     @ApiOperation(value = "Get a list of secondary CWL files from Git.", tags = {
-            "containers" }, notes = "Does not need authentication", response = SourceFile.class, responseContainer = "List")
-    public List<SourceFile> secondaryCwl(@ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId,
-            @QueryParam("tag") String tag) {
-        return getAllSecondaryFiles(containerId, tag, FileType.DOCKSTORE_CWL);
+        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List")
+    public List<SourceFile> secondaryCwl(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag) {
+        return getAllSecondaryFiles(containerId, tag, FileType.DOCKSTORE_CWL, user);
     }
 
     @GET
@@ -787,10 +805,10 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @UnitOfWork
     @Path("/{containerId}/secondaryWdl")
     @ApiOperation(value = "Get a list of secondary WDL files from Git.", tags = {
-            "containers" }, notes = "Does not need authentication", response = SourceFile.class, responseContainer = "List")
-    public List<SourceFile> secondaryWdl(@ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId,
-            @QueryParam("tag") String tag) {
-        return getAllSecondaryFiles(containerId, tag, FileType.DOCKSTORE_WDL);
+        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List")
+    public List<SourceFile> secondaryWdl(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag) {
+        return getAllSecondaryFiles(containerId, tag, FileType.DOCKSTORE_WDL, user);
     }
 
     @GET
@@ -798,11 +816,11 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @UnitOfWork
     @Path("/{containerId}/testParameterFiles")
     @ApiOperation(value = "Get the corresponding wdl test parameter files.", tags = {
-            "containers" }, notes = "Does not need authentication", response = SourceFile.class, responseContainer = "List")
-    public List<SourceFile> getTestParameterFiles(@ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId,
-            @QueryParam("tag") String tag,
-            @ApiParam(value = "Descriptor Type", required = true, allowableValues = "CWL, WDL, NFL") @QueryParam("descriptorType") String descriptorType) {
-        return getAllSourceFiles(containerId, tag, Workflow.getTestParameterType(descriptorType));
+        "containers" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List")
+    public List<SourceFile> getTestParameterFiles(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
+        @ApiParam(value = "Descriptor Type", required = true, allowableValues = "CWL, WDL, NFL") @QueryParam("descriptorType") String descriptorType) {
+        return getAllSourceFiles(containerId, tag, Workflow.getTestParameterType(descriptorType), user);
     }
 
     /*
@@ -821,13 +839,14 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @Timed
     @UnitOfWork
     @Path("/{containerId}/testParameterFiles")
-    @ApiOperation(value = "Add test parameter files for a given tag.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = SourceFile.class, responseContainer = "Set")
+    @ApiOperation(value = "Add test parameter files for a given tag.", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = SourceFile.class, responseContainer = "Set")
     public Set<SourceFile> addTestParameterFiles(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Tool to modify.", required = true) @PathParam("containerId") Long containerId,
-            @ApiParam(value = "List of paths.", required = true) @QueryParam("testParameterPaths") List<String> testParameterPaths,
-            @ApiParam(value = "This is here to appease Swagger. It requires PUT methods to have a body, even if it is empty. Please leave it empty.") String emptyBody,
-            @QueryParam("tagName") String tagName,
-            @ApiParam(value = "Descriptor Type", required = true, allowableValues = "CWL, WDL") @QueryParam("descriptorType") String descriptorType) {
+        @ApiParam(value = "Tool to modify.", required = true) @PathParam("containerId") Long containerId,
+        @ApiParam(value = "List of paths.", required = true) @QueryParam("testParameterPaths") List<String> testParameterPaths,
+        @ApiParam(value = "This is here to appease Swagger. It requires PUT methods to have a body, even if it is empty. Please leave it empty.") String emptyBody,
+        @QueryParam("tagName") String tagName,
+        @ApiParam(value = "Descriptor Type", required = true, allowableValues = "CWL, WDL") @QueryParam("descriptorType") String descriptorType) {
         Tool tool = toolDAO.findById(containerId);
         checkEntry(tool);
         checkNotHosted(tool);
@@ -836,15 +855,15 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
         if (!firstTag.isPresent()) {
             LOG.info("The tag \'" + tagName + "\' for tool \'" + tool.getToolPath() + "\' does not exist.");
             throw new CustomWebApplicationException("The tag \'" + tagName + "\' for tool \'" + tool.getToolPath() + "\' does not exist.",
-                    HttpStatus.SC_BAD_REQUEST);
+                HttpStatus.SC_BAD_REQUEST);
         }
 
         Tag tag = firstTag.get();
         Set<SourceFile> sourceFiles = tag.getSourceFiles();
 
         // Add new test parameter files
-        FileType fileType = (descriptorType.toUpperCase().equals(DescriptorType.CWL.toString())) ? FileType.CWL_TEST_JSON
-                : FileType.WDL_TEST_JSON;
+        FileType fileType =
+            (descriptorType.toUpperCase().equals(DescriptorType.CWL.toString())) ? FileType.CWL_TEST_JSON : FileType.WDL_TEST_JSON;
         createTestParameters(testParameterPaths, tag, sourceFiles, fileType, fileDAO);
         elasticManager.handleIndexUpdate(tool, ElasticMode.UPDATE);
         return tag.getSourceFiles();
@@ -854,12 +873,13 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @Timed
     @UnitOfWork
     @Path("/{containerId}/testParameterFiles")
-    @ApiOperation(value = "Delete test parameter files for a given tag.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = SourceFile.class, responseContainer = "Set")
+    @ApiOperation(value = "Delete test parameter files for a given tag.", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = SourceFile.class, responseContainer = "Set")
     public Set<SourceFile> deleteTestParameterFiles(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Tool to modify.", required = true) @PathParam("containerId") Long containerId,
-            @ApiParam(value = "List of paths.", required = true) @QueryParam("testParameterPaths") List<String> testParameterPaths,
-            @QueryParam("tagName") String tagName,
-            @ApiParam(value = "Descriptor Type", required = true, allowableValues = "CWL, WDL") @QueryParam("descriptorType") String descriptorType) {
+        @ApiParam(value = "Tool to modify.", required = true) @PathParam("containerId") Long containerId,
+        @ApiParam(value = "List of paths.", required = true) @QueryParam("testParameterPaths") List<String> testParameterPaths,
+        @QueryParam("tagName") String tagName,
+        @ApiParam(value = "Descriptor Type", required = true, allowableValues = "CWL, WDL") @QueryParam("descriptorType") String descriptorType) {
         Tool tool = toolDAO.findById(containerId);
         checkEntry(tool);
         checkNotHosted(tool);
@@ -869,15 +889,15 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
         if (!firstTag.isPresent()) {
             LOG.info("The tag \'" + tagName + "\' for tool \'" + tool.getToolPath() + "\' does not exist.");
             throw new CustomWebApplicationException("The tag \'" + tagName + "\' for tool \'" + tool.getToolPath() + "\' does not exist.",
-                    HttpStatus.SC_BAD_REQUEST);
+                HttpStatus.SC_BAD_REQUEST);
         }
 
         Tag tag = firstTag.get();
         Set<SourceFile> sourceFiles = tag.getSourceFiles();
 
         // Remove test parameter files
-        FileType fileType = (descriptorType.toUpperCase().equals(DescriptorType.CWL.toString())) ? FileType.CWL_TEST_JSON
-                : FileType.WDL_TEST_JSON;
+        FileType fileType =
+            (descriptorType.toUpperCase().equals(DescriptorType.CWL.toString())) ? FileType.CWL_TEST_JSON : FileType.WDL_TEST_JSON;
         for (String path : testParameterPaths) {
             sourceFiles.removeIf((SourceFile v) -> v.getPath().equals(path) && v.getType() == fileType);
         }
@@ -891,8 +911,8 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @Path("/{containerId}/star")
     @ApiOperation(value = "Stars a tool.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public void starEntry(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Tool to star.", required = true) @PathParam("containerId") Long containerId,
-            @ApiParam(value = "StarRequest to star a repo for a user", required = true) StarRequest request) {
+        @ApiParam(value = "Tool to star.", required = true) @PathParam("containerId") Long containerId,
+        @ApiParam(value = "StarRequest to star a repo for a user", required = true) StarRequest request) {
         Tool tool = toolDAO.findById(containerId);
         starEntryHelper(tool, user, "tool", tool.getToolPath());
         elasticManager.handleIndexUpdate(tool, ElasticMode.UPDATE);
@@ -904,7 +924,7 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @Path("/{containerId}/unstar")
     @ApiOperation(value = "Unstars a tool.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public void unstarEntry(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Tool to unstar.", required = true) @PathParam("containerId") Long containerId) {
+        @ApiParam(value = "Tool to unstar.", required = true) @PathParam("containerId") Long containerId) {
         Tool tool = toolDAO.findById(containerId);
         unstarEntryHelper(tool, user, "tool", tool.getToolPath());
         elasticManager.handleIndexUpdate(tool, ElasticMode.UPDATE);
@@ -916,7 +936,7 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
     @UnitOfWork
     @ApiOperation(value = "Returns list of users who starred the given tool", response = User.class, responseContainer = "List")
     public Set<User> getStarredUsers(
-            @ApiParam(value = "Tool to grab starred users for.", required = true) @PathParam("containerId") Long containerId) {
+        @ApiParam(value = "Tool to grab starred users for.", required = true) @PathParam("containerId") Long containerId) {
         Tool tool = toolDAO.findById(containerId);
         checkEntry(tool);
         return tool.getStarredUsers();
@@ -1025,7 +1045,7 @@ public class DockerRepoResource implements AuthenticatedResourceInterface, Entry
                 checkUser(user.get(), tool);
             } else {
                 throw new CustomWebApplicationException("Forbidden: you do not have the credentials required to access this entry.",
-                        HttpStatus.SC_FORBIDDEN);
+                    HttpStatus.SC_FORBIDDEN);
             }
         }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -77,6 +77,7 @@ public class EntryResource implements AuthenticatedResourceInterface {
         @ApiParam(value = "This is here to appease Swagger. It requires PUT methods to have a body, even if it is empty. Please leave it empty.") String emptyBody) {
         Entry<? extends Entry, ? extends Version> c = toolDAO.getGenericEntryById(id);
         checkEntry(c);
+        checkUserCanUpdate(user, c);
         // compute differences
         Set<String> oldAliases = c.getAliases().keySet();
         Set<String> newAliases = Sets.newHashSet(Arrays.stream(aliases.split(",")).map(String::trim).toArray(String[]::new));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/SwaggerTester.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/SwaggerTester.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class SwaggerTester {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AbstractHostedEntryResource.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SwaggerTester.class);
 
 
     private SwaggerTester() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -37,6 +37,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import com.codahale.metrics.annotation.Timed;
+import com.google.common.annotations.Beta;
 import com.google.common.collect.Lists;
 import io.dockstore.common.Registry;
 import io.dockstore.webservice.CustomWebApplicationException;
@@ -77,6 +78,7 @@ import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
 @Produces(MediaType.APPLICATION_JSON)
 public class UserResource implements AuthenticatedResourceInterface {
     private static final Logger LOG = LoggerFactory.getLogger(UserResource.class);
+    private static final String PERMISSIONS_NOTE = "This is not tied into PermissionsInterface but could be";
     private final ElasticManager elasticManager;
     private final UserDAO userDAO;
     private final GroupDAO groupDAO;
@@ -114,6 +116,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     @ApiOperation(value = "Get user", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
     public User listUser(@ApiParam(hidden = true) @Auth User authUser,
             @ApiParam("Username of user to return") @PathParam("username") String username) {
+        @SuppressWarnings("deprecation")
         User user = userDAO.findByUsername(username);
         checkUser(authUser, user.getId());
         return user;
@@ -197,6 +200,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     @ApiOperation(value = "Check if user with some username exists", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Boolean.class)
     public boolean checkUserExists(@ApiParam(hidden = true) @Auth User user,
                                    @ApiParam("User name to check") @PathParam("username") String username) {
+        @SuppressWarnings("deprecation")
         User foundUser = userDAO.findByUsername(username);
         return foundUser != null;
     }
@@ -209,7 +213,6 @@ public class UserResource implements AuthenticatedResourceInterface {
     public List<Token> getUserTokens(@ApiParam(hidden = true) @Auth User user,
             @ApiParam("User to return") @PathParam("userId") long userId) {
         checkUser(user, userId);
-
         return tokenDAO.findByUserId(userId);
     }
 
@@ -221,7 +224,6 @@ public class UserResource implements AuthenticatedResourceInterface {
     public List<Token> getGithubUserTokens(@ApiParam(hidden = true) @Auth User user,
             @ApiParam("User to return") @PathParam("userId") long userId) {
         checkUser(user, userId);
-
         return tokenDAO.findGithubByUserId(userId);
     }
 
@@ -233,7 +235,6 @@ public class UserResource implements AuthenticatedResourceInterface {
     public List<Token> getGitlabUserTokens(@ApiParam(hidden = true) @Auth User user,
             @ApiParam("User to return") @PathParam("userId") long userId) {
         checkUser(user, userId);
-
         return tokenDAO.findGitlabByUserId(userId);
     }
 
@@ -245,7 +246,6 @@ public class UserResource implements AuthenticatedResourceInterface {
     public List<Token> getQuayUserTokens(@ApiParam(hidden = true) @Auth User user,
             @ApiParam("User to return") @PathParam("userId") long userId) {
         checkUser(user, userId);
-
         return tokenDAO.findQuayByUserId(userId);
     }
 
@@ -257,15 +257,16 @@ public class UserResource implements AuthenticatedResourceInterface {
     public List<Token> getDockstoreUserTokens(@ApiParam(hidden = true) @Auth User user,
             @ApiParam("User to return") @PathParam("userId") long userId) {
         checkUser(user, userId);
-
         return tokenDAO.findQuayByUserId(userId);
     }
 
     @GET
+    @Beta
     @Timed
     @UnitOfWork
     @Path("/{userId}/groups")
-    @ApiOperation(value = "Get groups that the user belongs to", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Group.class, responseContainer = "List")
+    @ApiOperation(value = "Get groups that the user belongs to", notes = PERMISSIONS_NOTE, authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Group.class, responseContainer = "List")
     public List<Group> getGroupsFromUser(@ApiParam(hidden = true) @Auth User authUser, @ApiParam("User") @PathParam("userId") long userId) {
         checkUser(authUser, userId);
 
@@ -281,7 +282,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     @Timed
     @UnitOfWork
     @Path("/groups/{groupId}/users")
-    @ApiOperation(value = "Get users that belongs to a group", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class, responseContainer = "List")
+    @ApiOperation(value = "Get users that belongs to a group", notes = PERMISSIONS_NOTE, authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class, responseContainer = "List")
     public List<User> getUsersFromGroup(@ApiParam(hidden = true) @Auth User user, @ApiParam("Group") @PathParam("groupId") long groupId) {
         Group group = groupDAO.findById(groupId);
         if (group == null) {
@@ -295,7 +296,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     @Timed
     @UnitOfWork
     @Path("/groups")
-    @ApiOperation(value = "List all groups", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Group.class, responseContainer = "List")
+    @ApiOperation(value = "List all groups", notes = PERMISSIONS_NOTE, authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Group.class, responseContainer = "List")
     public List<Group> allGroups(@ApiParam(hidden = true) @Auth User user) {
         return groupDAO.findAll();
     }
@@ -304,7 +305,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     @Timed
     @UnitOfWork
     @Path("/groups/{groupId}")
-    @ApiOperation(value = "List a group", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Group.class)
+    @ApiOperation(value = "List a group", notes = PERMISSIONS_NOTE, authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Group.class)
     public Group getGroup(@ApiParam(hidden = true) @Auth User user, @ApiParam("Group") @PathParam("groupId") long groupId) {
         return groupDAO.findById(groupId);
     }
@@ -313,7 +314,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     @Timed
     @UnitOfWork
     @Path("/{userId}/groups")
-    @ApiOperation(value = "Add a group to a user", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
+    @ApiOperation(value = "Add a group to a user", notes = PERMISSIONS_NOTE, authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
     public User addGroupToUser(@ApiParam(hidden = true) @Auth User authUser, @ApiParam("User ID of user") @PathParam("userId") long userId,
             @ApiParam(value = "PublishRequest to refresh the list of repos for a user", required = true) Group groupParam) {
         checkUser(authUser, userId);
@@ -337,7 +338,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     @Timed
     @UnitOfWork
     @Path("/{userId}/groups/{groupId}")
-    @ApiOperation(value = "Remove a user from a group", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
+    @ApiOperation(value = "Remove a user from a group", notes = PERMISSIONS_NOTE, authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
     @ApiResponses(@ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = "Invalid user or group value"))
     public User removeUserFromGroup(@ApiParam(hidden = true) @Auth User authUser,
             @ApiParam("User ID of user") @PathParam("userId") long userId,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -279,6 +279,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     }
 
     @GET
+    @Beta
     @Timed
     @UnitOfWork
     @Path("/groups/{groupId}/users")
@@ -293,6 +294,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     }
 
     @GET
+    @Beta
     @Timed
     @UnitOfWork
     @Path("/groups")
@@ -302,6 +304,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     }
 
     @GET
+    @Beta
     @Timed
     @UnitOfWork
     @Path("/groups/{groupId}")
@@ -311,6 +314,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     }
 
     @PUT
+    @Beta
     @Timed
     @UnitOfWork
     @Path("/{userId}/groups")
@@ -335,6 +339,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     }
 
     @DELETE
+    @Beta
     @Timed
     @UnitOfWork
     @Path("/{userId}/groups/{groupId}")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -857,7 +857,7 @@ public class WorkflowResource
     @UnitOfWork
     @Path("/path/workflow/{repository}/actions")
     @ApiOperation(value = "Gets all actions a user can perform on a workflow", authorizations = {
-        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "", response = Role.Action.class, responseContainer = "List")
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Role.Action.class, responseContainer = "List")
     public List<Role.Action> getWorkflowActions(@ApiParam(hidden = true) @Auth User user,
         @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
         Workflow workflow = workflowDAO.findByPath(path, false);
@@ -1008,7 +1008,8 @@ public class WorkflowResource
     @UnitOfWork
     @Path("/{workflowId}/cwl")
     @ApiOperation(value = "Get the corresponding Dockstore.cwl file on Github.", tags = {
-        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public SourceFile cwl(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag) {
         return getSourceFile(workflowId, tag, FileType.DOCKSTORE_CWL, user);
@@ -1019,7 +1020,8 @@ public class WorkflowResource
     @UnitOfWork
     @Path("/{workflowId}/wdl")
     @ApiOperation(value = "Get the corresponding Dockstore.wdl file on Github.", tags = {
-        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public SourceFile wdl(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag) {
         return getSourceFile(workflowId, tag, FileType.DOCKSTORE_WDL, user);
@@ -1030,7 +1032,8 @@ public class WorkflowResource
     @UnitOfWork
     @Path("/{workflowId}/nextflow")
     @ApiOperation(value = "Get the corresponding nextflow.config file on Github.", tags = {
-        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public SourceFile nextflow(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag) {
         return getSourceFile(workflowId, tag, FileType.NEXTFLOW_CONFIG, user);
@@ -1041,7 +1044,8 @@ public class WorkflowResource
     @UnitOfWork
     @Path("/{workflowId}/cwl/{relative-path}")
     @ApiOperation(value = "Get the corresponding Dockstore.cwl file on Github.", tags = {
-        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public SourceFile secondaryCwlPath(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag,
         @PathParam("relative-path") String path) {
@@ -1053,7 +1057,8 @@ public class WorkflowResource
     @UnitOfWork
     @Path("/{workflowId}/wdl/{relative-path}")
     @ApiOperation(value = "Get the corresponding Dockstore.wdl file on Github.", tags = {
-        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public SourceFile secondaryWdlPath(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag,
         @PathParam("relative-path") String path) {
@@ -1065,7 +1070,8 @@ public class WorkflowResource
     @UnitOfWork
     @Path("/{workflowId}/nextflow/{relative-path}")
     @ApiOperation(value = "Get the corresponding nextflow documents on Github.", tags = {
-        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public SourceFile secondaryNextFlowPath(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag,
         @PathParam("relative-path") String path) {
@@ -1078,7 +1084,8 @@ public class WorkflowResource
     @UnitOfWork
     @Path("/{workflowId}/secondaryCwl")
     @ApiOperation(value = "Get the corresponding cwl documents on Github.", tags = {
-        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List")
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public List<SourceFile> secondaryCwl(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag) {
         return getAllSecondaryFiles(workflowId, tag, FileType.DOCKSTORE_CWL, user);
@@ -1089,7 +1096,8 @@ public class WorkflowResource
     @UnitOfWork
     @Path("/{workflowId}/secondaryWdl")
     @ApiOperation(value = "Get the corresponding wdl documents on Github.", tags = {
-        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List")
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public List<SourceFile> secondaryWdl(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag) {
         return getAllSecondaryFiles(workflowId, tag, FileType.DOCKSTORE_WDL, user);
@@ -1100,7 +1108,8 @@ public class WorkflowResource
     @UnitOfWork
     @Path("/{workflowId}/secondaryNextflow")
     @ApiOperation(value = "Get the corresponding Nextflow documents on Github.", tags = {
-        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List")
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public List<SourceFile> secondaryNextflow(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag) {
         return getAllSecondaryFiles(workflowId, tag, FileType.NEXTFLOW, user);
@@ -1111,7 +1120,8 @@ public class WorkflowResource
     @UnitOfWork
     @Path("/{workflowId}/testParameterFiles")
     @ApiOperation(value = "Get the corresponding test parameter files.", tags = {
-        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List")
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public List<SourceFile> getTestParameterFiles(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("version") String version) {
 
@@ -1694,6 +1704,5 @@ public class WorkflowResource
         return Response.ok().entity((StreamingOutput)output -> writeStreamAsZip(sourceFiles, output))
             .header("Content-Disposition", "attachment; filename=\"" + fileName + "\"").build();
     }
-
 
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -115,16 +115,21 @@ import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
 
 /**
  * TODO: remember to document new security concerns for hosted vs other workflows
+ *
  * @author dyuen
  */
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Path("/workflows")
 @Api("workflows")
 @Produces(MediaType.APPLICATION_JSON)
-public class WorkflowResource implements AuthenticatedResourceInterface, EntryVersionHelper<Workflow, WorkflowVersion, WorkflowDAO>, StarrableResourceInterface, SourceControlResourceInterface {
+public class WorkflowResource
+    implements AuthenticatedResourceInterface, EntryVersionHelper<Workflow, WorkflowVersion, WorkflowDAO>, StarrableResourceInterface,
+    SourceControlResourceInterface {
     private static final String CWL_CHECKER = "_cwl_checker";
     private static final String WDL_CHECKER = "_wdl_checker";
     private static final Logger LOG = LoggerFactory.getLogger(WorkflowResource.class);
     private static final String PAGINATION_LIMIT = "100";
+    private static final String OPTIONAL_AUTH_MESSAGE = "Does not require authentication for published workflows, authentication can be provided for restricted workflows";
     private final ElasticManager elasticManager;
     private final UserDAO userDAO;
     private final TokenDAO tokenDAO;
@@ -140,8 +145,8 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     private final String bitbucketClientSecret;
     private final PermissionsInterface permissionsInterface;
 
-    public WorkflowResource(HttpClient client, SessionFactory sessionFactory, String bitbucketClientID,
-        String bitbucketClientSecret, PermissionsInterface permissionsInterface) {
+    public WorkflowResource(HttpClient client, SessionFactory sessionFactory, String bitbucketClientID, String bitbucketClientSecret,
+        PermissionsInterface permissionsInterface) {
         this.userDAO = new UserDAO(sessionFactory);
         this.tokenDAO = new TokenDAO(sessionFactory);
         this.workflowVersionDAO = new WorkflowVersionDAO(sessionFactory);
@@ -162,6 +167,7 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
 
     /**
      * TODO: this should not be a GET either
+     *
      * @param user
      * @param workflowId
      * @return
@@ -170,8 +176,10 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Path("/{workflowId}/restub")
     @Timed
     @UnitOfWork
-    @ApiOperation(value = "Restub a workflow", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Restubs a full, unpublished workflow.", response = Workflow.class)
-    public Workflow restub(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "workflow ID", required = true) @PathParam("workflowId") Long workflowId) {
+    @ApiOperation(value = "Restub a workflow", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Restubs a full, unpublished workflow.", response = Workflow.class)
+    public Workflow restub(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "workflow ID", required = true) @PathParam("workflowId") Long workflowId) {
         Workflow workflow = workflowDAO.findById(workflowId);
         // Check that workflow is valid to restub
         if (workflow.getIsPublished()) {
@@ -192,7 +200,6 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
         // Do we maintain the checker workflow association? For now we won't
         workflow.setCheckerWorkflow(null);
 
-
         elasticManager.handleIndexUpdate(workflow, ElasticMode.DELETE);
         return workflow;
 
@@ -201,9 +208,9 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     /**
      * For each valid token for a git hosting service, refresh all workflows
      *
-     * @param user         a user to refresh workflows for
-     * @param organization limit the refresh to particular organizations if given
-     * @param alreadyProcessed     skip particular workflows if already refreshed, previously used for debugging
+     * @param user             a user to refresh workflows for
+     * @param organization     limit the refresh to particular organizations if given
+     * @param alreadyProcessed skip particular workflows if already refreshed, previously used for debugging
      */
     void refreshStubWorkflowsForUser(User user, String organization, Set<Long> alreadyProcessed) {
 
@@ -251,13 +258,15 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
      * @param user                    the user that made the request to refresh
      * @param organization            if specified, only refresh if workflow belongs to the organization
      */
-    private void refreshHelper(final SourceCodeRepoInterface sourceCodeRepoInterface, User user, String organization, Set<Long> alreadyProcessed) {
+    private void refreshHelper(final SourceCodeRepoInterface sourceCodeRepoInterface, User user, String organization,
+        Set<Long> alreadyProcessed) {
         /* helpful code for testing, this was used to refresh a users existing workflows
            with a fixed github token for all users
          */
         boolean statsCollection = false;
         if (statsCollection) {
-            List<Workflow> workflows = userDAO.findById(user.getId()).getEntries().stream().filter(entry -> entry instanceof Workflow).map(obj -> (Workflow)obj).collect(Collectors.toList());
+            List<Workflow> workflows = userDAO.findById(user.getId()).getEntries().stream().filter(entry -> entry instanceof Workflow)
+                .map(obj -> (Workflow)obj).collect(Collectors.toList());
             Map<String, String> workflowGitUrl2Name = new HashMap<>();
             for (Workflow workflow : workflows) {
                 workflowGitUrl2Name.put(workflow.getGitUrl(), workflow.getOrganization() + "/" + workflow.getRepository());
@@ -330,8 +339,10 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Path("/{workflowId}/refresh")
     @Timed
     @UnitOfWork
-    @ApiOperation(value = "Refresh one particular workflow. Always do a full refresh when targeted", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class)
-    public Workflow refresh(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "workflow ID", required = true) @PathParam("workflowId") Long workflowId) {
+    @ApiOperation(value = "Refresh one particular workflow. Always do a full refresh when targeted", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class)
+    public Workflow refresh(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "workflow ID", required = true) @PathParam("workflowId") Long workflowId) {
         Workflow workflow = workflowDAO.findById(workflowId);
         checkEntry(workflow);
         checkUser(user, workflow);
@@ -356,7 +367,8 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
             }
         }
 
-        final Workflow newWorkflow = sourceCodeRepo.getWorkflow(workflow.getOrganization() + '/' + workflow.getRepository(), Optional.of(workflow));
+        final Workflow newWorkflow = sourceCodeRepo
+            .getWorkflow(workflow.getOrganization() + '/' + workflow.getRepository(), Optional.of(workflow));
         workflow.getUsers().add(user);
         updateDBWorkflowWithSourceControlWorkflow(workflow, newWorkflow);
         FileFormatHelper.updateFileFormats(newWorkflow.getVersions(), fileFormatDAO);
@@ -433,25 +445,29 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/{workflowId}")
-    @ApiOperation(value = "Get a registered workflow", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class, notes = "This is one of the few endpoints that returns the user object with populated properties (minus the userProfiles property)")
-    public Workflow getWorkflow(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "workflow ID", required = true) @PathParam("workflowId") Long workflowId) {
+    @ApiOperation(value = "Get a registered workflow", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class, notes = "This is one of the few endpoints that returns the user object with populated properties (minus the userProfiles property)")
+    public Workflow getWorkflow(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "workflow ID", required = true) @PathParam("workflowId") Long workflowId) {
         Workflow workflow = workflowDAO.findById(workflowId);
         checkEntry(workflow);
-        checkCanReadWorkflow(user, workflow);
+        checkCanRead(user, workflow);
 
         // This somehow forces users to get loaded
         Hibernate.initialize(workflow.getUsers());
         return workflow;
     }
 
-
     @PUT
     @Timed
     @UnitOfWork
     @Path("/{workflowId}/labels")
-    @ApiOperation(value = "Update the labels linked to a workflow.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Labels are alphanumerical (case-insensitive and may contain internal hyphens), given in a comma-delimited list.", response = Workflow.class)
-    public Workflow updateLabels(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "Tool to modify.", required = true) @PathParam("workflowId") Long workflowId,
-        @ApiParam(value = "Comma-delimited list of labels.", required = true) @QueryParam("labels") String labelStrings, @ApiParam(value = "This is here to appease Swagger. It requires PUT methods to have a body, even if it is empty. Please leave it empty.") String emptyBody) {
+    @ApiOperation(value = "Update the labels linked to a workflow.", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Labels are alphanumerical (case-insensitive and may contain internal hyphens), given in a comma-delimited list.", response = Workflow.class)
+    public Workflow updateLabels(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "Tool to modify.", required = true) @PathParam("workflowId") Long workflowId,
+        @ApiParam(value = "Comma-delimited list of labels.", required = true) @QueryParam("labels") String labelStrings,
+        @ApiParam(value = "This is here to appease Swagger. It requires PUT methods to have a body, even if it is empty. Please leave it empty.") String emptyBody) {
         return this.updateLabels(user, workflowId, labelStrings, labelDAO, elasticManager);
     }
 
@@ -459,8 +475,10 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/{workflowId}")
-    @ApiOperation(value = "Update the workflow with the given workflow.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class)
-    public Workflow updateWorkflow(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "Workflow to modify.", required = true) @PathParam("workflowId") Long workflowId,
+    @ApiOperation(value = "Update the workflow with the given workflow.", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class)
+    public Workflow updateWorkflow(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "Workflow to modify.", required = true) @PathParam("workflowId") Long workflowId,
         @ApiParam(value = "Workflow with updated information", required = true) Workflow workflow) {
         Workflow wf = workflowDAO.findById(workflowId);
         checkEntry(wf);
@@ -471,7 +489,8 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
 
         if (duplicate != null && duplicate.getId() != workflowId) {
             LOG.info(user.getUsername() + ": " + "duplicate workflow found: {}" + workflow.getWorkflowPath());
-            throw new CustomWebApplicationException("Workflow " + workflow.getWorkflowPath() + " already exists.", HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException("Workflow " + workflow.getWorkflowPath() + " already exists.",
+                HttpStatus.SC_BAD_REQUEST);
         }
 
         updateInfo(wf, workflow);
@@ -486,16 +505,19 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/{workflowId}/defaultVersion")
-    @ApiOperation(value = "Update the default version of the given workflow.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class, nickname = "updateWorkflowDefaultVersion")
-    public Workflow updateDefaultVersion(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "Workflow to modify.", required = true) @PathParam("workflowId") Long workflowId,
-                                   @ApiParam(value = "Version name to set as default", required = true) String version) {
+    @ApiOperation(value = "Update the default version of the given workflow.", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class, nickname = "updateWorkflowDefaultVersion")
+    public Workflow updateDefaultVersion(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "Workflow to modify.", required = true) @PathParam("workflowId") Long workflowId,
+        @ApiParam(value = "Version name to set as default", required = true) String version) {
         return (Workflow)updateDefaultVersionHelper(version, workflowId, user, elasticManager);
     }
 
     // Used to update workflow manually (not refresh)
     private void updateInfo(Workflow oldWorkflow, Workflow newWorkflow) {
         // If workflow is FULL and descriptor type is being changed throw an error
-        if (Objects.equals(oldWorkflow.getMode(), WorkflowMode.FULL) && !Objects.equals(oldWorkflow.getDescriptorType(), newWorkflow.getDescriptorType())) {
+        if (Objects.equals(oldWorkflow.getMode(), WorkflowMode.FULL) && !Objects
+            .equals(oldWorkflow.getDescriptorType(), newWorkflow.getDescriptorType())) {
             throw new CustomWebApplicationException("You cannot change the descriptor type of a FULL workflow.", HttpStatus.SC_BAD_REQUEST);
         }
 
@@ -518,9 +540,12 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @UnitOfWork
     @Path("/{workflowId}/verify/{workflowVersionId}")
     @RolesAllowed("admin")
-    @ApiOperation(value = "Verify or unverify a workflow. ADMIN ONLY", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = WorkflowVersion.class, responseContainer = "List")
-    public Set<WorkflowVersion> verifyWorkflowVersion(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "Workflow to modify.", required = true) @PathParam("workflowId") Long workflowId,
-        @ApiParam(value = "workflowVersionId", required = true) @PathParam("workflowVersionId") Long workflowVersionId, @ApiParam(value = "Object containing verification information.", required = true) VerifyRequest verifyRequest) {
+    @ApiOperation(value = "Verify or unverify a workflow. ADMIN ONLY", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = WorkflowVersion.class, responseContainer = "List")
+    public Set<WorkflowVersion> verifyWorkflowVersion(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "Workflow to modify.", required = true) @PathParam("workflowId") Long workflowId,
+        @ApiParam(value = "workflowVersionId", required = true) @PathParam("workflowVersionId") Long workflowVersionId,
+        @ApiParam(value = "Object containing verification information.", required = true) VerifyRequest verifyRequest) {
         Workflow workflow = workflowDAO.findById(workflowId);
         checkEntry(workflow);
         // Note: if you set someone as an admin, they are not actually admin right away. Users must wait until after the
@@ -554,7 +579,8 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @UnitOfWork
     @Beta
     @Path("/{workflowId}/requestDOI/{workflowVersionId}")
-    @ApiOperation(value = "Request a DOI for this version of a workflow", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = WorkflowVersion.class, responseContainer = "List")
+    @ApiOperation(value = "Request a DOI for this version of a workflow", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = WorkflowVersion.class, responseContainer = "List")
     public Set<WorkflowVersion> requestDOIForWorkflowVersion(@ApiParam(hidden = true) @Auth User user,
         @ApiParam(value = "Workflow to modify.", required = true) @PathParam("workflowId") Long workflowId,
         @ApiParam(value = "workflowVersionId", required = true) @PathParam("workflowVersionId") Long workflowVersionId) {
@@ -586,8 +612,10 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/{workflowId}/resetVersionPaths")
-    @ApiOperation(value = "Change the workflow paths", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Workflow version correspond to each row of the versions table listing all information for a workflow", response = Workflow.class)
-    public Workflow updateWorkflowPath(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "Workflow to modify.", required = true) @PathParam("workflowId") Long workflowId,
+    @ApiOperation(value = "Change the workflow paths", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Workflow version correspond to each row of the versions table listing all information for a workflow", response = Workflow.class)
+    public Workflow updateWorkflowPath(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "Workflow to modify.", required = true) @PathParam("workflowId") Long workflowId,
         @ApiParam(value = "Workflow with updated information", required = true) Workflow workflow) {
 
         Workflow wf = workflowDAO.findById(workflowId);
@@ -612,8 +640,10 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/{workflowId}/users")
-    @ApiOperation(value = "Get users of a workflow", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class, responseContainer = "List")
-    public List<User> getUsers(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "workflow ID", required = true) @PathParam("workflowId") Long workflowId) {
+    @ApiOperation(value = "Get users of a workflow", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class, responseContainer = "List")
+    public List<User> getUsers(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "workflow ID", required = true) @PathParam("workflowId") Long workflowId) {
         Workflow c = workflowDAO.findById(workflowId);
         checkEntry(c);
 
@@ -638,7 +668,8 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @UnitOfWork
     @Path("/organization/{organization}/published")
     @ApiOperation(value = "List all published workflows belonging to the specified namespace", notes = "NO authentication", response = Workflow.class, responseContainer = "List")
-    public List<Workflow> getPublishedWorkflowsByOrganization(@ApiParam(value = "organization", required = true) @PathParam("organization") String organization) {
+    public List<Workflow> getPublishedWorkflowsByOrganization(
+        @ApiParam(value = "organization", required = true) @PathParam("organization") String organization) {
         List<Workflow> workflows = workflowDAO.findPublishedByOrganization(organization);
         filterContainersForHiddenTags(workflows);
         return workflows;
@@ -648,8 +679,10 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/{workflowId}/publish")
-    @ApiOperation(value = "Publish or unpublish a workflow", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Publish/publish a workflow (public or private).", response = Workflow.class)
-    public Workflow publish(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "Workflow id to publish/unpublish", required = true) @PathParam("workflowId") Long workflowId,
+    @ApiOperation(value = "Publish or unpublish a workflow", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Publish/publish a workflow (public or private).", response = Workflow.class)
+    public Workflow publish(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "Workflow id to publish/unpublish", required = true) @PathParam("workflowId") Long workflowId,
         @ApiParam(value = "PublishRequest to refresh the list of repos for a user", required = true) PublishRequest request) {
         Workflow c = workflowDAO.findById(workflowId);
         checkEntry(c);
@@ -701,7 +734,8 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
         "workflows" }, notes = "NO authentication", response = Workflow.class, responseContainer = "List")
     public List<Workflow> allPublishedWorkflows(
         @ApiParam(value = "Start index of paging. Pagination results can be based on numbers or other values chosen by the registry implementor (for example, SHA values). If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.") @QueryParam("offset") String offset,
-        @ApiParam(value = "Amount of records to return in a given page, limited to " + PAGINATION_LIMIT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
+        @ApiParam(value = "Amount of records to return in a given page, limited to "
+            + PAGINATION_LIMIT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
         @ApiParam(value = "Filter, this is a search string that filters the results.") @DefaultValue("") @QueryParam("filter") String filter,
         @ApiParam(value = "Sort column") @DefaultValue("stars") @QueryParam("sortCol") String sortCol,
         @ApiParam(value = "Sort order", allowableValues = "asc,desc") @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
@@ -742,26 +776,30 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/path/workflow/{repository}")
-    @ApiOperation(value = "Get a workflow by path", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Lists info of workflow. Enter full path.", response = Workflow.class)
-    public Workflow getWorkflowByPath(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
+    @ApiOperation(value = "Get a workflow by path", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Lists info of workflow. Enter full path.", response = Workflow.class)
+    public Workflow getWorkflowByPath(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
 
         Workflow workflow = workflowDAO.findByPath(path, false);
         checkEntry(workflow);
-        checkCanReadWorkflow(user, workflow);
+        checkCanRead(user, workflow);
         return workflow;
     }
 
     /**
      * Checks if <code>user</code> has permission to read <code>workflow</code>. If the user
      * does not have permission, throws a {@link CustomWebApplicationException}.
+     *
      * @param user
      * @param workflow
      */
-    private void checkCanReadWorkflow(User user, Workflow workflow) {
+    @Override
+    public void checkCanRead(User user, Entry workflow) {
         try {
             checkUser(user, workflow);
         } catch (CustomWebApplicationException ex) {
-            if (!permissionsInterface.canDoAction(user, workflow, Role.Action.READ)) {
+            if (!permissionsInterface.canDoAction(user, (Workflow)workflow, Role.Action.READ)) {
                 throw ex;
             }
         }
@@ -770,6 +808,7 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     /**
      * Checks if <code>user</code> has permission to write <code>workflow</code>. If the user
      * does not have permission, throws a {@link CustomWebApplicationException}.
+     *
      * @param user
      * @param workflow
      */
@@ -786,6 +825,7 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     /**
      * Checks if <code>user</code> has permission to share <code>workflow</code>. If the user
      * does not have permission, throws a {@link CustomWebApplicationException}.
+     *
      * @param user
      * @param workflow
      */
@@ -803,8 +843,10 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/path/workflow/{repository}/permissions")
-    @ApiOperation(value = "Get all permissions for a workflow", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Lists all permissions for a workflow. The user must be the workflow owner.", response = Permission.class, responseContainer = "List")
-    public List<Permission> getWorkflowPermissions(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
+    @ApiOperation(value = "Get all permissions for a workflow", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Lists all permissions for a workflow. The user must be the workflow owner.", response = Permission.class, responseContainer = "List")
+    public List<Permission> getWorkflowPermissions(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
         Workflow workflow = workflowDAO.findByPath(path, false);
         checkEntry(workflow);
         return this.permissionsInterface.getPermissionsForWorkflow(user, workflow);
@@ -814,8 +856,10 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/path/workflow/{repository}/actions")
-    @ApiOperation(value = "Gets all actions a user can perform on a workflow", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "", response = Role.Action.class, responseContainer = "List")
-    public List<Role.Action> getWorkflowActions(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
+    @ApiOperation(value = "Gets all actions a user can perform on a workflow", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "", response = Role.Action.class, responseContainer = "List")
+    public List<Role.Action> getWorkflowActions(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
         Workflow workflow = workflowDAO.findByPath(path, false);
         checkEntry(workflow);
         return this.permissionsInterface.getActionsForWorkflow(user, workflow);
@@ -825,10 +869,11 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/path/workflow/{repository}/permissions")
-    @ApiOperation(value = "Set the specified permission for a user on a workflow", authorizations = { @Authorization(value =  JWT_SECURITY_DEFINITION_NAME)}, notes = "Adds a permission for a workflow. The user must be the workflow owner. Currently only supported on hosted workflows.", response = Permission.class, responseContainer = "List")
+    @ApiOperation(value = "Set the specified permission for a user on a workflow", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Adds a permission for a workflow. The user must be the workflow owner. Currently only supported on hosted workflows.", response = Permission.class, responseContainer = "List")
     public List<Permission> addWorkflowPermission(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "repository path", required = true) @PathParam("repository") String path,
-            @ApiParam(value = "user permission", required = true) Permission permission) {
+        @ApiParam(value = "repository path", required = true) @PathParam("repository") String path,
+        @ApiParam(value = "user permission", required = true) Permission permission) {
         Workflow workflow = workflowDAO.findByPath(path, false);
         checkEntry(workflow);
         // TODO: Remove this guard when ready to expand sharing to non-hosted workflows. https://github.com/ga4gh/dockstore/issues/1593
@@ -843,11 +888,12 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/path/workflow/{repository}/permissions")
-    @ApiOperation(value = "Remove the specified user role for a workflow", authorizations = { @Authorization(value =  JWT_SECURITY_DEFINITION_NAME)}, notes = "Removes a role from a workflow. The user must be the workflow owner.", response = Permission.class, responseContainer = "List")
+    @ApiOperation(value = "Remove the specified user role for a workflow", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Removes a role from a workflow. The user must be the workflow owner.", response = Permission.class, responseContainer = "List")
     public List<Permission> removeWorkflowRole(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "repository path", required = true) @PathParam("repository") String path,
-            @ApiParam(value = "user email", required = true) @QueryParam("email") String email,
-            @ApiParam(value = "role", required = true) @QueryParam("role") Role role) {
+        @ApiParam(value = "repository path", required = true) @PathParam("repository") String path,
+        @ApiParam(value = "user email", required = true) @QueryParam("email") String email,
+        @ApiParam(value = "role", required = true) @QueryParam("role") Role role) {
         Workflow workflow = workflowDAO.findByPath(path, false);
         checkEntry(workflow);
         this.permissionsInterface.removePermission(user, workflow, email, role);
@@ -858,8 +904,10 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/path/entry/{repository}")
-    @ApiOperation(value = "Get an entry by path", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Gets an entry from the path. Enter full path.", response = Entry.class)
-    public Entry getEntryByPath(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
+    @ApiOperation(value = "Get an entry by path", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Gets an entry from the path. Enter full path.", response = Entry.class)
+    public Entry getEntryByPath(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
         MutablePair<String, Entry> entryPair = toolDAO.findEntryByPath(path, false);
 
         // Check if the entry exists
@@ -893,7 +941,8 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/path/{repository}")
-    @ApiOperation(value = "Get a list of workflows by path", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Lists info of workflow. Enter full path.", response = Workflow.class, responseContainer = "List")
+    @ApiOperation(value = "Get a list of workflows by path", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Lists info of workflow. Enter full path.", response = Workflow.class, responseContainer = "List")
     public List<Workflow> getAllWorkflowByPath(@ApiParam(hidden = true) @Auth User user,
         @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
         List<Workflow> workflows = workflowDAO.findAllByPath(path, false);
@@ -918,12 +967,13 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/versions")
-    @ApiOperation(value = "List the versions for a published workflow", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = WorkflowVersion.class, responseContainer = "List", hidden = true)
+    @ApiOperation(value = "List the versions for a published workflow", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = WorkflowVersion.class, responseContainer = "List", hidden = true)
     public List<WorkflowVersion> tags(@ApiParam(hidden = true) @Auth User user, @QueryParam("workflowId") long workflowId) {
         Workflow repository = workflowDAO.findById(workflowId);
         checkEntry(repository);
 
-        checkCanReadWorkflow(user, repository);
+        checkCanRead(user, repository);
 
         return new ArrayList<>(repository.getVersions());
     }
@@ -932,13 +982,15 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/{workflowId}/verifiedSources")
-    @ApiOperation(value = "Get a semicolon delimited list of verified sources", tags = { "workflows" }, notes = "Does not need authentication", response = String.class)
+    @ApiOperation(value = "Get a semicolon delimited list of verified sources", tags = {
+        "workflows" }, notes = "Does not need authentication", response = String.class)
     public String verifiedSources(@ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId) {
         Workflow workflow = workflowDAO.findById(workflowId);
         checkEntry(workflow);
 
         Set<String> verifiedSourcesArray = new HashSet<>();
-        workflow.getWorkflowVersions().stream().filter(Version::isVerified).forEach((WorkflowVersion v) -> verifiedSourcesArray.add(v.getVerifiedSource()));
+        workflow.getWorkflowVersions().stream().filter(Version::isVerified)
+            .forEach((WorkflowVersion v) -> verifiedSourcesArray.add(v.getVerifiedSource()));
 
         JSONArray jsonArray;
         try {
@@ -955,18 +1007,22 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/{workflowId}/cwl")
-    @ApiOperation(value = "Get the corresponding Dockstore.cwl file on Github.", tags = { "workflows" }, notes = "Does not need authentication", response = SourceFile.class)
-    public SourceFile cwl(@ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag) {
-        return getSourceFile(workflowId, tag, FileType.DOCKSTORE_CWL);
+    @ApiOperation(value = "Get the corresponding Dockstore.cwl file on Github.", tags = {
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+    public SourceFile cwl(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag) {
+        return getSourceFile(workflowId, tag, FileType.DOCKSTORE_CWL, user);
     }
 
     @GET
     @Timed
     @UnitOfWork
     @Path("/{workflowId}/wdl")
-    @ApiOperation(value = "Get the corresponding Dockstore.wdl file on Github.", tags = { "workflows" }, notes = "Does not need authentication", response = SourceFile.class)
-    public SourceFile wdl(@ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag) {
-        return getSourceFile(workflowId, tag, FileType.DOCKSTORE_WDL);
+    @ApiOperation(value = "Get the corresponding Dockstore.wdl file on Github.", tags = {
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+    public SourceFile wdl(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag) {
+        return getSourceFile(workflowId, tag, FileType.DOCKSTORE_WDL, user);
     }
 
     @GET
@@ -974,28 +1030,34 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @UnitOfWork
     @Path("/{workflowId}/nextflow")
     @ApiOperation(value = "Get the corresponding nextflow.config file on Github.", tags = {
-        "workflows" }, notes = "Does not need authentication", response = SourceFile.class)
-    public SourceFile nextflow(@ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId,
-        @QueryParam("tag") String tag) {
-        return getSourceFile(workflowId, tag, FileType.NEXTFLOW_CONFIG);
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+    public SourceFile nextflow(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag) {
+        return getSourceFile(workflowId, tag, FileType.NEXTFLOW_CONFIG, user);
     }
 
     @GET
     @Timed
     @UnitOfWork
     @Path("/{workflowId}/cwl/{relative-path}")
-    @ApiOperation(value = "Get the corresponding Dockstore.cwl file on Github.", tags = { "workflows" }, notes = "Does not need authentication", response = SourceFile.class)
-    public SourceFile secondaryCwlPath(@ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag, @PathParam("relative-path") String path) {
-        return getSourceFileByPath(workflowId, tag, FileType.DOCKSTORE_CWL, path);
+    @ApiOperation(value = "Get the corresponding Dockstore.cwl file on Github.", tags = {
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+    public SourceFile secondaryCwlPath(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag,
+        @PathParam("relative-path") String path) {
+        return getSourceFileByPath(workflowId, tag, FileType.DOCKSTORE_CWL, path, user);
     }
 
     @GET
     @Timed
     @UnitOfWork
     @Path("/{workflowId}/wdl/{relative-path}")
-    @ApiOperation(value = "Get the corresponding Dockstore.wdl file on Github.", tags = { "workflows" }, notes = "Does not need authentication", response = SourceFile.class)
-    public SourceFile secondaryWdlPath(@ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag, @PathParam("relative-path") String path) {
-        return getSourceFileByPath(workflowId, tag, FileType.DOCKSTORE_WDL, path);
+    @ApiOperation(value = "Get the corresponding Dockstore.wdl file on Github.", tags = {
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+    public SourceFile secondaryWdlPath(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag,
+        @PathParam("relative-path") String path) {
+        return getSourceFileByPath(workflowId, tag, FileType.DOCKSTORE_WDL, path, user);
     }
 
     @GET
@@ -1003,29 +1065,34 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @UnitOfWork
     @Path("/{workflowId}/nextflow/{relative-path}")
     @ApiOperation(value = "Get the corresponding nextflow documents on Github.", tags = {
-        "workflows" }, notes = "Does not need authentication", response = SourceFile.class)
-    public SourceFile secondaryNextFlowPath(@ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId,
-        @QueryParam("tag") String tag, @PathParam("relative-path") String path) {
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class)
+    public SourceFile secondaryNextFlowPath(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag,
+        @PathParam("relative-path") String path) {
 
-        return getSourceFileByPath(workflowId, tag, FileType.NEXTFLOW, path);
+        return getSourceFileByPath(workflowId, tag, FileType.NEXTFLOW, path, user);
     }
 
     @GET
     @Timed
     @UnitOfWork
     @Path("/{workflowId}/secondaryCwl")
-    @ApiOperation(value = "Get the corresponding cwl documents on Github.", tags = { "workflows" }, notes = "Does not need authentication", response = SourceFile.class, responseContainer = "List")
-    public List<SourceFile> secondaryCwl(@ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag) {
-        return getAllSecondaryFiles(workflowId, tag, FileType.DOCKSTORE_CWL);
+    @ApiOperation(value = "Get the corresponding cwl documents on Github.", tags = {
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List")
+    public List<SourceFile> secondaryCwl(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag) {
+        return getAllSecondaryFiles(workflowId, tag, FileType.DOCKSTORE_CWL, user);
     }
 
     @GET
     @Timed
     @UnitOfWork
     @Path("/{workflowId}/secondaryWdl")
-    @ApiOperation(value = "Get the corresponding wdl documents on Github.", tags = { "workflows" }, notes = "Does not need authentication", response = SourceFile.class, responseContainer = "List")
-    public List<SourceFile> secondaryWdl(@ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag) {
-        return getAllSecondaryFiles(workflowId, tag, FileType.DOCKSTORE_WDL);
+    @ApiOperation(value = "Get the corresponding wdl documents on Github.", tags = {
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List")
+    public List<SourceFile> secondaryWdl(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag) {
+        return getAllSecondaryFiles(workflowId, tag, FileType.DOCKSTORE_WDL, user);
     }
 
     @GET
@@ -1033,33 +1100,37 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @UnitOfWork
     @Path("/{workflowId}/secondaryNextflow")
     @ApiOperation(value = "Get the corresponding Nextflow documents on Github.", tags = {
-        "workflows" }, notes = "Does not need authentication", response = SourceFile.class, responseContainer = "List")
-    public List<SourceFile> secondaryNextflow(@ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId,
-        @QueryParam("tag") String tag) {
-        return getAllSecondaryFiles(workflowId, tag, FileType.NEXTFLOW);
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List")
+    public List<SourceFile> secondaryNextflow(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag) {
+        return getAllSecondaryFiles(workflowId, tag, FileType.NEXTFLOW, user);
     }
 
     @GET
     @Timed
     @UnitOfWork
     @Path("/{workflowId}/testParameterFiles")
-    @ApiOperation(value = "Get the corresponding test parameter files.", tags = { "workflows" }, notes = "Does not need authentication", response = SourceFile.class, responseContainer = "List")
-    public List<SourceFile> getTestParameterFiles(@ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId,
-        @QueryParam("version") String version) {
+    @ApiOperation(value = "Get the corresponding test parameter files.", tags = {
+        "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List")
+    public List<SourceFile> getTestParameterFiles(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("version") String version) {
 
         Workflow workflow = workflowDAO.findById(workflowId);
         checkEntry(workflow);
         FileType testParameterType = workflow.getTestParameterType();
-        return getAllSourceFiles(workflowId, version, testParameterType);
+        return getAllSourceFiles(workflowId, version, testParameterType, user);
     }
 
     @PUT
     @Timed
     @UnitOfWork
     @Path("/{workflowId}/testParameterFiles")
-    @ApiOperation(value = "Add test parameter files for a given version.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = SourceFile.class, responseContainer = "Set")
-    public Set<SourceFile> addTestParameterFiles(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "Workflow to modify.", required = true) @PathParam("workflowId") Long workflowId,
-        @ApiParam(value = "List of paths.", required = true) @QueryParam("testParameterPaths") List<String> testParameterPaths, @ApiParam(value = "This is here to appease Swagger. It requires PUT methods to have a body, even if it is empty. Please leave it empty.") String emptyBody,
+    @ApiOperation(value = "Add test parameter files for a given version.", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = SourceFile.class, responseContainer = "Set")
+    public Set<SourceFile> addTestParameterFiles(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "Workflow to modify.", required = true) @PathParam("workflowId") Long workflowId,
+        @ApiParam(value = "List of paths.", required = true) @QueryParam("testParameterPaths") List<String> testParameterPaths,
+        @ApiParam(value = "This is here to appease Swagger. It requires PUT methods to have a body, even if it is empty. Please leave it empty.") String emptyBody,
         @QueryParam("version") String version) {
         Workflow workflow = workflowDAO.findById(workflowId);
         checkEntry(workflow);
@@ -1067,7 +1138,8 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
         checkNotHosted(workflow);
 
         if (workflow.getMode() == WorkflowMode.STUB) {
-            String msg = "The workflow \'" + workflow.getWorkflowPath() + "\' is a STUB. Refresh the workflow if you want to add test parameter files";
+            String msg = "The workflow \'" + workflow.getWorkflowPath()
+                + "\' is a STUB. Refresh the workflow if you want to add test parameter files";
             LOG.info(msg);
             throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
         }
@@ -1102,9 +1174,12 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/{workflowId}/testParameterFiles")
-    @ApiOperation(value = "Delete test parameter files for a given version.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = SourceFile.class, responseContainer = "Set")
-    public Set<SourceFile> deleteTestParameterFiles(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "Workflow to modify.", required = true) @PathParam("workflowId") Long workflowId,
-        @ApiParam(value = "List of paths.", required = true) @QueryParam("testParameterPaths") List<String> testParameterPaths, @QueryParam("version") String version) {
+    @ApiOperation(value = "Delete test parameter files for a given version.", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = SourceFile.class, responseContainer = "Set")
+    public Set<SourceFile> deleteTestParameterFiles(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "Workflow to modify.", required = true) @PathParam("workflowId") Long workflowId,
+        @ApiParam(value = "List of paths.", required = true) @QueryParam("testParameterPaths") List<String> testParameterPaths,
+        @QueryParam("version") String version) {
         Workflow workflow = workflowDAO.findById(workflowId);
         checkEntry(workflow);
         checkCanWriteWorkflow(user, workflow);
@@ -1115,7 +1190,8 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
 
         if (!potentialWorfklowVersion.isPresent()) {
             LOG.info("The version \'" + version + "\' for workflow \'" + workflow.getWorkflowPath() + "\' does not exist.");
-            throw new CustomWebApplicationException("The version \'" + version + "\' for workflow \'" + workflow.getWorkflowPath() + "\' does not exist.",
+            throw new CustomWebApplicationException(
+                "The version \'" + version + "\' for workflow \'" + workflow.getWorkflowPath() + "\' does not exist.",
                 HttpStatus.SC_BAD_REQUEST);
         }
 
@@ -1123,7 +1199,8 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
 
         if (!workflowVersion.isValid()) {
             LOG.info("The version \'" + version + "\' for workflow \'" + workflow.getWorkflowPath() + "\' is invalid.");
-            throw new CustomWebApplicationException("The version \'" + version + "\' for workflow \'" + workflow.getWorkflowPath() + "\' is invalid.",
+            throw new CustomWebApplicationException(
+                "The version \'" + version + "\' for workflow \'" + workflow.getWorkflowPath() + "\' is invalid.",
                 HttpStatus.SC_BAD_REQUEST);
         }
 
@@ -1131,7 +1208,8 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
 
         // Remove test parameter files
         FileType testParameterType = workflow.getTestParameterType();
-        testParameterPaths.forEach(path -> sourceFiles.removeIf((SourceFile v) -> v.getPath().equals(path) && v.getType() == testParameterType));
+        testParameterPaths
+            .forEach(path -> sourceFiles.removeIf((SourceFile v) -> v.getPath().equals(path) && v.getType() == testParameterType));
         elasticManager.handleIndexUpdate(workflow, ElasticMode.UPDATE);
         return workflowVersion.getSourceFiles();
     }
@@ -1141,12 +1219,15 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @UnitOfWork
     @Path("/manualRegister")
     @SuppressWarnings("checkstyle:ParameterNumber")
-    @ApiOperation(value = "Manually register a workflow", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Manually register workflow (public or private).", response = Workflow.class)
-    public Workflow manualRegister(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "Workflow registry", required = true) @QueryParam("workflowRegistry") String workflowRegistry,
-        @ApiParam(value = "Workflow repository", required = true) @QueryParam("workflowPath") String workflowPath, @ApiParam(value = "Workflow container new descriptor path (CWL or WDL) and/or name", required = true) @QueryParam("defaultWorkflowPath") String defaultWorkflowPath,
-        @ApiParam(value = "Workflow name", required = true) @QueryParam("workflowName") String workflowName, @ApiParam(value = "Descriptor type", required = true) @QueryParam("descriptorType") String descriptorType,
+    @ApiOperation(value = "Manually register a workflow", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Manually register workflow (public or private).", response = Workflow.class)
+    public Workflow manualRegister(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "Workflow registry", required = true) @QueryParam("workflowRegistry") String workflowRegistry,
+        @ApiParam(value = "Workflow repository", required = true) @QueryParam("workflowPath") String workflowPath,
+        @ApiParam(value = "Workflow container new descriptor path (CWL or WDL) and/or name", required = true) @QueryParam("defaultWorkflowPath") String defaultWorkflowPath,
+        @ApiParam(value = "Workflow name", required = true) @QueryParam("workflowName") String workflowName,
+        @ApiParam(value = "Descriptor type", required = true) @QueryParam("descriptorType") String descriptorType,
         @ApiParam(value = "Default test parameter file path") @QueryParam("defaultTestParameterFilePath") String defaultTestParameterFilePath) {
-
 
         // Set up source code interface and ensure token is set up
         // construct git url like git@github.com:ga4gh/dockstore-ui.git
@@ -1180,7 +1261,8 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
                     + " and ends in the file nextflow.config", HttpStatus.SC_BAD_REQUEST);
         } else if (!"nextflow".equals(descriptorType) && !defaultWorkflowPath.endsWith(descriptorType)) {
             throw new CustomWebApplicationException(
-                "Please ensure that the given workflow path '" + defaultWorkflowPath + "' is of type " + descriptorType + " and has the file extension " + descriptorType, HttpStatus.SC_BAD_REQUEST);
+                "Please ensure that the given workflow path '" + defaultWorkflowPath + "' is of type " + descriptorType
+                    + " and has the file extension " + descriptorType, HttpStatus.SC_BAD_REQUEST);
         }
 
         Workflow duplicate = workflowDAO.findByPath(sourceControlEnum.toString() + '/' + completeWorkflowPath, false);
@@ -1233,8 +1315,10 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/{workflowId}/workflowVersions")
-    @ApiOperation(value = "Update the workflow versions linked to a workflow", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Workflow version correspond to each row of the versions table listing all information for a workflow", response = WorkflowVersion.class, responseContainer = "List")
-    public Set<WorkflowVersion> updateWorkflowVersion(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "Workflow to modify.", required = true) @PathParam("workflowId") Long workflowId,
+    @ApiOperation(value = "Update the workflow versions linked to a workflow", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Workflow version correspond to each row of the versions table listing all information for a workflow", response = WorkflowVersion.class, responseContainer = "List")
+    public Set<WorkflowVersion> updateWorkflowVersion(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "Workflow to modify.", required = true) @PathParam("workflowId") Long workflowId,
         @ApiParam(value = "List of modified workflow versions", required = true) List<WorkflowVersion> workflowVersions) {
 
         Workflow w = workflowDAO.findById(workflowId);
@@ -1271,7 +1355,9 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @UnitOfWork
     @Path("/{workflowId}/dag/{workflowVersionId}")
     @ApiOperation(value = "Get the DAG for a given workflow version", response = String.class)
-    public String getWorkflowDag(@ApiParam(hidden = true) @Auth Optional<User> user, @ApiParam(value = "workflowId", required = true) @PathParam("workflowId") Long workflowId, @ApiParam(value = "workflowVersionId", required = true) @PathParam("workflowVersionId") Long workflowVersionId) {
+    public String getWorkflowDag(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "workflowId", required = true) @PathParam("workflowId") Long workflowId,
+        @ApiParam(value = "workflowVersionId", required = true) @PathParam("workflowVersionId") Long workflowVersionId) {
         Workflow workflow = workflowDAO.findById(workflowId);
         checkEntry(workflow);
         checkOptionalAuthRead(user, workflow);
@@ -1301,7 +1387,9 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @UnitOfWork
     @Path("/{workflowId}/tools/{workflowVersionId}")
     @ApiOperation(value = "Get the Tools for a given workflow version", response = String.class)
-    public String getTableToolContent(@ApiParam(hidden = true) @Auth Optional<User> user, @ApiParam(value = "workflowId", required = true) @PathParam("workflowId") Long workflowId, @ApiParam(value = "workflowVersionId", required = true) @PathParam("workflowVersionId") Long workflowVersionId) {
+    public String getTableToolContent(@ApiParam(hidden = true) @Auth Optional<User> user,
+        @ApiParam(value = "workflowId", required = true) @PathParam("workflowId") Long workflowId,
+        @ApiParam(value = "workflowVersionId", required = true) @PathParam("workflowVersionId") Long workflowVersionId) {
 
         Workflow workflow = workflowDAO.findById(workflowId);
         checkEntry(workflow);
@@ -1384,7 +1472,8 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @UnitOfWork
     @Path("/{workflowId}/star")
     @ApiOperation(value = "Stars a workflow.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
-    public void starEntry(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "Tool to star.", required = true) @PathParam("workflowId") Long workflowId,
+    public void starEntry(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "Tool to star.", required = true) @PathParam("workflowId") Long workflowId,
         @ApiParam(value = "StarRequest to star a repo for a user", required = true) StarRequest request) {
         Workflow workflow = workflowDAO.findById(workflowId);
 
@@ -1397,7 +1486,8 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @UnitOfWork
     @Path("/{workflowId}/unstar")
     @ApiOperation(value = "Unstars a workflow.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
-    public void unstarEntry(@ApiParam(hidden = true) @Auth User user, @ApiParam(value = "Workflow to unstar.", required = true) @PathParam("workflowId") Long workflowId) {
+    public void unstarEntry(@ApiParam(hidden = true) @Auth User user,
+        @ApiParam(value = "Workflow to unstar.", required = true) @PathParam("workflowId") Long workflowId) {
         Workflow workflow = workflowDAO.findById(workflowId);
         unstarEntryHelper(workflow, user, "workflow", workflow.getWorkflowPath());
         elasticManager.handleIndexUpdate(workflow, ElasticMode.UPDATE);
@@ -1408,7 +1498,8 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @ApiOperation(value = "Returns list of users who starred the given Workflow", response = User.class, responseContainer = "List")
-    public Set<User> getStarredUsers(@ApiParam(value = "Workflow to grab starred users for.", required = true) @PathParam("workflowId") Long workflowId) {
+    public Set<User> getStarredUsers(
+        @ApiParam(value = "Workflow to grab starred users for.", required = true) @PathParam("workflowId") Long workflowId) {
         Workflow workflow = workflowDAO.findById(workflowId);
         checkEntry(workflow);
 
@@ -1419,7 +1510,8 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
     @Timed
     @UnitOfWork
     @Path("/{entryId}/registerCheckerWorkflow/{descriptorType}")
-    @ApiOperation(value = "Register a checker workflow and associates it with the given tool/workflow", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Entry.class)
+    @ApiOperation(value = "Register a checker workflow and associates it with the given tool/workflow", authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Entry.class)
     @SuppressWarnings("checkstyle:MagicNumber")
     public Entry registerCheckerWorkflow(@ApiParam(hidden = true) @Auth User user,
         @ApiParam(value = "Path of the main descriptor of the checker workflow (located in associated tool/workflow repository)", required = true) @QueryParam("checkerWorkflowPath") String checkerWorkflowPath,
@@ -1430,8 +1522,10 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
         Entry<? extends Entry, ? extends Version> entry = toolDAO.getGenericEntryById(entryId);
 
         // Check if valid descriptor type
-        if (!Objects.equals(descriptorType, DescriptorType.CWL.toString().toLowerCase()) && !Objects.equals(descriptorType, DescriptorType.WDL.toString().toLowerCase())) {
-            throw new CustomWebApplicationException(descriptorType + " is not a valid descriptor type. Only cwl and wdl are valid.", HttpStatus.SC_BAD_REQUEST);
+        if (!Objects.equals(descriptorType, DescriptorType.CWL.toString().toLowerCase()) && !Objects
+            .equals(descriptorType, DescriptorType.WDL.toString().toLowerCase())) {
+            throw new CustomWebApplicationException(descriptorType + " is not a valid descriptor type. Only cwl and wdl are valid.",
+                HttpStatus.SC_BAD_REQUEST);
         }
 
         checkEntry(entry);
@@ -1439,7 +1533,7 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
 
         // Don't allow workflow stubs
         if (entry instanceof Workflow) {
-            Workflow workflow = (Workflow) entry;
+            Workflow workflow = (Workflow)entry;
             if (Objects.equals(workflow.getMode().name(), WorkflowMode.STUB.toString())) {
                 throw new CustomWebApplicationException("Checker workflows cannot be added to workflow stubs.", HttpStatus.SC_BAD_REQUEST);
             }
@@ -1476,7 +1570,8 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
                 workflowName += "_cwl_checker";
                 defaultTestParameterPath = tool.getDefaultTestCwlParameterFile();
             } else {
-                throw new UnsupportedOperationException("The descriptor type " + descriptorType + " is not valid.\nSupported types include cwl and wdl.");
+                throw new UnsupportedOperationException(
+                    "The descriptor type " + descriptorType + " is not valid.\nSupported types include cwl and wdl.");
             }
 
             // Determine gitUrl
@@ -1519,9 +1614,10 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
             if (Objects.equals(workflow.getDescriptorType().toLowerCase(), DescriptorType.CWL.toString().toLowerCase())) {
                 workflowName += CWL_CHECKER;
             } else if (Objects.equals(workflow.getDescriptorType().toLowerCase(), DescriptorType.WDL.toString().toLowerCase())) {
-                workflowName +=  WDL_CHECKER;
+                workflowName += WDL_CHECKER;
             } else {
-                throw new UnsupportedOperationException("The descriptor type " + workflow.getDescriptorType().toLowerCase() + " is not valid.\nSupported types include cwl and wdl.");
+                throw new UnsupportedOperationException("The descriptor type " + workflow.getDescriptorType().toLowerCase()
+                    + " is not valid.\nSupported types include cwl and wdl.");
             }
         } else {
             throw new CustomWebApplicationException("No entry with the given ID exists.", HttpStatus.SC_BAD_REQUEST);
@@ -1562,7 +1658,6 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
         return toolDAO.getGenericEntryById(entryId);
     }
 
-
     @Override
     public WorkflowDAO getDAO() {
         return this.workflowDAO;
@@ -1600,24 +1695,5 @@ public class WorkflowResource implements AuthenticatedResourceInterface, EntryVe
             .header("Content-Disposition", "attachment; filename=\"" + fileName + "\"").build();
     }
 
-    /**
-     * This method checks that a workflow can be read in two situations
-     * 1) A published workflow
-     * 2) A workflow that is unpublished but that I have access to
-     * @param user
-     * @param workflow
-     */
-    private void checkOptionalAuthRead(Optional<User> user, Workflow workflow) {
-        if (workflow.getIsPublished()) {
-            checkEntry(workflow);
-        } else {
-            checkEntry(workflow);
-            if (user.isPresent()) {
-                checkCanReadWorkflow(user.get(), workflow);
-            } else {
-                throw new CustomWebApplicationException("Forbidden: you do not have the credentials required to access this entry.",
-                        HttpStatus.SC_FORBIDDEN);
-            }
-        }
-    }
+
 }

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
@@ -502,12 +502,12 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
                 // this only works for test parameters associated with tools
                 List<SourceFile> testSourceFiles = new ArrayList<>();
                 try {
-                    testSourceFiles.addAll(toolHelper.getAllSourceFiles(entry.getId(), versionId, type));
+                    testSourceFiles.addAll(toolHelper.getAllSourceFiles(entry.getId(), versionId, type, user));
                 } catch (CustomWebApplicationException e) {
                     LOG.warn("intentionally ignoring failure to get test parameters", e);
                 }
                 try {
-                    testSourceFiles.addAll(workflowHelper.getAllSourceFiles(entry.getId(), versionId, type));
+                    testSourceFiles.addAll(workflowHelper.getAllSourceFiles(entry.getId(), versionId, type, user));
                 } catch (CustomWebApplicationException e) {
                     LOG.warn("intentionally ignoring failure to get source files", e);
                 }

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -1923,8 +1923,8 @@ paths:
         - containers
       summary: Get the corresponding Dockstore.cwl file on Github.
       description: >-
-        Does not require authentication for published workflows, authentication
-        can be provided for restricted tools
+        Does not require authentication for published tools, authentication can
+        be provided for restricted tools
       operationId: cwl
       parameters:
         - name: containerId
@@ -1946,14 +1946,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SourceFile'
+      security:
+        - BEARER: []
   '/containers/{containerId}/cwl/{relative-path}':
     get:
       tags:
         - containers
       summary: Get the corresponding Dockstore.cwl file on Github.
       description: >-
-        Does not require authentication for published workflows, authentication
-        can be provided for restricted tools
+        Does not require authentication for published tools, authentication can
+        be provided for restricted tools
       operationId: secondaryCwlPath
       parameters:
         - name: containerId
@@ -1980,12 +1982,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SourceFile'
+      security:
+        - BEARER: []
   '/containers/{containerId}/dockerfile':
     get:
       tags:
         - containers
       summary: Get the corresponding Dockerfile on Github.
-      description: Does not need authentication
+      description: >-
+        Does not require authentication for published tools, authentication can
+        be provided for restricted tools
       operationId: dockerfile
       parameters:
         - name: containerId
@@ -2007,6 +2013,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SourceFile'
+      security:
+        - BEARER: []
   '/containers/{containerId}/labels':
     put:
       tags:
@@ -2132,8 +2140,8 @@ paths:
         - containers
       summary: Get a list of secondary CWL files from Git.
       description: >-
-        Does not require authentication for published workflows, authentication
-        can be provided for restricted tools
+        Does not require authentication for published tools, authentication can
+        be provided for restricted tools
       operationId: secondaryCwl
       parameters:
         - name: containerId
@@ -2157,14 +2165,16 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SourceFile'
+      security:
+        - BEARER: []
   '/containers/{containerId}/secondaryWdl':
     get:
       tags:
         - containers
       summary: Get a list of secondary WDL files from Git.
       description: >-
-        Does not require authentication for published workflows, authentication
-        can be provided for restricted tools
+        Does not require authentication for published tools, authentication can
+        be provided for restricted tools
       operationId: secondaryWdl
       parameters:
         - name: containerId
@@ -2188,6 +2198,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SourceFile'
+      security:
+        - BEARER: []
   '/containers/{containerId}/star':
     put:
       tags:
@@ -2342,8 +2354,8 @@ paths:
         - containers
       summary: Get the corresponding wdl test parameter files.
       description: >-
-        Does not require authentication for published workflows, authentication
-        can be provided for restricted tools
+        Does not require authentication for published tools, authentication can
+        be provided for restricted tools
       operationId: getTestParameterFiles
       parameters:
         - name: containerId
@@ -2377,6 +2389,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SourceFile'
+      security:
+        - BEARER: []
     put:
       tags:
         - containers
@@ -2555,7 +2569,7 @@ paths:
     get:
       tags:
         - containers
-      summary: Get the corresponding Dockstore.cwl file on Github.
+      summary: Get the sources that verified a particular tool.
       description: Does not need authentication
       operationId: verifiedSources
       parameters:
@@ -2614,8 +2628,8 @@ paths:
         - containers
       summary: Get the corresponding Dockstore.wdl file on Github.
       description: >-
-        Does not require authentication for published workflows, authentication
-        can be provided for restricted tools
+        Does not require authentication for published tools, authentication can
+        be provided for restricted tools
       operationId: wdl
       parameters:
         - name: containerId
@@ -2637,14 +2651,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SourceFile'
+      security:
+        - BEARER: []
   '/containers/{containerId}/wdl/{relative-path}':
     get:
       tags:
         - containers
       summary: Get the corresponding Dockstore.wdl file on Github.
       description: >-
-        Does not require authentication for published workflows, authentication
-        can be provided for restricted tools
+        Does not require authentication for published tools, authentication can
+        be provided for restricted tools
       operationId: secondaryWdlPath
       parameters:
         - name: containerId
@@ -2671,6 +2687,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SourceFile'
+      security:
+        - BEARER: []
   '/containers/{toolId}/defaultVersion':
     put:
       tags:
@@ -2938,7 +2956,7 @@ paths:
       tags:
         - users
       summary: List all groups
-      description: ''
+      description: This is not tied into PermissionsInterface but could be
       operationId: allGroups
       responses:
         '200':
@@ -2977,7 +2995,7 @@ paths:
       tags:
         - users
       summary: List a group
-      description: ''
+      description: This is not tied into PermissionsInterface but could be
       operationId: getGroup
       parameters:
         - name: groupId
@@ -3001,7 +3019,7 @@ paths:
       tags:
         - users
       summary: Get users that belongs to a group
-      description: ''
+      description: This is not tied into PermissionsInterface but could be
       operationId: getUsersFromGroup
       parameters:
         - name: groupId
@@ -3334,7 +3352,7 @@ paths:
       tags:
         - users
       summary: Get groups that the user belongs to
-      description: ''
+      description: This is not tied into PermissionsInterface but could be
       operationId: getGroupsFromUser
       parameters:
         - name: userId
@@ -3359,7 +3377,7 @@ paths:
       tags:
         - users
       summary: Add a group to a user
-      description: ''
+      description: This is not tied into PermissionsInterface but could be
       operationId: addGroupToUser
       parameters:
         - name: userId
@@ -3390,7 +3408,7 @@ paths:
       tags:
         - users
       summary: Remove a user from a group
-      description: ''
+      description: This is not tied into PermissionsInterface but could be
       operationId: removeUserFromGroup
       parameters:
         - name: userId
@@ -4307,6 +4325,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SourceFile'
+      security:
+        - BEARER: []
   '/workflows/{workflowId}/cwl/{relative-path}':
     get:
       tags:
@@ -4341,6 +4361,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SourceFile'
+      security:
+        - BEARER: []
   '/workflows/{workflowId}/dag/{workflowVersionId}':
     get:
       tags:
@@ -4464,6 +4486,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SourceFile'
+      security:
+        - BEARER: []
   '/workflows/{workflowId}/nextflow/{relative-path}':
     get:
       tags:
@@ -4498,6 +4522,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SourceFile'
+      security:
+        - BEARER: []
   '/workflows/{workflowId}/publish':
     post:
       tags:
@@ -4664,6 +4690,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SourceFile'
+      security:
+        - BEARER: []
   '/workflows/{workflowId}/secondaryNextflow':
     get:
       tags:
@@ -4695,6 +4723,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SourceFile'
+      security:
+        - BEARER: []
   '/workflows/{workflowId}/secondaryWdl':
     get:
       tags:
@@ -4726,6 +4756,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SourceFile'
+      security:
+        - BEARER: []
   '/workflows/{workflowId}/star':
     put:
       tags:
@@ -4803,6 +4835,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SourceFile'
+      security:
+        - BEARER: []
     put:
       tags:
         - workflows
@@ -5046,6 +5080,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SourceFile'
+      security:
+        - BEARER: []
   '/workflows/{workflowId}/wdl/{relative-path}':
     get:
       tags:
@@ -5080,6 +5116,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SourceFile'
+      security:
+        - BEARER: []
   '/workflows/{workflowId}/workflowVersions':
     put:
       tags:

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ info:
     This describes the dockstore API, a webservice that manages pairs of Docker
     images and associated metadata such as CWL documents and Dockerfiles used to
     build those images
-  version: 1.5.0-alpha.10-SNAPSHOT
+  version: 1.5.0-beta.0-SNAPSHOT
   title: Dockstore API
   termsOfService: TBD
   contact:
@@ -1922,7 +1922,9 @@ paths:
       tags:
         - containers
       summary: Get the corresponding Dockstore.cwl file on Github.
-      description: Does not need authentication
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted tools
       operationId: cwl
       parameters:
         - name: containerId
@@ -1949,7 +1951,9 @@ paths:
       tags:
         - containers
       summary: Get the corresponding Dockstore.cwl file on Github.
-      description: Does not need authentication
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted tools
       operationId: secondaryCwlPath
       parameters:
         - name: containerId
@@ -2127,7 +2131,9 @@ paths:
       tags:
         - containers
       summary: Get a list of secondary CWL files from Git.
-      description: Does not need authentication
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted tools
       operationId: secondaryCwl
       parameters:
         - name: containerId
@@ -2156,7 +2162,9 @@ paths:
       tags:
         - containers
       summary: Get a list of secondary WDL files from Git.
-      description: Does not need authentication
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted tools
       operationId: secondaryWdl
       parameters:
         - name: containerId
@@ -2333,7 +2341,9 @@ paths:
       tags:
         - containers
       summary: Get the corresponding wdl test parameter files.
-      description: Does not need authentication
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted tools
       operationId: getTestParameterFiles
       parameters:
         - name: containerId
@@ -2603,7 +2613,9 @@ paths:
       tags:
         - containers
       summary: Get the corresponding Dockstore.wdl file on Github.
-      description: Does not need authentication
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted tools
       operationId: wdl
       parameters:
         - name: containerId
@@ -2630,7 +2642,9 @@ paths:
       tags:
         - containers
       summary: Get the corresponding Dockstore.wdl file on Github.
-      description: Does not need authentication
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted tools
       operationId: secondaryWdlPath
       parameters:
         - name: containerId
@@ -4269,7 +4283,9 @@ paths:
       tags:
         - workflows
       summary: Get the corresponding Dockstore.cwl file on Github.
-      description: Does not need authentication
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted workflows
       operationId: cwl
       parameters:
         - name: workflowId
@@ -4296,7 +4312,9 @@ paths:
       tags:
         - workflows
       summary: Get the corresponding Dockstore.cwl file on Github.
-      description: Does not need authentication
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted workflows
       operationId: secondaryCwlPath
       parameters:
         - name: workflowId
@@ -4422,7 +4440,9 @@ paths:
       tags:
         - workflows
       summary: Get the corresponding nextflow.config file on Github.
-      description: Does not need authentication
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted workflows
       operationId: nextflow
       parameters:
         - name: workflowId
@@ -4449,7 +4469,9 @@ paths:
       tags:
         - workflows
       summary: Get the corresponding nextflow documents on Github.
-      description: Does not need authentication
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted workflows
       operationId: secondaryNextFlowPath
       parameters:
         - name: workflowId
@@ -4616,7 +4638,9 @@ paths:
       tags:
         - workflows
       summary: Get the corresponding cwl documents on Github.
-      description: Does not need authentication
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted workflows
       operationId: secondaryCwl
       parameters:
         - name: workflowId
@@ -4645,7 +4669,9 @@ paths:
       tags:
         - workflows
       summary: Get the corresponding Nextflow documents on Github.
-      description: Does not need authentication
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted workflows
       operationId: secondaryNextflow
       parameters:
         - name: workflowId
@@ -4674,7 +4700,9 @@ paths:
       tags:
         - workflows
       summary: Get the corresponding wdl documents on Github.
-      description: Does not need authentication
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted workflows
       operationId: secondaryWdl
       parameters:
         - name: workflowId
@@ -4749,7 +4777,9 @@ paths:
       tags:
         - workflows
       summary: Get the corresponding test parameter files.
-      description: Does not need authentication
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted workflows
       operationId: getTestParameterFiles
       parameters:
         - name: workflowId
@@ -4992,7 +5022,9 @@ paths:
       tags:
         - workflows
       summary: Get the corresponding Dockstore.wdl file on Github.
-      description: Does not need authentication
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted workflows
       operationId: wdl
       parameters:
         - name: workflowId
@@ -5019,7 +5051,9 @@ paths:
       tags:
         - workflows
       summary: Get the corresponding Dockstore.wdl file on Github.
-      description: Does not need authentication
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted workflows
       operationId: secondaryWdlPath
       parameters:
         - name: workflowId

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.5.0-alpha.10-SNAPSHOT"
+  version: "1.5.0-beta.0-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:
@@ -1654,7 +1654,8 @@ paths:
       tags:
       - "containers"
       summary: "Get the corresponding Dockstore.cwl file on Github."
-      description: "Does not need authentication"
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted tools"
       operationId: "cwl"
       produces:
       - "application/json"
@@ -1679,7 +1680,8 @@ paths:
       tags:
       - "containers"
       summary: "Get the corresponding Dockstore.cwl file on Github."
-      description: "Does not need authentication"
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted tools"
       operationId: "secondaryCwlPath"
       produces:
       - "application/json"
@@ -1853,7 +1855,8 @@ paths:
       tags:
       - "containers"
       summary: "Get a list of secondary CWL files from Git."
-      description: "Does not need authentication"
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted tools"
       operationId: "secondaryCwl"
       produces:
       - "application/json"
@@ -1880,7 +1883,8 @@ paths:
       tags:
       - "containers"
       summary: "Get a list of secondary WDL files from Git."
-      description: "Does not need authentication"
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted tools"
       operationId: "secondaryWdl"
       produces:
       - "application/json"
@@ -2052,7 +2056,8 @@ paths:
       tags:
       - "containers"
       summary: "Get the corresponding wdl test parameter files."
-      description: "Does not need authentication"
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted tools"
       operationId: "getTestParameterFiles"
       produces:
       - "application/json"
@@ -2319,7 +2324,8 @@ paths:
       tags:
       - "containers"
       summary: "Get the corresponding Dockstore.wdl file on Github."
-      description: "Does not need authentication"
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted tools"
       operationId: "wdl"
       produces:
       - "application/json"
@@ -2344,7 +2350,8 @@ paths:
       tags:
       - "containers"
       summary: "Get the corresponding Dockstore.wdl file on Github."
-      description: "Does not need authentication"
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted tools"
       operationId: "secondaryWdlPath"
       produces:
       - "application/json"
@@ -3923,7 +3930,8 @@ paths:
       tags:
       - "workflows"
       summary: "Get the corresponding Dockstore.cwl file on Github."
-      description: "Does not need authentication"
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted workflows"
       operationId: "cwl"
       produces:
       - "application/json"
@@ -3948,7 +3956,8 @@ paths:
       tags:
       - "workflows"
       summary: "Get the corresponding Dockstore.cwl file on Github."
-      description: "Does not need authentication"
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted workflows"
       operationId: "secondaryCwlPath"
       produces:
       - "application/json"
@@ -4069,7 +4078,8 @@ paths:
       tags:
       - "workflows"
       summary: "Get the corresponding nextflow.config file on Github."
-      description: "Does not need authentication"
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted workflows"
       operationId: "nextflow"
       produces:
       - "application/json"
@@ -4094,7 +4104,8 @@ paths:
       tags:
       - "workflows"
       summary: "Get the corresponding nextflow documents on Github."
-      description: "Does not need authentication"
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted workflows"
       operationId: "secondaryNextFlowPath"
       produces:
       - "application/json"
@@ -4259,7 +4270,8 @@ paths:
       tags:
       - "workflows"
       summary: "Get the corresponding cwl documents on Github."
-      description: "Does not need authentication"
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted workflows"
       operationId: "secondaryCwl"
       produces:
       - "application/json"
@@ -4286,7 +4298,8 @@ paths:
       tags:
       - "workflows"
       summary: "Get the corresponding Nextflow documents on Github."
-      description: "Does not need authentication"
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted workflows"
       operationId: "secondaryNextflow"
       produces:
       - "application/json"
@@ -4313,7 +4326,8 @@ paths:
       tags:
       - "workflows"
       summary: "Get the corresponding wdl documents on Github."
-      description: "Does not need authentication"
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted workflows"
       operationId: "secondaryWdl"
       produces:
       - "application/json"
@@ -4390,7 +4404,8 @@ paths:
       tags:
       - "workflows"
       summary: "Get the corresponding test parameter files."
-      description: "Does not need authentication"
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted workflows"
       operationId: "getTestParameterFiles"
       produces:
       - "application/json"
@@ -4629,7 +4644,8 @@ paths:
       tags:
       - "workflows"
       summary: "Get the corresponding Dockstore.wdl file on Github."
-      description: "Does not need authentication"
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted workflows"
       operationId: "wdl"
       produces:
       - "application/json"
@@ -4654,7 +4670,8 @@ paths:
       tags:
       - "workflows"
       summary: "Get the corresponding Dockstore.wdl file on Github."
-      description: "Does not need authentication"
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted workflows"
       operationId: "secondaryWdlPath"
       produces:
       - "application/json"

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -1654,7 +1654,7 @@ paths:
       tags:
       - "containers"
       summary: "Get the corresponding Dockstore.cwl file on Github."
-      description: "Does not require authentication for published workflows, authentication\
+      description: "Does not require authentication for published tools, authentication\
         \ can be provided for restricted tools"
       operationId: "cwl"
       produces:
@@ -1675,12 +1675,14 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/SourceFile"
+      security:
+      - BEARER: []
   /containers/{containerId}/cwl/{relative-path}:
     get:
       tags:
       - "containers"
       summary: "Get the corresponding Dockstore.cwl file on Github."
-      description: "Does not require authentication for published workflows, authentication\
+      description: "Does not require authentication for published tools, authentication\
         \ can be provided for restricted tools"
       operationId: "secondaryCwlPath"
       produces:
@@ -1705,12 +1707,15 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/SourceFile"
+      security:
+      - BEARER: []
   /containers/{containerId}/dockerfile:
     get:
       tags:
       - "containers"
       summary: "Get the corresponding Dockerfile on Github."
-      description: "Does not need authentication"
+      description: "Does not require authentication for published tools, authentication\
+        \ can be provided for restricted tools"
       operationId: "dockerfile"
       produces:
       - "application/json"
@@ -1730,6 +1735,8 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/SourceFile"
+      security:
+      - BEARER: []
   /containers/{containerId}/labels:
     put:
       tags:
@@ -1855,7 +1862,7 @@ paths:
       tags:
       - "containers"
       summary: "Get a list of secondary CWL files from Git."
-      description: "Does not require authentication for published workflows, authentication\
+      description: "Does not require authentication for published tools, authentication\
         \ can be provided for restricted tools"
       operationId: "secondaryCwl"
       produces:
@@ -1878,12 +1885,14 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/SourceFile"
+      security:
+      - BEARER: []
   /containers/{containerId}/secondaryWdl:
     get:
       tags:
       - "containers"
       summary: "Get a list of secondary WDL files from Git."
-      description: "Does not require authentication for published workflows, authentication\
+      description: "Does not require authentication for published tools, authentication\
         \ can be provided for restricted tools"
       operationId: "secondaryWdl"
       produces:
@@ -1906,6 +1915,8 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/SourceFile"
+      security:
+      - BEARER: []
   /containers/{containerId}/star:
     put:
       tags:
@@ -2056,7 +2067,7 @@ paths:
       tags:
       - "containers"
       summary: "Get the corresponding wdl test parameter files."
-      description: "Does not require authentication for published workflows, authentication\
+      description: "Does not require authentication for published tools, authentication\
         \ can be provided for restricted tools"
       operationId: "getTestParameterFiles"
       produces:
@@ -2088,6 +2099,8 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/SourceFile"
+      security:
+      - BEARER: []
     put:
       tags:
       - "containers"
@@ -2265,7 +2278,7 @@ paths:
     get:
       tags:
       - "containers"
-      summary: "Get the corresponding Dockstore.cwl file on Github."
+      summary: "Get the sources that verified a particular tool."
       description: "Does not need authentication"
       operationId: "verifiedSources"
       produces:
@@ -2324,7 +2337,7 @@ paths:
       tags:
       - "containers"
       summary: "Get the corresponding Dockstore.wdl file on Github."
-      description: "Does not require authentication for published workflows, authentication\
+      description: "Does not require authentication for published tools, authentication\
         \ can be provided for restricted tools"
       operationId: "wdl"
       produces:
@@ -2345,12 +2358,14 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/SourceFile"
+      security:
+      - BEARER: []
   /containers/{containerId}/wdl/{relative-path}:
     get:
       tags:
       - "containers"
       summary: "Get the corresponding Dockstore.wdl file on Github."
-      description: "Does not require authentication for published workflows, authentication\
+      description: "Does not require authentication for published tools, authentication\
         \ can be provided for restricted tools"
       operationId: "secondaryWdlPath"
       produces:
@@ -2375,6 +2390,8 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/SourceFile"
+      security:
+      - BEARER: []
   /containers/{toolId}/defaultVersion:
     put:
       tags:
@@ -2639,7 +2656,7 @@ paths:
       tags:
       - "users"
       summary: "List all groups"
-      description: ""
+      description: "This is not tied into PermissionsInterface but could be"
       operationId: "allGroups"
       produces:
       - "application/json"
@@ -2678,7 +2695,7 @@ paths:
       tags:
       - "users"
       summary: "List a group"
-      description: ""
+      description: "This is not tied into PermissionsInterface but could be"
       operationId: "getGroup"
       produces:
       - "application/json"
@@ -2701,7 +2718,7 @@ paths:
       tags:
       - "users"
       summary: "Get users that belongs to a group"
-      description: ""
+      description: "This is not tied into PermissionsInterface but could be"
       operationId: "getUsersFromGroup"
       produces:
       - "application/json"
@@ -3031,7 +3048,7 @@ paths:
       tags:
       - "users"
       summary: "Get groups that the user belongs to"
-      description: ""
+      description: "This is not tied into PermissionsInterface but could be"
       operationId: "getGroupsFromUser"
       produces:
       - "application/json"
@@ -3055,7 +3072,7 @@ paths:
       tags:
       - "users"
       summary: "Add a group to a user"
-      description: ""
+      description: "This is not tied into PermissionsInterface but could be"
       operationId: "addGroupToUser"
       produces:
       - "application/json"
@@ -3084,7 +3101,7 @@ paths:
       tags:
       - "users"
       summary: "Remove a user from a group"
-      description: ""
+      description: "This is not tied into PermissionsInterface but could be"
       operationId: "removeUserFromGroup"
       produces:
       - "application/json"
@@ -3951,6 +3968,8 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/SourceFile"
+      security:
+      - BEARER: []
   /workflows/{workflowId}/cwl/{relative-path}:
     get:
       tags:
@@ -3981,6 +4000,8 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/SourceFile"
+      security:
+      - BEARER: []
   /workflows/{workflowId}/dag/{workflowVersionId}:
     get:
       tags:
@@ -4099,6 +4120,8 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/SourceFile"
+      security:
+      - BEARER: []
   /workflows/{workflowId}/nextflow/{relative-path}:
     get:
       tags:
@@ -4129,6 +4152,8 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/SourceFile"
+      security:
+      - BEARER: []
   /workflows/{workflowId}/publish:
     post:
       tags:
@@ -4293,6 +4318,8 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/SourceFile"
+      security:
+      - BEARER: []
   /workflows/{workflowId}/secondaryNextflow:
     get:
       tags:
@@ -4321,6 +4348,8 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/SourceFile"
+      security:
+      - BEARER: []
   /workflows/{workflowId}/secondaryWdl:
     get:
       tags:
@@ -4349,6 +4378,8 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/SourceFile"
+      security:
+      - BEARER: []
   /workflows/{workflowId}/star:
     put:
       tags:
@@ -4427,6 +4458,8 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/SourceFile"
+      security:
+      - BEARER: []
     put:
       tags:
       - "workflows"
@@ -4665,6 +4698,8 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/SourceFile"
+      security:
+      - BEARER: []
   /workflows/{workflowId}/wdl/{relative-path}:
     get:
       tags:
@@ -4695,6 +4730,8 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/SourceFile"
+      security:
+      - BEARER: []
   /workflows/{workflowId}/workflowVersions:
     put:
       tags:


### PR DESCRIPTION
* use optional auth for all resources that return descriptors (published content always visible, unpublished content visible if you are the owner or have rights in SAM)
* this includes somewhat unexpected resources like tool listing and DAG display
* lock down a few more like aliasing, stubbing, verification more precisiely