### PR TITLE
When self-destructing, remove sharing records

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -245,7 +245,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         environment.jersey().register(new DockerRepoTagResource(toolDAO, tagDAO));
         environment.jersey().register(new TokenResource(tokenDAO, userDAO, httpClient, cachingAuthenticator, configuration));
 
-        environment.jersey().register(new UserResource(getHibernate().getSessionFactory(), workflowResource, dockerRepoResource, cachingAuthenticator));
+        environment.jersey().register(new UserResource(getHibernate().getSessionFactory(), workflowResource, dockerRepoResource, cachingAuthenticator, authorizer));
         environment.jersey().register(new MetadataResource(getHibernate().getSessionFactory(), configuration));
         environment.jersey().register(new HostedToolResource(getHibernate().getSessionFactory(), authorizer));
         environment.jersey().register(new HostedWorkflowResource(getHibernate().getSessionFactory(), authorizer));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ExtendedUserData.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ExtendedUserData.java
@@ -16,6 +16,7 @@
 package io.dockstore.webservice.core;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dockstore.webservice.permissions.PermissionsInterface;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.hibernate.Hibernate;
@@ -28,9 +29,9 @@ public class ExtendedUserData {
     @ApiModelProperty(value = "Whether a user can change their username")
     private boolean canChangeUsername;
 
-    public ExtendedUserData(User user) {
+    public ExtendedUserData(User user, PermissionsInterface authorizer) {
         Hibernate.initialize(user.getEntries());
-        this.canChangeUsername = user.getEntries().stream().noneMatch(Entry::getIsPublished);
+        this.canChangeUsername = user.getEntries().stream().noneMatch(Entry::getIsPublished) && authorizer.isSharing(user);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ExtendedUserData.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ExtendedUserData.java
@@ -31,7 +31,7 @@ public class ExtendedUserData {
 
     public ExtendedUserData(User user, PermissionsInterface authorizer) {
         Hibernate.initialize(user.getEntries());
-        this.canChangeUsername = user.getEntries().stream().noneMatch(Entry::getIsPublished) && authorizer.isSharing(user);
+        this.canChangeUsername = user.getEntries().stream().noneMatch(Entry::getIsPublished) && !authorizer.isSharing(user);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
@@ -181,7 +181,10 @@ public class InMemoryPermissionsImpl implements PermissionsInterface {
 
     @Override
     public void selfDestruct(User user) {
-
+        if (isSharing(user)) {
+            throw new CustomWebApplicationException("The user is sharing at least one workflow and cannot be deleted.",
+                    HttpStatus.SC_BAD_REQUEST);
+        }
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
@@ -184,6 +184,12 @@ public class InMemoryPermissionsImpl implements PermissionsInterface {
         if (isSharing(user)) {
             throw new CustomWebApplicationException("The user is sharing at least one workflow and cannot be deleted.",
                     HttpStatus.SC_BAD_REQUEST);
+        } else {
+           user.getEntries().stream().forEach(e -> {
+               if (e instanceof Workflow) {
+                   resourceToUsersAndRolesMap.remove(((Workflow)e).getWorkflowPath());
+               }
+           });
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import io.dockstore.webservice.CustomWebApplicationException;
-import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
@@ -58,7 +57,6 @@ public class InMemoryPermissionsImpl implements PermissionsInterface {
      * this implementation, because we may only have the name, and not the email, of users logged in with GitHub.
      */
     private final Map<String, Map<String, Role>> resourceToUsersAndRolesMap = new ConcurrentHashMap<>();
-    private DockstoreWebserviceConfiguration configuration;
 
     @Override
     public List<Permission> setPermission(User requester, Workflow workflow, Permission permission) {
@@ -179,6 +177,25 @@ public class InMemoryPermissionsImpl implements PermissionsInterface {
                 return false;
             }
         }).orElse(false);
+    }
+
+    @Override
+    public void selfDestruct(User user) {
+
+    }
+
+    @Override
+    public boolean isSharing(User user) {
+        final String userKey = userKey(user);
+        return user.getEntries().stream().anyMatch(e -> {
+            if (e instanceof Workflow) {
+                final Map<String, Role> map = resourceToUsersAndRolesMap.get(((Workflow)e).getWorkflowPath());
+                if (map != null && map.keySet().stream().anyMatch(u -> !userKey.equals(u))) {
+                    return true;
+                }
+            }
+            return false;
+        });
     }
 
     private Optional<Role> getRole(User requester, Workflow workflow) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
@@ -185,11 +185,11 @@ public class InMemoryPermissionsImpl implements PermissionsInterface {
             throw new CustomWebApplicationException("The user is sharing at least one workflow and cannot be deleted.",
                     HttpStatus.SC_BAD_REQUEST);
         } else {
-           user.getEntries().stream().forEach(e -> {
-               if (e instanceof Workflow) {
-                   resourceToUsersAndRolesMap.remove(((Workflow)e).getWorkflowPath());
-               }
-           });
+            user.getEntries().stream().forEach(e -> {
+                if (e instanceof Workflow) {
+                    resourceToUsersAndRolesMap.remove(((Workflow)e).getWorkflowPath());
+                }
+            });
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/NoOpPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/NoOpPermissionsImpl.java
@@ -43,4 +43,14 @@ public class NoOpPermissionsImpl implements PermissionsInterface {
     public boolean canDoAction(User user, Workflow workflow, Role.Action action) {
         return false;
     }
+
+    @Override
+    public void selfDestruct(User user) {
+        // Do nothing
+    }
+
+    @Override
+    public boolean isSharing(User user) {
+        return true;
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/NoOpPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/NoOpPermissionsImpl.java
@@ -51,6 +51,6 @@ public class NoOpPermissionsImpl implements PermissionsInterface {
 
     @Override
     public boolean isSharing(User user) {
-        return true;
+        return false;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/PermissionsInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/PermissionsInterface.java
@@ -124,8 +124,23 @@ public interface PermissionsInterface {
     boolean canDoAction(User user, Workflow workflow, Role.Action action);
 
     /**
+     * Deletes all sharing artifacts that the user is an owner of. This method will fail with a {@link CustomWebApplicationException}
+     * if the user is sharing anything.
+     * @param user
+     */
+    void selfDestruct(User user);
+
+    /**
+     * Indicates whether a user is sharing any workflows.
+     *
+     * @param user
+     * @return
+     */
+    boolean isSharing(User user);
+
+    /**
      * Merges two lists of permissions, removing any duplicate users. If there
-     * are duplicates, gives precendence to <code>dockstoreOwners</code>.
+     * are duplicates, gives precedence to <code>dockstoreOwners</code>.
      *
      * @param dockstoreOwners
      * @param nativePermissions

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -55,6 +55,7 @@ import io.dockstore.webservice.helpers.GoogleHelper;
 import io.dockstore.webservice.jdbi.GroupDAO;
 import io.dockstore.webservice.jdbi.TokenDAO;
 import io.dockstore.webservice.jdbi.UserDAO;
+import io.dockstore.webservice.permissions.PermissionsInterface;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.auth.CachingAuthenticator;
 import io.dropwizard.hibernate.UnitOfWork;
@@ -88,15 +89,17 @@ public class UserResource implements AuthenticatedResourceInterface {
 
     private final WorkflowResource workflowResource;
     private final DockerRepoResource dockerRepoResource;
+    private PermissionsInterface authorizer;
     private final CachingAuthenticator cachingAuthenticator;
 
-    public UserResource(SessionFactory sessionFactory, WorkflowResource workflowResource,
-        DockerRepoResource dockerRepoResource, CachingAuthenticator cachingAuthenticator) {
+    public UserResource(SessionFactory sessionFactory, WorkflowResource workflowResource, DockerRepoResource dockerRepoResource,
+            CachingAuthenticator cachingAuthenticator, PermissionsInterface authorizer) {
         this.userDAO = new UserDAO(sessionFactory);
         this.groupDAO = new GroupDAO(sessionFactory);
         this.tokenDAO = new TokenDAO(sessionFactory);
         this.workflowResource = workflowResource;
         this.dockerRepoResource = dockerRepoResource;
+        this.authorizer = authorizer;
         elasticManager = new ElasticManager();
         this.cachingAuthenticator = cachingAuthenticator;
     }
@@ -158,7 +161,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     @ApiOperation(value = "Get additional information on the logged-in user", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = ExtendedUserData.class)
     public ExtendedUserData getExtendedUserData(@ApiParam(hidden = true) @Auth User user) {
         User foundUser = userDAO.findById(user.getId());
-        return new ExtendedUserData(foundUser);
+        return new ExtendedUserData(foundUser, this.authorizer);
     }
 
     @POST
@@ -173,7 +176,7 @@ public class UserResource implements AuthenticatedResourceInterface {
             throw new CustomWebApplicationException("Username pattern invalid", HttpStatus.SC_BAD_REQUEST);
         }
         User user = userDAO.findById(authUser.getId());
-        if (!new ExtendedUserData(user).canChangeUsername()) {
+        if (!new ExtendedUserData(user, this.authorizer).canChangeUsername()) {
             throw new CustomWebApplicationException("Cannot change username, user not ready", HttpStatus.SC_BAD_REQUEST);
         }
         user.setUsername(username);
@@ -191,9 +194,11 @@ public class UserResource implements AuthenticatedResourceInterface {
             @ApiParam(hidden = true) @Auth User authUser) {
         checkUser(authUser, authUser.getId());
         User user = userDAO.findById(authUser.getId());
-        if (!new ExtendedUserData(user).canChangeUsername()) {
+        if (!new ExtendedUserData(user, this.authorizer).canChangeUsername()) {
             throw new CustomWebApplicationException("Cannot delete user, user not ready for deletion", HttpStatus.SC_BAD_REQUEST);
         }
+        // Remove dangling sharing artifacts before getting rid of tokens
+        this.authorizer.selfDestruct(user);
 
         List<Token> byUserId = tokenDAO.findByUserId(user.getId());
         for (Token token : byUserId) {

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/InMemoryPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/InMemoryPermissionsImplTest.java
@@ -157,4 +157,16 @@ public class InMemoryPermissionsImplTest {
         Assert.assertTrue(inMemoryPermissions.isSharing(johnDoeUser));
     }
 
+    public void testSelfDestruct() {
+        // Nothing shared at all
+        Assert.assertFalse(inMemoryPermissions.isSharing(johnDoeUser));
+
+        inMemoryPermissions.selfDestruct(johnDoeUser);
+        // Share with Jane
+        final Permission permission = new Permission("jane", Role.OWNER);
+        inMemoryPermissions.setPermission(johnDoeUser, fooWorkflow, permission);
+        thrown.expect(CustomWebApplicationException.class);
+        inMemoryPermissions.selfDestruct(johnDoeUser);
+    }
+
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/InMemoryPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/InMemoryPermissionsImplTest.java
@@ -45,6 +45,7 @@ public class InMemoryPermissionsImplTest {
         profile.email = JOHN_DOE_EXAMPLE_COM;
         johnDoeUser.getUserProfiles().put(TokenType.GOOGLE_COM.toString(), profile);
         johnDoeUser.setUsername(JOHN_DOE_EXAMPLE_COM);
+        johnDoeUser.getEntries().add(fooWorkflow);
 
         when(fooWorkflow.getUsers()).thenReturn(new HashSet<>(Arrays.asList(johnDoeUser)));
         when(gooWorkflow.getWorkflowPath()).thenReturn("goo");
@@ -145,5 +146,15 @@ public class InMemoryPermissionsImplTest {
         inMemoryPermissions.getPermissionsForWorkflow(janeDoeUser, fooWorkflow);
     }
 
+    @Test
+    public void testIsSharing() {
+        // Nothing shared at all
+        Assert.assertFalse(inMemoryPermissions.isSharing(johnDoeUser));
+
+        // Share with Jane
+        final Permission permission = new Permission("jane", Role.OWNER);
+        inMemoryPermissions.setPermission(johnDoeUser, fooWorkflow, permission);
+        Assert.assertTrue(inMemoryPermissions.isSharing(johnDoeUser));
+    }
 
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/InMemoryPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/InMemoryPermissionsImplTest.java
@@ -157,14 +157,14 @@ public class InMemoryPermissionsImplTest {
         Assert.assertTrue(inMemoryPermissions.isSharing(johnDoeUser));
     }
 
+    @Test
     public void testSelfDestruct() {
         // Nothing shared at all
         Assert.assertFalse(inMemoryPermissions.isSharing(johnDoeUser));
 
         inMemoryPermissions.selfDestruct(johnDoeUser);
         // Share with Jane
-        final Permission permission = new Permission("jane", Role.OWNER);
-        inMemoryPermissions.setPermission(johnDoeUser, fooWorkflow, permission);
+        inMemoryPermissions.setPermission(johnDoeUser, fooWorkflow, new Permission("jane", Role.OWNER));
         thrown.expect(CustomWebApplicationException.class);
         inMemoryPermissions.selfDestruct(johnDoeUser);
     }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/PermissionsInterfaceTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/PermissionsInterfaceTest.java
@@ -80,6 +80,16 @@ public class PermissionsInterfaceTest {
             public boolean canDoAction(User user, Workflow workflow, Role.Action action) {
                 return false;
             }
+
+            @Override
+            public void selfDestruct(User user) {
+
+            }
+
+            @Override
+            public boolean isSharing(User user) {
+                return false;
+            }
         };
     }
 


### PR DESCRIPTION
#1719 

1. Add new new methods to PermissionsInterface:
    1. `isSharing`
    2. `selfDestruct`
2. In `ExtendedUserData`, call `Permissions.isSharing()` to check if user is sharing anything.
3. In `SamPermissionsImpl`, if user is not sharing anything, remove resources from SAM

Had to inject `PermissionsInterface` instance into `User`
