### PR TITLE
Preserve newlines when reading imported files

### DIFF
--- a/dockstore-common/src/main/java/io/github/collaboratory/wdl/BridgeHelper.java
+++ b/dockstore-common/src/main/java/io/github/collaboratory/wdl/BridgeHelper.java
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
  */
 public class BridgeHelper {
     private static final Logger LOG = LoggerFactory.getLogger(BridgeHelper.class);
-    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
     /**
      * This resolves a URL into file content

--- a/dockstore-common/src/main/java/io/github/collaboratory/wdl/BridgeHelper.java
+++ b/dockstore-common/src/main/java/io/github/collaboratory/wdl/BridgeHelper.java
@@ -16,11 +16,8 @@
 
 package io.github.collaboratory.wdl;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -28,6 +25,7 @@ import java.util.Map;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
+import com.google.common.io.Resources;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +44,7 @@ public class BridgeHelper {
      * @return content of file
      */
     public String resolveUrl(String importUrl) {
-        StringBuilder content = new StringBuilder();
+        String content = "";
 
         // Check if valid URL
         UrlValidator urlValidator = new UrlValidator();
@@ -56,15 +54,7 @@ public class BridgeHelper {
                     .startsWith("https://gitlab.com")) {
                 // Grab file located at URL
                 try {
-                    try (InputStream inputStream = new URL(importUrl).openStream()) {
-                        InputStreamReader inputStreamReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-                        BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
-                        String line;
-                        while ((line = bufferedReader.readLine()) != null) {
-                            content.append(line);
-                            content.append(LINE_SEPARATOR);
-                        }
-                    }
+                    content = Resources.toString(new URL(importUrl), StandardCharsets.UTF_8);
                 } catch (MalformedURLException ex) {
                     LOG.debug("Invalid URL: " + importUrl);
                 } catch (IOException ex) {
@@ -76,7 +66,7 @@ public class BridgeHelper {
         } else {
             LOG.debug("Invalid URL: " + importUrl);
         }
-        return content.toString();
+        return content;
     }
 
     /**

--- a/dockstore-common/src/main/java/io/github/collaboratory/wdl/BridgeHelper.java
+++ b/dockstore-common/src/main/java/io/github/collaboratory/wdl/BridgeHelper.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public class BridgeHelper {
     private static final Logger LOG = LoggerFactory.getLogger(BridgeHelper.class);
+    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
     /**
      * This resolves a URL into file content
@@ -61,6 +62,7 @@ public class BridgeHelper {
                         String line;
                         while ((line = bufferedReader.readLine()) != null) {
                             content.append(line);
+                            content.append(LINE_SEPARATOR);
                         }
                     }
                 } catch (MalformedURLException ex) {


### PR DESCRIPTION
#1847

Newlines were being lost when reading the file from a url, so the WDL
parser would not be able to parse the content correctly.

