### PR TITLE
Fix check to avoid null pointer

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -913,7 +913,7 @@ public class SwaggerClientIT extends BaseIT {
 
     private SourceFile createCwlWorkflow() {
         SourceFile fileCWL = new SourceFile();
-        fileCWL.setContent("class: Workflow"); // Need this for CWLHandler:isValidWorkflow
+        fileCWL.setContent("class: Workflow\ncwlVersion: v1.0"); // Need this for CWLHandler:isValidWorkflow
         fileCWL.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
         fileCWL.setPath("/Dockstore.cwl");
         return fileCWL;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -755,7 +755,7 @@ public class WorkflowIT extends BaseIT {
             workflowApi.allPublishedWorkflows(null, null, null, null, null).size());
         final long count3 = testingPostgres
                 .runSelectStatement("select count(*) from workflow where mode = '" + Workflow.ModeEnum.FULL + "'", new ScalarHandler<>());
-        assertEquals("Two workflows are in full mode", 1, count3);
+        assertEquals("One workflow is in full mode", 1, count3);
         final long count4 = testingPostgres
                 .runSelectStatement("select count(*) from workflowversion where valid = 't'", new ScalarHandler<>());
         assertEquals("There should be 2 valid version tags, there are " + count4, 2, count4);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -688,7 +688,7 @@ public class WorkflowIT extends BaseIT {
         assertNotNull("did not get published workflow", publishedWorkflowByPath);
 
         // publish everything so pagination testing makes more sense (going to unfortunately use rate limit)
-        Lists.newArrayList("github.com/DockstoreTestUser2/hello-dockstore-workflow", "github.com/DockstoreTestUser2/dockstore-whalesay-imports", "bitbucket.org/dockstore_testuser2/dockstore-workflow", "github.com/DockstoreTestUser2/parameter_test_workflow").forEach(path -> {
+        Lists.newArrayList("github.com/DockstoreTestUser2/hello-dockstore-workflow", "github.com/DockstoreTestUser2/dockstore-whalesay-imports", "github.com/DockstoreTestUser2/parameter_test_workflow").forEach(path -> {
             Workflow workflow = workflowApi.getWorkflowByPath(path);
             workflowApi.refresh(workflow.getId());
             workflowApi.publish(workflow.getId(), publishRequest);
@@ -750,19 +750,20 @@ public class WorkflowIT extends BaseIT {
         workflowApi.refresh(githubWorkflow.getId());
         workflowApi.publish(githubWorkflow.getId(), publishRequest);
 
-        // Publish bitbucket workflow
-        workflowApi.refresh(bitbucketWorkflow.getId());
-        workflowApi.publish(bitbucketWorkflow.getId(), publishRequest);
-
         // Assert some things
-        assertEquals("should have two published, found  " + workflowApi.allPublishedWorkflows(null, null, null, null, null).size(), 2,
+        assertEquals("should have two published, found  " + workflowApi.allPublishedWorkflows(null, null, null, null, null).size(), 1,
             workflowApi.allPublishedWorkflows(null, null, null, null, null).size());
         final long count3 = testingPostgres
                 .runSelectStatement("select count(*) from workflow where mode = '" + Workflow.ModeEnum.FULL + "'", new ScalarHandler<>());
-        assertEquals("Two workflows are in full mode", 2, count3);
+        assertEquals("Two workflows are in full mode", 1, count3);
         final long count4 = testingPostgres
                 .runSelectStatement("select count(*) from workflowversion where valid = 't'", new ScalarHandler<>());
-        assertEquals("There should be 5 valid version tags, there are " + count4, 6, count4);
+        assertEquals("There should be 2 valid version tags, there are " + count4, 2, count4);
+
+        workflowApi.refresh(bitbucketWorkflow.getId());
+        thrown.expect(ApiException.class);
+        // Publish bitbucket workflow, will fail now since the workflow test case is actually invalid now
+        workflowApi.publish(bitbucketWorkflow.getId(), publishRequest);
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -186,8 +186,8 @@ public class WorkflowIT extends BaseIT {
         assertEquals("should find 4 versions with files for bitbucket workflow, found : " + refreshBitbucket.getWorkflowVersions().stream()
                 .filter(workflowVersion -> !workflowVersion.getSourceFiles().isEmpty()).count(), 4,
             refreshBitbucket.getWorkflowVersions().stream().filter(workflowVersion -> !workflowVersion.getSourceFiles().isEmpty()).count());
-        assertEquals("should find 4 valid versions for bitbucket workflow, found : " + refreshBitbucket.getWorkflowVersions().stream()
-                .filter(WorkflowVersion::isValid).count(), 4,
+        assertEquals("should find 0 valid versions for bitbucket workflow, found : " + refreshBitbucket.getWorkflowVersions().stream()
+                .filter(WorkflowVersion::isValid).count(), 0,
             refreshBitbucket.getWorkflowVersions().stream().filter(WorkflowVersion::isValid).count());
 
         // should not be able to get content normally
@@ -196,24 +196,24 @@ public class WorkflowIT extends BaseIT {
         boolean exceptionThrown = false;
         try {
             anonymousGa4Ghv2Api
-                .toolsIdVersionsVersionIdTypeDescriptorGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_DOCKSTORE_WORKFLOW, "master");
+                .toolsIdVersionsVersionIdTypeDescriptorGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW, "master");
         } catch (ApiException e) {
             exceptionThrown = true;
         }
         assertTrue(exceptionThrown);
         FileWrapper adminToolDescriptor = adminGa4Ghv2Api
-            .toolsIdVersionsVersionIdTypeDescriptorGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_DOCKSTORE_WORKFLOW, "master");
+            .toolsIdVersionsVersionIdTypeDescriptorGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW, "testCWL");
         assertTrue("could not get content via optional auth", adminToolDescriptor != null && !adminToolDescriptor.getContent().isEmpty());
 
-        workflowApi.publish(workflowByPathBitbucket.getId(), new PublishRequest(){
+        workflowApi.publish(refreshGithub.getId(), new PublishRequest(){
             public Boolean isPublish() { return true;}
         });
         // check on URLs for workflows via ga4gh calls
         FileWrapper toolDescriptor = adminGa4Ghv2Api
-            .toolsIdVersionsVersionIdTypeDescriptorGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_DOCKSTORE_WORKFLOW, "master");
+            .toolsIdVersionsVersionIdTypeDescriptorGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW, "testCWL");
         String content = IOUtils.toString(new URI(toolDescriptor.getUrl()), StandardCharsets.UTF_8);
         Assert.assertTrue("could not find content from generated URL", !content.isEmpty());
-        checkForRelativeFile(adminGa4Ghv2Api, "#workflow/" + DOCKSTORE_TEST_USER2_DOCKSTORE_WORKFLOW, "master", "grep.cwl");
+        checkForRelativeFile(adminGa4Ghv2Api, "#workflow/" + DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW, "testCWL", "Dockstore.cwl");
 
 
         // check on commit ids for github

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
@@ -185,18 +185,10 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
         if (!Strings.isNullOrEmpty(content)) {
             file = new SourceFile();
             // Grab content from found file
-
-            // Is workflow descriptor valid?
-            boolean validWorkflow = true;
-            if (LanguageHandlerFactory.isWorkflow(type)) {
-                validWorkflow = LanguageHandlerFactory.getInterface(type).isValidWorkflow(content);
-            }
-
-            if (validWorkflow) {
-                file.setType(type);
-                file.setContent(content);
-                file.setPath(path);
-            }
+            // do not censor invalid versions to match github expected behaviour
+            file.setType(type);
+            file.setContent(content);
+            file.setPath(path);
         }
         return file;
     }
@@ -308,9 +300,9 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
                     // TODO: No exceptions are caught here in the event of a failed call
                     SourceFile sourceFile = getSourceFile(calculatedPath, repositoryId, branchName, identifiedType);
 
-                    // Non-null sourcefile means that the sourcefile is valid
+                    // validity is checked just for the root description
                     if (sourceFile != null) {
-                        version.setValid(true);
+                        version.setValid(LanguageHandlerFactory.getInterface(identifiedType).isValidWorkflow(sourceFile.getContent()));
                     }
 
                     // Use default test parameter file if either new version or existing version that hasn't been edited

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -137,7 +137,8 @@ public class CWLHandler implements LanguageHandlerInterface {
 
     @Override
     public boolean isValidWorkflow(String content) {
-        return content.contains("class: Workflow");
+        Yaml yaml = new Yaml();
+        return content.contains("class: Workflow") && this.isValidCwl(content, yaml);
     }
 
     @Override
@@ -609,10 +610,14 @@ public class CWLHandler implements LanguageHandlerInterface {
     private boolean isValidCwl(String content, Yaml yaml) {
         try {
             Map<String, Object> mapping = yaml.loadAs(content, Map.class);
-            String cwlVersion = mapping.get("cwlVersion").toString();
+            final Object cwlVersion = mapping.get("cwlVersion");
 
             if (cwlVersion != null) {
-                return "v1.0".equals(cwlVersion);
+                final boolean equals = cwlVersion.toString().startsWith("v1");
+                if (!equals) {
+                    LOG.error("detected invalid version: " + cwlVersion.toString());
+                }
+                return equals;
             }
         } catch (ClassCastException e) {
             return false;


### PR DESCRIPTION
* null pointer was killing check and causing invalid workflows to be shown as valid
* a valid CWL workflow could be invalid CWL, which is confusing (i.e. all valid CWL workflows should valid CWL)
