### PR TITLE
Fix owner losing permissions to their own SAM resource

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -881,8 +881,7 @@ public class WorkflowResource
         if (workflow.getMode() != WorkflowMode.HOSTED) {
             throw new CustomWebApplicationException("Setting permissions is only allowed on hosted workflows.", HttpStatus.SC_BAD_REQUEST);
         }
-        this.permissionsInterface.setPermission(user, workflow, permission);
-        return this.permissionsInterface.getPermissionsForWorkflow(user, workflow);
+        return this.permissionsInterface.setPermission(user, workflow, permission);
     }
 
     @DELETE

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ info:
     This describes the dockstore API, a webservice that manages pairs of Docker
     images and associated metadata such as CWL documents and Dockerfiles used to
     build those images
-  version: 1.5.0-rc.0-SNAPSHOT
+  version: 1.5.0-rc.2-SNAPSHOT
   title: Dockstore API
   termsOfService: TBD
   contact:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.5.0-rc.0-SNAPSHOT"
+  version: "1.5.0-rc.2-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
@@ -533,6 +533,17 @@ public class SamPermissionsImplTest {
         }
     }
 
+    @Test
+    public void testAddingOwnerDoesNotCreateSecondOwnerPolicy() throws ApiException { //https://github.com/ga4gh/dockstore/issues/1805
+        when(fooWorkflow.getUsers()).thenReturn(new HashSet<>(Arrays.asList(userMock)));
+        final String resourceId = SamConstants.ENCODED_WORKFLOW_PREFIX + FOO_WORKFLOW_NAME;
+        ResourceAndAccessPolicy owner = resourceAndAccessPolicyHelper(resourceId, SamConstants.OWNER_POLICY);
+        when(resourcesApiMock.listResourcesAndPolicies(SamConstants.RESOURCE_TYPE))
+                .thenReturn(Arrays.asList(owner));
+        samPermissionsImpl.setPermission(userMock, fooWorkflow, new Permission("johndoe@example.com", Role.OWNER));
+        verify(resourcesApiMock, times(0)).overwritePolicy(eq(SamConstants.RESOURCE_TYPE), anyString(), eq(SamConstants.OWNER_POLICY), any());
+    }
+
     private void setupInitializePermissionsMocks(String encodedPath) {
         try {
             doNothing().when(resourcesApiMock).createResourceWithDefaults(anyString(), anyString());


### PR DESCRIPTION
#1805

Problem was that a new owner policy was being created when adding
another owner, and the new owner policy only added the new owner.

1. We don't need to ever create an owner policy explicitly, as SAM
is configured for dockstore-tool resource to always create a default
owner policy. This is unlike the writer and reader policies, which we do
need to explicitly create.
2. The problem originated in that I was passing the list of policies
the new user already belonged to ensurePolicyExists(), which would
check to see if the owner policy existed, and it wasn't in the list.
3. Two fixes for that, to be safe.
    1. Don't ever let ensurePolicyExists() create an owner policy
    2. Pass all of a resource's existing policies to ensurePolicyExists,
    instead of just the ones the new user already belongs to.
4. In doing that, I noticed that initializePermissions was not
returning the policy's permissions.
5. Finally, in looking at this, I noticed the setPermission already
returns the list of permissions, and WorkflowResource was
unnecessarily fetching them again.
