### PR TITLE
Simple fix for dev env

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
@@ -13,6 +13,7 @@ import com.github.zafarkhaja.semver.Version;
  * @since 13/04/18
  */
 public final class PipHelper {
+    public static final String DEV_SEM_VER = "development-build";
     private PipHelper() { }
 
     /**
@@ -22,7 +23,7 @@ public final class PipHelper {
      * @return              The most recently changed pip requirements file to the Dockstore client version (can be older, but not newer)
      */
     public static String convertSemVerToAvailableVersion(String semVerString) {
-        if (semVerString == null || "development-build".equals(semVerString)) {
+        if (semVerString == null || DEV_SEM_VER.equals(semVerString)) {
             semVerString = "9001.9001.9001";
         }
         Version semVer = Version.valueOf(semVerString);

--- a/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
@@ -22,7 +22,7 @@ public final class PipHelper {
      * @return              The most recently changed pip requirements file to the Dockstore client version (can be older, but not newer)
      */
     public static String convertSemVerToAvailableVersion(String semVerString) {
-        if (semVerString == null) {
+        if (semVerString == null || "development-build".equals(semVerString)) {
             semVerString = "9001.9001.9001";
         }
         Version semVer = Version.valueOf(semVerString);

--- a/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
@@ -20,7 +20,7 @@ public final class PipHelper {
      * Figures out which pip requirements file to resolve to since not every clientVersion changes the pip requirements.
      * This function should be modified every time a new pip requirements file is added.
      * @param semVerString  The Dockstore client version
-     * @return              The most recently changed pip requirements file to the Dockstore client version (can be older, but not newer)
+     * @return              The most recently changed pip requirements file to the Dockstore client version
      */
     public static String convertSemVerToAvailableVersion(String semVerString) {
         if (semVerString == null || DEV_SEM_VER.equals(semVerString)) {

--- a/dockstore-common/src/test/java/io/dockstore/common/PipHelperTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/PipHelperTest.java
@@ -1,0 +1,24 @@
+package io.dockstore.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author gluu
+ * @since 14/08/18
+ */
+public class PipHelperTest {
+    @Test
+    public void convertSemVerToAvailableVersion() throws Exception {
+        Assert.assertEquals("1.5.0", PipHelper.convertSemVerToAvailableVersion(PipHelper.DEV_SEM_VER));
+        Assert.assertEquals("1.5.0", PipHelper.convertSemVerToAvailableVersion(null));
+        Assert.assertEquals("1.5.0", PipHelper.convertSemVerToAvailableVersion("1.5.0-snapshot"));
+        Assert.assertEquals("1.5.0", PipHelper.convertSemVerToAvailableVersion("1.5.0"));
+        Assert.assertEquals("1.4.0", PipHelper.convertSemVerToAvailableVersion("1.4.0-snapshot"));
+        Assert.assertEquals("1.4.0", PipHelper.convertSemVerToAvailableVersion("1.4.0"));
+        Assert.assertEquals("1.4.0", PipHelper.convertSemVerToAvailableVersion("1.3.0-snapshot"));
+        Assert.assertEquals("1.4.0", PipHelper.convertSemVerToAvailableVersion("1.3.0"));
+    }
+}

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/MetadataApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/MetadataApiServiceImpl.java
@@ -26,6 +26,8 @@ import io.dockstore.webservice.core.User;
 import io.swagger.api.MetadataApiService;
 import io.swagger.model.Metadata;
 
+import static io.dockstore.common.PipHelper.DEV_SEM_VER;
+
 public class MetadataApiServiceImpl extends MetadataApiService {
     @Override
     public Response metadataGet(SecurityContext securityContext, ContainerRequestContext containerContext, Optional<User> user) {
@@ -34,7 +36,7 @@ public class MetadataApiServiceImpl extends MetadataApiService {
         metadata.setApiVersion("2.0.0");
         metadata.setFriendlyName("Dockstore");
         String implVersion = ToolsApiServiceImpl.class.getPackage().getImplementationVersion();
-        implVersion = implVersion == null ? "development-build" : implVersion;
+        implVersion = implVersion == null ? DEV_SEM_VER : implVersion;
         metadata.setVersion(implVersion);
         return Response.ok(metadata).build();
     }


### PR DESCRIPTION
Onboarding CLI page doesn't work nice in UI2 because the version is "development-build" which is not semver.  Letting webservice handle it.  I suppose the change could've also be done in UI2 instead :man_shrugging: 