### PR TITLE
Missing annotation for dag and tools

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AuthenticatedResourceInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AuthenticatedResourceInterface.java
@@ -31,7 +31,7 @@ public interface AuthenticatedResourceInterface {
     /**
      * Check if tool is null
      *
-     * @param entry
+     * @param entry entry to check permissions for
      */
     default void checkEntry(Entry entry) {
         if (entry == null) {
@@ -42,7 +42,7 @@ public interface AuthenticatedResourceInterface {
     /**
      * Check if tool is null
      *
-     * @param entry
+     * @param entry entry to check permissions for
      */
     default void checkEntry(List<? extends Entry> entry) {
         if (entry == null) {
@@ -54,7 +54,7 @@ public interface AuthenticatedResourceInterface {
     /**
      * Check if admin
      *
-     * @param user
+     * @param user the user that is requesting something
      */
     default void checkAdmin(User user) {
         if (!user.getIsAdmin()) {
@@ -66,8 +66,8 @@ public interface AuthenticatedResourceInterface {
     /**
      * Check if admin or if tool belongs to user
      *
-     * @param user
-     * @param entry
+     * @param user the user that is requesting something
+     * @param entry entry to check permissions for
      */
     default void checkUser(User user, Entry entry) {
         if (!user.getIsAdmin() && (entry.getUsers()).stream().noneMatch(u -> ((User)(u)).getId() == user.getId())) {
@@ -79,7 +79,7 @@ public interface AuthenticatedResourceInterface {
     /**
      * Check if admin or if container belongs to user
      *
-     * @param user
+     * @param user the user that is requesting something
      * @param list
      */
     static void checkUser(User user, List<? extends Entry> list) {
@@ -94,7 +94,7 @@ public interface AuthenticatedResourceInterface {
     /**
      * Check if admin or correct user
      *
-     * @param user
+     * @param user the user that is requesting something
      * @param id
      */
     default void checkUser(User user, long id) {
@@ -107,8 +107,8 @@ public interface AuthenticatedResourceInterface {
      * Checks if a user can read an entry. Default implementation
      * is to invoke <code>checkUser</code>. Implmenations that support
      * more nuanched sharing should override.
-     * @param user
-     * @param entry
+     * @param user the user that is requesting something
+     * @param entry entry to check permissions for()
      */
     default void checkUserCanRead(User user, Entry entry) {
         checkUser(user, entry);
@@ -119,8 +119,8 @@ public interface AuthenticatedResourceInterface {
      * is to invoke <code>checkUser</code>. Implementations that support
      * more nuanced sharing should override.
      *
-     * @param user
-     * @param entry
+     * @param user the user that is requesting something
+     * @param entry entry to check permissions for()
      */
     default void checkUserCanUpdate(User user, Entry entry) {
         checkUser(user, entry);
@@ -131,8 +131,8 @@ public interface AuthenticatedResourceInterface {
      * is to invoke <code>checkUser</code>. Implementations that support
      * more nuanced sharing should override.
      *
-     * @param user
-     * @param entry
+     * @param user the user that is requesting something
+     * @param entry entry to check permissions for()
      */
     default void checkUserCanDelete(User user, Entry entry) {
         checkUser(user, entry);
@@ -143,8 +143,8 @@ public interface AuthenticatedResourceInterface {
      * is to invoke <code>checkUser</code>. Implmentations that support
      * more nuanced sharing should override.
      *
-     * @param user
-     * @param entry
+     * @param user the user that is requesting something
+     * @param entry entry to check permissions for()
      */
     default void checkUserCanShare(User user, Entry entry) {
         checkUser(user, entry);
@@ -153,10 +153,10 @@ public interface AuthenticatedResourceInterface {
     /**
      * Override for resources that are permissions aware.
      * Currently done for WorkflowResource
-     * @param user
-     * @param workflow
+     * @param user the user that is requesting something
+     * @param entry entry to check permissions for()
      */
-    default void checkCanRead(User user, Entry workflow) {
+    default void checkCanRead(User user, Entry entry) {
         throw new CustomWebApplicationException("Forbidden: you do not have the credentials required to access this entry.",
             HttpStatus.SC_FORBIDDEN);
     }
@@ -166,8 +166,8 @@ public interface AuthenticatedResourceInterface {
      * 1) A published workflow
      * 2) A workflow that is unpublished but that I have access to
      *
-     * @param user
-     * @param entry
+     * @param user the user that is requesting something
+     * @param entry entry to check permissions for()
      */
     default void checkOptionalAuthRead(Optional<User> user, Entry entry) {
         if (entry.getIsPublished()) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -49,6 +49,7 @@ import io.dockstore.common.Registry;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.api.PublishRequest;
 import io.dockstore.webservice.api.StarRequest;
+import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.Label;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.SourceFile.FileType;
@@ -830,6 +831,26 @@ public class DockerRepoResource
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
         @ApiParam(value = "Descriptor Type", required = true, allowableValues = "CWL, WDL, NFL") @QueryParam("descriptorType") String descriptorType) {
         return getAllSourceFiles(containerId, tag, Workflow.getTestParameterType(descriptorType), user);
+    }
+
+    /**
+     * Checks if <code>user</code> has permission to read <code>workflow</code>. If the user
+     * does not have permission, throws a {@link CustomWebApplicationException}.
+     *
+     * @param user
+     * @param tool
+     */
+    @Override
+    public void checkCanRead(User user, Entry tool) {
+        try {
+            checkUser(user, tool);
+        } catch (CustomWebApplicationException ex) {
+            LOG.info("permissions are not yet tool aware");
+            //TODO permissions will eventually need to know about tools too
+            //            if (!permissionsInterface.canDoAction(user, (Workflow)workflow, Role.Action.READ)) {
+            //                throw ex;
+            //            }
+        }
     }
 
     /*

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1365,7 +1365,8 @@ public class WorkflowResource
     @Timed
     @UnitOfWork
     @Path("/{workflowId}/dag/{workflowVersionId}")
-    @ApiOperation(value = "Get the DAG for a given workflow version", response = String.class)
+    @ApiOperation(value = "Get the DAG for a given workflow version", response = String.class, notes = OPTIONAL_AUTH_MESSAGE, authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public String getWorkflowDag(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "workflowId", required = true) @PathParam("workflowId") Long workflowId,
         @ApiParam(value = "workflowVersionId", required = true) @PathParam("workflowVersionId") Long workflowVersionId) {
@@ -1397,7 +1398,8 @@ public class WorkflowResource
     @Timed
     @UnitOfWork
     @Path("/{workflowId}/tools/{workflowVersionId}")
-    @ApiOperation(value = "Get the Tools for a given workflow version", response = String.class)
+    @ApiOperation(value = "Get the Tools for a given workflow version", notes = OPTIONAL_AUTH_MESSAGE, response = String.class, authorizations = {
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
     public String getTableToolContent(@ApiParam(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = "workflowId", required = true) @PathParam("workflowId") Long workflowId,
         @ApiParam(value = "workflowVersionId", required = true) @PathParam("workflowVersionId") Long workflowVersionId) {

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ info:
     This describes the dockstore API, a webservice that manages pairs of Docker
     images and associated metadata such as CWL documents and Dockerfiles used to
     build those images
-  version: 1.5.0-beta.1-SNAPSHOT
+  version: 1.5.0-beta.2-SNAPSHOT
   title: Dockstore API
   termsOfService: TBD
   contact:
@@ -4368,7 +4368,9 @@ paths:
       tags:
         - workflows
       summary: Get the DAG for a given workflow version
-      description: ''
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted workflows
       operationId: getWorkflowDag
       parameters:
         - name: workflowId
@@ -4392,6 +4394,8 @@ paths:
             application/json:
               schema:
                 type: string
+      security:
+        - BEARER: []
   '/workflows/{workflowId}/defaultVersion':
     put:
       tags:
@@ -4924,7 +4928,9 @@ paths:
       tags:
         - workflows
       summary: Get the Tools for a given workflow version
-      description: ''
+      description: >-
+        Does not require authentication for published workflows, authentication
+        can be provided for restricted workflows
       operationId: getTableToolContent
       parameters:
         - name: workflowId
@@ -4948,6 +4954,8 @@ paths:
             application/json:
               schema:
                 type: string
+      security:
+        - BEARER: []
   '/workflows/{workflowId}/unstar':
     delete:
       tags:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.5.0-beta.1-SNAPSHOT"
+  version: "1.5.0-beta.2-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:
@@ -4007,7 +4007,8 @@ paths:
       tags:
       - "workflows"
       summary: "Get the DAG for a given workflow version"
-      description: ""
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted workflows"
       operationId: "getWorkflowDag"
       produces:
       - "application/json"
@@ -4029,6 +4030,8 @@ paths:
           description: "successful operation"
           schema:
             type: "string"
+      security:
+      - BEARER: []
   /workflows/{workflowId}/defaultVersion:
     put:
       tags:
@@ -4546,7 +4549,8 @@ paths:
       tags:
       - "workflows"
       summary: "Get the Tools for a given workflow version"
-      description: ""
+      description: "Does not require authentication for published workflows, authentication\
+        \ can be provided for restricted workflows"
       operationId: "getTableToolContent"
       produces:
       - "application/json"
@@ -4568,6 +4572,8 @@ paths:
           description: "successful operation"
           schema:
             type: "string"
+      security:
+      - BEARER: []
   /workflows/{workflowId}/unstar:
     delete:
       tags:


### PR DESCRIPTION
* Needed for swagger to be aware of optional auth for tools and dag
* permissions check fix for test parameters for tools
Follows #1706  (DAG and tool listing potentially leak information about unpublished tools/workflows, but UI needs to display them for your own)
