### PR TITLE
Address SAM edge cases

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamConstants.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamConstants.java
@@ -12,10 +12,6 @@ public interface SamConstants {
     String WRITE_POLICY = "writer";
     String OWNER_POLICY = "owner";
 
-    // SAM role names
-    String READ_ROLE = "reader";
-    String WRITE_ROLE = "writer";
-    String OWNER_ROLE = "owner";
 
     enum SamActions {
         DELETE("delete"),

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
@@ -100,6 +100,7 @@ public class SamPermissionsImpl implements PermissionsInterface {
                     encodedPath).stream().filter(entry -> entry.getPolicy().getMemberEmails().contains(permission.getEmail()))
                     .collect(Collectors.toList());
             final String samPolicyName = permissionSamMap.get(permission.getRole());
+            ensurePolicyExists(policyList, samPolicyName, encodedPath, resourcesApi);
             // If the email does not already belong to the policy, add it.
             if (!policyList.stream().anyMatch(entry -> entry.getPolicyName().equals(samPolicyName))) {
                 resourcesApi.addUserToPolicy(SamConstants.RESOURCE_TYPE, encodedPath, samPolicyName,
@@ -122,6 +123,13 @@ public class SamPermissionsImpl implements PermissionsInterface {
 
     ResourcesApi getResourcesApi(User requester) {
         return new ResourcesApi(getApiClient(requester));
+    }
+
+    private void ensurePolicyExists(List<AccessPolicyResponseEntry> policyList, String policyName, String resourceId, ResourcesApi resourcesApi)
+            throws ApiException {
+        if (policyList.stream().noneMatch(policy -> policyName.equals(policy.getPolicyName()))) {
+            addPolicy(resourcesApi, resourceId, policyName);
+        }
     }
 
     private List<AccessPolicyResponseEntry> ensureResourceExists(Workflow workflow, User requester, ResourcesApi resourcesApi, String encodedPath) {
@@ -205,7 +213,8 @@ public class SamPermissionsImpl implements PermissionsInterface {
             return PermissionsInterface.mergePermissions(dockstoreOwners, removeDuplicateEmails(samPermissions));
         } catch (ApiException e) {
             final String errorGettingPermissions = "Error getting permissions";
-            if (e.getCode() != HttpStatus.SC_NOT_FOUND) { // If 404, SAM resource has not been created; just return Dockstore owners
+            // 404 - SAM resource has not been created, or user doesn't have access; just return Dockstore owners
+            if (e.getCode() != HttpStatus.SC_NOT_FOUND) {
                 throw new CustomWebApplicationException(errorGettingPermissions, e.getCode());
             }
         }
@@ -279,17 +288,35 @@ public class SamPermissionsImpl implements PermissionsInterface {
         String encodedPath = encodedWorkflowResource(workflow, resourcesApi.getApiClient());
         try {
             resourcesApi.createResourceWithDefaults(SamConstants.RESOURCE_TYPE, encodedPath);
-
-            final AccessPolicyMembership writerPolicy = new AccessPolicyMembership();
-            writerPolicy.addRolesItem("writer");
-            resourcesApi.overwritePolicy(SamConstants.RESOURCE_TYPE, encodedPath, SamConstants.WRITE_POLICY, writerPolicy);
-
-            final AccessPolicyMembership readerPolicy = new AccessPolicyMembership();
-            readerPolicy.addRolesItem("reader");
-            resourcesApi.overwritePolicy(SamConstants.RESOURCE_TYPE, encodedPath, SamConstants.READ_POLICY, readerPolicy);
+            addPolicy(resourcesApi, encodedPath, SamConstants.WRITE_POLICY);
+            addPolicy(resourcesApi, encodedPath, SamConstants.READ_POLICY);
         } catch (ApiException e) {
-            throw new CustomWebApplicationException("Error initializing permissions", e.getCode());
+            if (e.getCode() == HttpStatus.SC_CONFLICT) {
+                handleConflict(encodedPath);
+            } else {
+                throw new CustomWebApplicationException("Error initializing permissions", e.getCode());
+            }
         }
+    }
+
+    private void addPolicy(ResourcesApi resourcesApi, String resourceId, String policyName) throws ApiException {
+        final AccessPolicyMembership policy = new AccessPolicyMembership();
+        policy.addRolesItem(policyName); // The role name and the policy name are the same
+        resourcesApi.overwritePolicy(SamConstants.RESOURCE_TYPE, resourceId, policyName, policy);
+
+    }
+
+    /**
+     * Handles the case where a SAM resource already exists for this workflow. In normal usage of Dockstore APIs
+     * this shouldn't occur, but it can happen if another user access the SAM API directly and creates the resource.
+     *
+     * @param resourceId
+     */
+    private void handleConflict(String resourceId) {
+        final String message = MessageFormat.format(
+                "An unexpected error occurred. Please send a private message to \"admins\" at https://discuss.dockstore.org and mention \"SAM {0}\"",
+                resourceId);
+        throw new CustomWebApplicationException(message, HttpStatus.SC_CONFLICT);
     }
 
     @Override

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
@@ -38,8 +38,10 @@ import org.mockito.Mockito;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -74,21 +76,21 @@ public class SamPermissionsImplTest {
         ownerPolicy = new AccessPolicyResponseEntry();
         ownerPolicy.setPolicyName(SamConstants.OWNER_POLICY);
         AccessPolicyMembership accessPolicyMembership = new AccessPolicyMembership();
-        accessPolicyMembership.setRoles(Arrays.asList(SamConstants.OWNER_ROLE));
+        accessPolicyMembership.setRoles(Arrays.asList(SamConstants.OWNER_POLICY));
         accessPolicyMembership.setMemberEmails(Arrays.asList("jdoe@ucsc.edu"));
         ownerPolicy.setPolicy(accessPolicyMembership);
 
         writerPolicy = new AccessPolicyResponseEntry();
         writerPolicy.setPolicyName(SamConstants.WRITE_POLICY);
         AccessPolicyMembership writerMembership = new AccessPolicyMembership();
-        writerMembership.setRoles(Arrays.asList(SamConstants.WRITE_ROLE));
+        writerMembership.setRoles(Arrays.asList(SamConstants.WRITE_POLICY));
         writerMembership.setMemberEmails(Arrays.asList(JANE_DOE_GMAIL_COM));
         writerPolicy.setPolicy(writerMembership);
 
         readerPolicy = new AccessPolicyResponseEntry();
         readerPolicy.setPolicyName(SamConstants.READ_POLICY);
         AccessPolicyMembership readerMembership = new AccessPolicyMembership();
-        readerMembership.setRoles(Arrays.asList(SamConstants.READ_ROLE));
+        readerMembership.setRoles(Arrays.asList(SamConstants.READ_POLICY));
         readerMembership.setMemberEmails(Arrays.asList(JANE_DOE_GMAIL_COM));
         readerPolicy.setPolicy(readerMembership);
 
@@ -488,6 +490,35 @@ public class SamPermissionsImplTest {
         thrown.expect(CustomWebApplicationException.class);
         samPermissionsImpl.selfDestruct(userMock);
 
+    }
+
+    @Test
+    public void testSetPermissionWhenResourceCreatedWithoutAllPolicies() throws ApiException {
+        when(fooWorkflow.getUsers()).thenReturn(new HashSet<>(Arrays.asList(userMock)));
+        final String resourceId = SamConstants.ENCODED_WORKFLOW_PREFIX + FOO_WORKFLOW_NAME;
+        ResourceAndAccessPolicy owner = resourceAndAccessPolicyHelper(resourceId, SamConstants.OWNER_POLICY);
+        when(resourcesApiMock.listResourcesAndPolicies(SamConstants.RESOURCE_TYPE))
+                .thenReturn(Arrays.asList(owner));
+        setupInitializePermissionsMocks(resourceId);
+        samPermissionsImpl.setPermission(userMock, fooWorkflow, new Permission("johndoe@example.com", Role.WRITER));
+        verify(resourcesApiMock, times(1)).overwritePolicy(eq(SamConstants.RESOURCE_TYPE), anyString(), eq(SamConstants.WRITE_POLICY), any());
+    }
+
+    @Test
+    public void testSamPolicyOwnedbyAnother() throws ApiException {
+        when(fooWorkflow.getUsers()).thenReturn(new HashSet<>(Arrays.asList(userMock)));
+        final String resourceId = SamConstants.WORKFLOW_PREFIX + FOO_WORKFLOW_NAME;
+        when(resourcesApiMock.listResourcePolicies(SamConstants.RESOURCE_TYPE, resourceId))
+                .thenThrow(new ApiException(HttpStatus.SC_NOT_FOUND, "")); // If you don't have permissions, you get a 404
+        doThrow(new ApiException(HttpStatus.SC_CONFLICT, ""))
+                .when(resourcesApiMock)
+                .createResourceWithDefaults(SamConstants.RESOURCE_TYPE, resourceId);
+        try {
+            samPermissionsImpl.setPermission(userMock, fooWorkflow, new Permission("johndoe@example.com", Role.WRITER));
+            Assert.fail("Expected setPermission to throw exception");
+        } catch (CustomWebApplicationException ex) {
+            Assert.assertTrue(ex.getMessage().contains(" 409 "));
+        }
     }
 
     private void setupInitializePermissionsMocks(String encodedPath) {

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
@@ -492,6 +492,18 @@ public class SamPermissionsImplTest {
 
     }
 
+    /**
+     * Tests this use case:
+     *
+     * <ol>
+     *     <li>User creates a SAM resource with the SAM API directly. When you do that, the writer and reader policies are
+     *     not added.</li>
+     *     <li>Using Dockstore API, user then adds an email to Writer role.</li>
+     * </ol>
+     *
+     * This tests that the writer policy gets added to the resource.
+     * @throws ApiException
+     */
     @Test
     public void testSetPermissionWhenResourceCreatedWithoutAllPolicies() throws ApiException {
         when(fooWorkflow.getUsers()).thenReturn(new HashSet<>(Arrays.asList(userMock)));


### PR DESCRIPTION
#1713

1. If a SAM resource was created by another user directly in the SAM
API, handles the 409 status code by returning a message indicating
user should contact Dockstore admins at discuss.dockstore.org
2. If a SAM resource was created in the SAM API by the same user, but
without all 3 policies, create the additional policies as needed.

Also got rid of SAM role name constants, since they are duplicates
of the policy names. Made writing some code easier.