### PR TITLE
Feature/wdl validation

### DIFF
--- a/dockstore-common/src/main/scala/io/dockstore/common/Bridge.scala
+++ b/dockstore-common/src/main/scala/io/dockstore/common/Bridge.scala
@@ -90,7 +90,6 @@ class Bridge(basePath : String) {
     * @param file
     * @throws wdl4s.parser.WdlParser.SyntaxError
     * @throws java.lang.NullPointerException
-    * @return
     */
   @throws(classOf[WdlParser.SyntaxError])
   @throws(classOf[NullPointerException])

--- a/dockstore-common/src/main/scala/io/dockstore/common/Bridge.scala
+++ b/dockstore-common/src/main/scala/io/dockstore/common/Bridge.scala
@@ -85,6 +85,13 @@ class Bridge(basePath : String) {
     }
   }
 
+  /**
+    * Will throw an error if the file is an invalid workflow
+    * @param file
+    * @throws wdl4s.parser.WdlParser.SyntaxError
+    * @throws java.lang.NullPointerException
+    * @return
+    */
   @throws(classOf[WdlParser.SyntaxError])
   @throws(classOf[NullPointerException])
   def isValidWorkflow(file: JFile) = {
@@ -92,6 +99,12 @@ class Bridge(basePath : String) {
       WdlNamespaceWithWorkflow.load(lines, Seq(resolveHttpAndSecondaryFiles _)).get
   }
 
+  /**
+    * Will throw an error if the file is an invalid tool
+    * @param file
+    * @throws wdl4s.parser.WdlParser.SyntaxError
+    * @throws java.lang.NullPointerException
+    */
   @throws(classOf[WdlParser.SyntaxError])
   @throws(classOf[NullPointerException])
   def isValidTool(file: JFile) = {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ValidationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ValidationIT.java
@@ -132,6 +132,10 @@ public class ValidationIT extends BaseIT {
         return false;
     }
 
+    /**
+     * Tests that we properly validate WDL workflows
+     * Requires GitHub Repo DockstoreTestUser2/TestEntryValidation, master branch
+     */
     @Test
     public void testWdlWorkflow() {
         // Setup webservice and get workflows api
@@ -194,6 +198,10 @@ public class ValidationIT extends BaseIT {
         Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
     }
 
+    /**
+     * Tests that we properly validate CWL workflows
+     * Requires GitHub Repo DockstoreTestUser2/TestEntryValidation, master branch
+     */
     @Test
     public void testCwlWorkflow() {
         // Setup webservice and get workflows api
@@ -251,6 +259,7 @@ public class ValidationIT extends BaseIT {
 
     /**
      * This tests that validation works as expected on tools for CWL and WDL
+     * Requires GitHub Repo DockstoreTestUser2/TestEntryValidation, master branch
      */
     @Test
     public void testTool() {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ValidationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ValidationIT.java
@@ -1,0 +1,379 @@
+package io.dockstore.client.cli;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.dockstore.common.CommonTestUtilities;
+import io.dockstore.common.ConfidentialTest;
+import io.dockstore.common.Registry;
+import io.swagger.client.ApiClient;
+import io.swagger.client.ApiException;
+import io.swagger.client.api.ContainersApi;
+import io.swagger.client.api.WorkflowsApi;
+import io.swagger.client.model.DockstoreTool;
+import io.swagger.client.model.Tag;
+import io.swagger.client.model.Workflow;
+import io.swagger.client.model.WorkflowVersion;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
+import org.junit.experimental.categories.Category;
+
+
+/**
+ * @author aduncan
+ */
+@Category({ ConfidentialTest.class})
+public class ValidationIT extends BaseIT {
+
+    @Rule
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+
+    @Rule
+    public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
+
+    @Before
+    @Override
+    public void resetDBBetweenTests() throws Exception {
+        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
+    }
+
+    /**
+     * this method will set up the webservice and return the container api
+     *
+     * @return ContainersApi
+     * @throws ApiException
+     */
+    private ContainersApi setupToolWebService() throws ApiException {
+        ApiClient client = getWebClient(USER_2_USERNAME);
+        return new ContainersApi(client);
+    }
+
+    /**
+     * this method will set up the webservice and return the workflows api
+     *
+     * @return WorkflowsApi
+     * @throws ApiException
+     */
+    private WorkflowsApi setupWorkflowWebService() throws ApiException {
+        ApiClient client = getWebClient(USER_2_USERNAME);
+        return new WorkflowsApi(client);
+    }
+
+    private DockstoreTool getTool() {
+        DockstoreTool c = new DockstoreTool();
+        c.setMode(DockstoreTool.ModeEnum.MANUAL_IMAGE_PATH);
+        c.setName("dockstore-tool-validation");
+        c.setGitUrl("https://github.com/DockstoreTestUser2/TestEntryValidation");
+        c.setDefaultDockerfilePath("/Dockerfile");
+        c.setDefaultCwlPath("/validTool.cwl");
+        c.setRegistryString(Registry.DOCKER_HUB.toString());
+        c.setIsPublished(false);
+        c.setNamespace("DockstoreTestUser2");
+        c.setToolname("test5");
+        c.setPath("registry.hub.docker.com/dockstoretestuser2/dockstore-tool-validation");
+
+        Tag tag = new Tag();
+        tag.setName("master");
+        tag.setReference("master");
+        tag.setValid(true);
+        tag.setImageId("123456");
+        tag.setCwlPath(c.getDefaultCwlPath());
+        tag.setWdlPath(c.getDefaultWdlPath());
+        List<Tag> tags = new ArrayList<>();
+        tags.add(tag);
+        c.setTags(tags);
+
+        return c;
+    }
+
+    /**
+     * Returns whether a version with the given name for a workflow is valid or not
+     * @param workflow
+     * @param name
+     * @return is workflow version valid
+     */
+    protected boolean isWorkflowVersionValid(Workflow workflow, String name) {
+        Optional<WorkflowVersion> workflowVersion = workflow.getWorkflowVersions()
+                .stream()
+                .filter(version -> Objects.equals(name, version.getName()))
+                .findFirst();
+
+        if (workflowVersion.isPresent()) {
+            return workflowVersion.get().isValid();
+        }
+        return false;
+    }
+
+    /**
+     * Returns whether a tag with the given name for a tool is valid or not
+     * @param tool
+     * @param name
+     * @return is tag valid
+     */
+    protected boolean isTagValid(DockstoreTool tool, String name) {
+        Optional<Tag> tag = tool.getTags()
+                .stream()
+                .filter(version -> Objects.equals(name, version.getName()))
+                .findFirst();
+
+        if (tag.isPresent()) {
+            return tag.get().isValid();
+        }
+        return false;
+    }
+
+    @Test
+    public void testWdlWorkflow() {
+        // Setup webservice and get workflows api
+        WorkflowsApi workflowsApi = setupWorkflowWebService();
+
+        // Register a workflow
+        Workflow workflow = workflowsApi.manualRegister("GitHub", "DockstoreTestUser2/TestEntryValidation", "/validWorkflow.wdl", "testname", "wdl", "/test.json");
+        workflow = workflowsApi.refresh(workflow.getId());
+        Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
+
+        // change to empty wdl - should be invalid
+        workflow.setWorkflowPath("empty.wdl");
+        workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
+        workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
+        workflow = workflowsApi.refresh(workflow.getId());
+        Assert.assertTrue("Should be invalid", !isWorkflowVersionValid(workflow, "master"));
+
+        // change to missing import - should be invalid
+        workflow.setWorkflowPath("missingImport.wdl");
+        workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
+        workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
+        workflow = workflowsApi.refresh(workflow.getId());
+        Assert.assertTrue("Should be invalid", !isWorkflowVersionValid(workflow, "master"));
+
+        // change to missing workflow section - should be invalid
+        workflow.setWorkflowPath("missingWorkflowSection.wdl");
+        workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
+        workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
+        workflow = workflowsApi.refresh(workflow.getId());
+        Assert.assertTrue("Should be invalid", !isWorkflowVersionValid(workflow, "master"));
+
+        // change to valid tool - should be valid
+        workflow.setWorkflowPath("validTool.wdl");
+        workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
+        workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
+        workflow = workflowsApi.refresh(workflow.getId());
+        Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
+
+        // change back to valid workflow - should be valid
+        workflow.setWorkflowPath("validWorkflow.wdl");
+        workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
+        workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
+        workflow = workflowsApi.refresh(workflow.getId());
+        Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
+
+        // add invalid test json - should be invalid
+        List<String> testParameterFiles = new ArrayList<>();
+        testParameterFiles.add("/invalidJson.json");
+        workflowsApi.addTestParameterFiles(workflow.getId(), testParameterFiles, "", "master");
+        workflow = workflowsApi.refresh(workflow.getId());
+        Assert.assertTrue("Should be invalid", !isWorkflowVersionValid(workflow, "master"));
+        workflowsApi.deleteTestParameterFiles(workflow.getId(), testParameterFiles, "master");
+        workflow = workflowsApi.refresh(workflow.getId());
+
+        // add valid test json - should again be valid
+        testParameterFiles = new ArrayList<>();
+        testParameterFiles.add("/valid.json");
+        workflowsApi.addTestParameterFiles(workflow.getId(), testParameterFiles, "", "master");
+        workflow = workflowsApi.refresh(workflow.getId());
+        Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
+    }
+
+    @Test
+    public void testCwlWorkflow() {
+        // Setup webservice and get workflows api
+        WorkflowsApi workflowsApi = setupWorkflowWebService();
+
+        // Register a workflow
+        Workflow workflow = workflowsApi.manualRegister("GitHub", "DockstoreTestUser2/TestEntryValidation", "/validWorkflow.cwl", "testname", "cwl", "/test.json");
+        workflow = workflowsApi.refresh(workflow.getId());
+        Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
+
+        // change to empty cwl - should be invalid
+        workflow.setWorkflowPath("empty.cwl");
+        workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
+        workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
+        workflow = workflowsApi.refresh(workflow.getId());
+        Assert.assertTrue("Should be invalid", !isWorkflowVersionValid(workflow, "master"));
+
+        // change to wrong version - should be invalid
+        workflow.setWorkflowPath("wrongVersion.cwl");
+        workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
+        workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
+        workflow = workflowsApi.refresh(workflow.getId());
+        Assert.assertTrue("Should be invalid", !isWorkflowVersionValid(workflow, "master"));
+
+        // change to tool - should be invalid
+        workflow.setWorkflowPath("validTool.cwl");
+        workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
+        workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
+        workflow = workflowsApi.refresh(workflow.getId());
+        Assert.assertTrue("Should be invalid", !isWorkflowVersionValid(workflow, "master"));
+
+        // change back to valid workflow - should be valid
+        workflow.setWorkflowPath("validWorkflow.cwl");
+        workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
+        workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
+        workflow = workflowsApi.refresh(workflow.getId());
+        Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
+
+        // add invalid test json - should be invalid
+        List<String> testParameterFiles = new ArrayList<>();
+        testParameterFiles.add("/invalidJson.json");
+        workflowsApi.addTestParameterFiles(workflow.getId(), testParameterFiles, "", "master");
+        workflow = workflowsApi.refresh(workflow.getId());
+        Assert.assertTrue("Should be invalid", !isWorkflowVersionValid(workflow, "master"));
+        workflowsApi.deleteTestParameterFiles(workflow.getId(), testParameterFiles, "master");
+        workflow = workflowsApi.refresh(workflow.getId());
+
+        // add valid test json - should again be valid
+        testParameterFiles = new ArrayList<>();
+        testParameterFiles.add("/valid.json");
+        workflowsApi.addTestParameterFiles(workflow.getId(), testParameterFiles, "", "master");
+        workflow = workflowsApi.refresh(workflow.getId());
+        Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
+    }
+
+    /**
+     * This tests that validation works as expected on tools for CWL and WDL
+     */
+    @Test
+    public void testTool() {
+        // Setup webservice and get tool api
+        ContainersApi toolsApi = setupToolWebService();
+
+        // Register tool, should be valid
+        DockstoreTool tool = getTool();
+        tool = toolsApi.registerManual(tool);
+        tool = toolsApi.refresh(tool.getId());
+        Assert.assertTrue("Should be valid", isTagValid(tool, "master"));
+
+        // Change to a workflow (not a valid tool)
+        tool.setDefaultCwlPath("/validWorkflow.cwl");
+        tool = toolsApi.updateContainer(tool.getId(), tool);
+        toolsApi.updateTagContainerPath(tool.getId(), tool);
+        tool = toolsApi.refresh(tool.getId());
+        Assert.assertTrue("Should be invalid", !isTagValid(tool, "master"));
+
+        // Change to invalid cwl version
+        tool.setDefaultCwlPath("/wrongVersion.cwl");
+        tool = toolsApi.updateContainer(tool.getId(), tool);
+        toolsApi.updateTagContainerPath(tool.getId(), tool);
+        tool = toolsApi.refresh(tool.getId());
+        Assert.assertTrue("Should be invalid", !isTagValid(tool, "master"));
+
+        // Change to valid cwl tool
+        tool.setDefaultCwlPath("/validTool.cwl");
+        tool = toolsApi.updateContainer(tool.getId(), tool);
+        toolsApi.updateTagContainerPath(tool.getId(), tool);
+        tool = toolsApi.refresh(tool.getId());
+        Assert.assertTrue("Should be valid", isTagValid(tool, "master"));
+
+        // Add invalid json cwl - should be invalid
+        List<String> testParameterFiles = new ArrayList<>();
+        testParameterFiles.add("/invalidJson.json");
+        toolsApi.addTestParameterFiles(tool.getId(), testParameterFiles, "CWL", "", "master");
+        tool = toolsApi.refresh(tool.getId());
+        Assert.assertTrue("Should be invalid", !isTagValid(tool, "master"));
+        toolsApi.deleteTestParameterFiles(tool.getId(), testParameterFiles, "CWL", "master");
+        tool = toolsApi.refresh(tool.getId());
+
+        // Add valid json cwl - should be valid
+        testParameterFiles = new ArrayList<>();
+        testParameterFiles.add("/valid.json");
+        toolsApi.addTestParameterFiles(tool.getId(), testParameterFiles, "CWL", "", "master");
+        tool = toolsApi.refresh(tool.getId());
+        Assert.assertTrue("Should be valid", isTagValid(tool, "master"));
+        toolsApi.deleteTestParameterFiles(tool.getId(), testParameterFiles, "CWL", "master");
+        tool = toolsApi.refresh(tool.getId());
+
+        // add invalid wdl - should be valid
+        tool.setDefaultWdlPath("/empty.wdl");
+        tool = toolsApi.updateContainer(tool.getId(), tool);
+        toolsApi.updateTagContainerPath(tool.getId(), tool);
+        tool = toolsApi.refresh(tool.getId());
+        Assert.assertTrue("Should be valid", isTagValid(tool, "master"));
+
+        // change cwl to invalid - should be invalid
+        tool.setDefaultCwlPath("/invalidTool.cwl");
+        tool = toolsApi.updateContainer(tool.getId(), tool);
+        toolsApi.updateTagContainerPath(tool.getId(), tool);
+        tool = toolsApi.refresh(tool.getId());
+        Assert.assertTrue("Should be invalid", !isTagValid(tool, "master"));
+
+        // make wdl valid - should be valid
+        tool.setDefaultWdlPath("/validTool.wdl");
+        tool = toolsApi.updateContainer(tool.getId(), tool);
+        toolsApi.updateTagContainerPath(tool.getId(), tool);
+        tool = toolsApi.refresh(tool.getId());
+        Assert.assertTrue("Should be valid", isTagValid(tool, "master"));
+
+        // make wdl missing docker - should be invalid
+        tool.setDefaultWdlPath("/missingDocker.wdl");
+        tool = toolsApi.updateContainer(tool.getId(), tool);
+        toolsApi.updateTagContainerPath(tool.getId(), tool);
+        tool = toolsApi.refresh(tool.getId());
+        Assert.assertTrue("Should be invalid", !isTagValid(tool, "master"));
+
+        // make wdl missing import - should be invalid
+        tool.setDefaultWdlPath("/missingImport.wdl");
+        tool = toolsApi.updateContainer(tool.getId(), tool);
+        toolsApi.updateTagContainerPath(tool.getId(), tool);
+        tool = toolsApi.refresh(tool.getId());
+        Assert.assertTrue("Should be invalid", !isTagValid(tool, "master"));
+
+        // make wdl missing workflow section - should be invalid
+        tool.setDefaultWdlPath("/missingWorkflowSection.wdl");
+        tool = toolsApi.updateContainer(tool.getId(), tool);
+        toolsApi.updateTagContainerPath(tool.getId(), tool);
+        tool = toolsApi.refresh(tool.getId());
+        Assert.assertTrue("Should be invalid", !isTagValid(tool, "master"));
+
+        // make wdl which is valid workflow, not tool - should be invalid
+        tool.setDefaultWdlPath("/validWorkflow.wdl");
+        tool = toolsApi.updateContainer(tool.getId(), tool);
+        toolsApi.updateTagContainerPath(tool.getId(), tool);
+        tool = toolsApi.refresh(tool.getId());
+        Assert.assertTrue("Should be invalid", !isTagValid(tool, "master"));
+
+        // make wdl valid again - should be valid
+        tool.setDefaultWdlPath("/validTool.wdl");
+        tool = toolsApi.updateContainer(tool.getId(), tool);
+        toolsApi.updateTagContainerPath(tool.getId(), tool);
+        tool = toolsApi.refresh(tool.getId());
+        Assert.assertTrue("Should be valid", isTagValid(tool, "master"));
+
+        // make invalid json wdl - should be invalid
+        testParameterFiles = new ArrayList<>();
+        testParameterFiles.add("/invalidJson.json");
+        toolsApi.addTestParameterFiles(tool.getId(), testParameterFiles, "WDL", "", "master");
+        tool = toolsApi.refresh(tool.getId());
+        Assert.assertTrue("Should be invalid", !isTagValid(tool, "master"));
+        toolsApi.deleteTestParameterFiles(tool.getId(), testParameterFiles, "WDL", "master");
+        tool = toolsApi.refresh(tool.getId());
+
+        // make valid json wdl - should be valid
+        testParameterFiles = new ArrayList<>();
+        testParameterFiles.add("/valid.json");
+        toolsApi.addTestParameterFiles(tool.getId(), testParameterFiles, "WDL", "", "master");
+        tool = toolsApi.refresh(tool.getId());
+        Assert.assertTrue("Should be valid", isTagValid(tool, "master"));
+        toolsApi.deleteTestParameterFiles(tool.getId(), testParameterFiles, "WDL", "master");
+        tool = toolsApi.refresh(tool.getId());
+    }
+}

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -898,6 +898,7 @@ public class WorkflowIT extends BaseIT {
         ContainersApi toolApi = new ContainersApi(webClient);
 
         DockstoreTool tool = new DockstoreTool();
+        tool.setDefaultDockerfilePath("/Dockerfile");
         tool.setDefaultCwlPath("/cwls/cgpmap-bamOut.cwl");
         tool.setGitUrl("git@github.com:DockstoreTestUser2/dockstore-cgpmap.git");
         tool.setNamespace("dockstoretestuser2");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -69,7 +69,7 @@ public final class CommonTestUtilities {
         LOG.info("Dropping and Recreating the database with no test data");
         Application<DockstoreWebserviceConfiguration> application = support.newApplication();
         application.run("db", "drop-all", "--confirm-delete-everything", CONFIDENTIAL_CONFIG_PATH);
-        application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0");
+        application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0,1.6.0");
     }
 
     /**
@@ -92,6 +92,7 @@ public final class CommonTestUtilities {
         application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "1.4.0");
         application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "1.5.0");
         application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "test_1.5.0");
+        application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "1.6.0");
 
     }
 
@@ -122,6 +123,7 @@ public final class CommonTestUtilities {
         application.run("db", "migrate", configPath, "--include", "1.4.0");
         application.run("db", "migrate", configPath, "--include", "1.5.0");
         application.run("db", "migrate", configPath, "--include", "test.confidential1_1.5.0");
+        application.run("db", "migrate", configPath, "--include", "1.6.0");
     }
 
     public static void runMigration(List<String> migrationList, Application<DockstoreWebserviceConfiguration> application, String configPath) {
@@ -167,6 +169,7 @@ public final class CommonTestUtilities {
         application.run("db", "migrate", configPath, "--include", "1.4.0");
         application.run("db", "migrate", configPath, "--include", "1.5.0");
         application.run("db", "migrate", configPath, "--include", "test.confidential2_1.5.0");
+        application.run("db", "migrate", configPath, "--include", "1.6.0");
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/CustomWebApplicationException.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/CustomWebApplicationException.java
@@ -25,8 +25,17 @@ import javax.ws.rs.core.Response;
  */
 public class CustomWebApplicationException extends WebApplicationException {
 
+    public String errorMessage;
     public CustomWebApplicationException(String message, int status) {
         super(Response.status(status).entity(message).type(MediaType.TEXT_PLAIN).build());
+        this.errorMessage = message;
     }
 
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/CustomWebApplicationException.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/CustomWebApplicationException.java
@@ -25,7 +25,7 @@ import javax.ws.rs.core.Response;
  */
 public class CustomWebApplicationException extends WebApplicationException {
 
-    public String errorMessage;
+    public final String errorMessage;
     public CustomWebApplicationException(String message, int status) {
         super(Response.status(status).entity(message).type(MediaType.TEXT_PLAIN).build());
         this.errorMessage = message;
@@ -33,9 +33,5 @@ public class CustomWebApplicationException extends WebApplicationException {
 
     public String getErrorMessage() {
         return errorMessage;
-    }
-
-    public void setErrorMessage(String errorMessage) {
-        this.errorMessage = errorMessage;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -38,6 +38,7 @@ import io.dockstore.webservice.core.Tag;
 import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.User;
+import io.dockstore.webservice.core.VersionValidation;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowVersion;
 import io.dockstore.webservice.doi.DOIGeneratorFactory;
@@ -119,7 +120,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
 
     private final HibernateBundle<DockstoreWebserviceConfiguration> hibernate = new HibernateBundle<DockstoreWebserviceConfiguration>(
             Token.class, Tool.class, User.class, Group.class, Tag.class, Label.class, SourceFile.class, Workflow.class,
-            WorkflowVersion.class, FileFormat.class) {
+            WorkflowVersion.class, FileFormat.class, VersionValidation.class) {
         @Override
         public DataSourceFactory getDataSourceFactory(DockstoreWebserviceConfiguration configuration) {
             return configuration.getDataSourceFactory();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
@@ -73,6 +73,14 @@ public class Tag extends Version<Tag> implements Comparable<Tag> {
     @ApiModelProperty(value = "Implementation specific, indicates whether this is an automated build on quay.io", position = 17)
     private boolean automated;
 
+    @Column(columnDefinition = "TEXT")
+    @ApiModelProperty(value = "Error message for CWL file validation.", position = 22)
+    private String cwlValidationMessage;
+
+    @Column(columnDefinition = "TEXT")
+    @ApiModelProperty(value = "Error message for WDL file validation.", position = 23)
+    private String wdlValidationMessage;
+
     public Tag() {
         super();
     }
@@ -110,6 +118,8 @@ public class Tag extends Version<Tag> implements Comparable<Tag> {
         automated = tag.automated;
         imageId = tag.imageId;
         size = tag.size;
+        cwlValidationMessage = tag.cwlValidationMessage;
+        wdlValidationMessage = tag.wdlValidationMessage;
     }
 
     public void clone(Tag tag) {
@@ -129,6 +139,23 @@ public class Tag extends Version<Tag> implements Comparable<Tag> {
 
         dockerfilePath = tag.dockerfilePath;
     }
+
+    public String getCwlValidationMessage() {
+        return cwlValidationMessage;
+    }
+
+    public void setCwlValidationMessage(String cwlValidationMessage) {
+        this.cwlValidationMessage = cwlValidationMessage;
+    }
+
+    public String getWdlValidationMessage() {
+        return wdlValidationMessage;
+    }
+
+    public void setWdlValidationMessage(String wdlValidationMessage) {
+        this.wdlValidationMessage = wdlValidationMessage;
+    }
+
 
     @JsonProperty
     @ApiModelProperty(position = 19)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
@@ -73,14 +73,6 @@ public class Tag extends Version<Tag> implements Comparable<Tag> {
     @ApiModelProperty(value = "Implementation specific, indicates whether this is an automated build on quay.io", position = 17)
     private boolean automated;
 
-    @Column(columnDefinition = "TEXT")
-    @ApiModelProperty(value = "Error message for CWL file validation.", position = 22)
-    private String cwlValidationMessage;
-
-    @Column(columnDefinition = "TEXT")
-    @ApiModelProperty(value = "Error message for WDL file validation.", position = 23)
-    private String wdlValidationMessage;
-
     public Tag() {
         super();
     }
@@ -118,8 +110,6 @@ public class Tag extends Version<Tag> implements Comparable<Tag> {
         automated = tag.automated;
         imageId = tag.imageId;
         size = tag.size;
-        cwlValidationMessage = tag.cwlValidationMessage;
-        wdlValidationMessage = tag.wdlValidationMessage;
     }
 
     public void clone(Tag tag) {
@@ -139,23 +129,6 @@ public class Tag extends Version<Tag> implements Comparable<Tag> {
 
         dockerfilePath = tag.dockerfilePath;
     }
-
-    public String getCwlValidationMessage() {
-        return cwlValidationMessage;
-    }
-
-    public void setCwlValidationMessage(String cwlValidationMessage) {
-        this.cwlValidationMessage = cwlValidationMessage;
-    }
-
-    public String getWdlValidationMessage() {
-        return wdlValidationMessage;
-    }
-
-    public void setWdlValidationMessage(String wdlValidationMessage) {
-        this.wdlValidationMessage = wdlValidationMessage;
-    }
-
 
     @JsonProperty
     @ApiModelProperty(position = 19)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -159,6 +159,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @JoinTable(name = "version_versionvalidation", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "versionvalidationid", referencedColumnName = "id"))
     @ApiModelProperty(value = "Cached validations for each version.")
     @OrderBy("type")
+    @Cascade(org.hibernate.annotations.CascadeType.DETACH)
     private final SortedSet<VersionValidation> validations;
 
     public Version() {
@@ -248,11 +249,6 @@ public abstract class Version<T extends Version> implements Comparable<T> {
 
     public void addVersionValidation(VersionValidation versionValidation) {
         validations.add(versionValidation);
-    }
-
-    public void upsertVersionValidations(SortedSet<VersionValidation> versionValidations) {
-        getValidations().clear();
-//        getValidations().addAll(versionValidations);
     }
 
     @JsonProperty

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -155,10 +155,9 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @OrderBy("id")
     private SortedSet<FileFormat> outputFileFormats = new TreeSet<>();
 
-    @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.EAGER, orphanRemoval = true, cascade = CascadeType.ALL)
     @JoinTable(name = "version_versionvalidation", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "versionvalidationid", referencedColumnName = "id"))
     @ApiModelProperty(value = "Cached validations for each version.")
-    @Cascade(org.hibernate.annotations.CascadeType.DETACH)
     @OrderBy("type")
     private final SortedSet<VersionValidation> validations;
 
@@ -249,6 +248,11 @@ public abstract class Version<T extends Version> implements Comparable<T> {
 
     public void addVersionValidation(VersionValidation versionValidation) {
         validations.add(versionValidation);
+    }
+
+    public void upsertVersionValidations(SortedSet<VersionValidation> versionValidations) {
+        getValidations().clear();
+//        getValidations().addAll(versionValidations);
     }
 
     @JsonProperty

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -155,6 +155,10 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @OrderBy("id")
     private SortedSet<FileFormat> outputFileFormats = new TreeSet<>();
 
+    @Column(columnDefinition = "TEXT")
+    @ApiModelProperty(value = "Error message for file validation.", position = 22)
+    private String validationMessage;
+
     public Version() {
         sourceFiles = new TreeSet<>();
         doiStatus = DOIStatus.NOT_REQUESTED;
@@ -193,6 +197,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
 
     public void update(T version) {
         valid = version.isValid();
+        validationMessage = version.getValidationMessage();
         lastModified = version.getLastModified();
         name = version.getName();
         referenceType = version.getReferenceType();
@@ -342,6 +347,14 @@ public abstract class Version<T extends Version> implements Comparable<T> {
 
     public void setDbUpdateDate(Timestamp dbUpdateDate) {
         this.dbUpdateDate = dbUpdateDate;
+    }
+
+    public String getValidationMessage() {
+        return validationMessage;
+    }
+
+    public void setValidationMessage(String validationMessage) {
+        this.validationMessage = validationMessage;
     }
 
     public enum DOIStatus { NOT_REQUESTED, REQUESTED, CREATED }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -19,6 +19,7 @@ package io.dockstore.webservice.core;
 import java.sql.Timestamp;
 import java.util.Date;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -248,7 +249,13 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     }
 
     public void addVersionValidation(VersionValidation versionValidation) {
-        validations.add(versionValidation);
+        Optional<VersionValidation> matchingValidation = getValidations().stream().filter(versionValidation1 -> Objects.equals(versionValidation.getType(), versionValidation1.getType())).findFirst();
+        if (matchingValidation.isPresent()) {
+            matchingValidation.get().setMessage(versionValidation.getMessage());
+            matchingValidation.get().setType(versionValidation.getType());
+        } else {
+            validations.add(versionValidation);
+        }
     }
 
     @JsonProperty

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -252,7 +252,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
         Optional<VersionValidation> matchingValidation = getValidations().stream().filter(versionValidation1 -> Objects.equals(versionValidation.getType(), versionValidation1.getType())).findFirst();
         if (matchingValidation.isPresent()) {
             matchingValidation.get().setMessage(versionValidation.getMessage());
-            matchingValidation.get().setType(versionValidation.getType());
+            matchingValidation.get().setValid(versionValidation.isValid());
         } else {
             validations.add(versionValidation);
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -155,8 +155,16 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @OrderBy("id")
     private SortedSet<FileFormat> outputFileFormats = new TreeSet<>();
 
+    @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
+    @JoinTable(name = "version_versionvalidation", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "versionvalidationid", referencedColumnName = "id"))
+    @ApiModelProperty(value = "Cached validations for each version.")
+    @Cascade(org.hibernate.annotations.CascadeType.DETACH)
+    @OrderBy("type")
+    private final SortedSet<VersionValidation> validations;
+
     public Version() {
         sourceFiles = new TreeSet<>();
+        validations = new TreeSet<>();
         doiStatus = DOIStatus.NOT_REQUESTED;
     }
 
@@ -233,6 +241,14 @@ public abstract class Version<T extends Version> implements Comparable<T> {
 
     public void addSourceFile(SourceFile file) {
         sourceFiles.add(file);
+    }
+
+    public SortedSet<VersionValidation> getValidations() {
+        return validations;
+    }
+
+    public void addVersionValidation(VersionValidation versionValidation) {
+        validations.add(versionValidation);
     }
 
     @JsonProperty

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -155,10 +155,6 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @OrderBy("id")
     private SortedSet<FileFormat> outputFileFormats = new TreeSet<>();
 
-    @Column(columnDefinition = "TEXT")
-    @ApiModelProperty(value = "Error message for file validation.", position = 22)
-    private String validationMessage;
-
     public Version() {
         sourceFiles = new TreeSet<>();
         doiStatus = DOIStatus.NOT_REQUESTED;
@@ -197,7 +193,6 @@ public abstract class Version<T extends Version> implements Comparable<T> {
 
     public void update(T version) {
         valid = version.isValid();
-        validationMessage = version.getValidationMessage();
         lastModified = version.getLastModified();
         name = version.getName();
         referenceType = version.getReferenceType();
@@ -347,14 +342,6 @@ public abstract class Version<T extends Version> implements Comparable<T> {
 
     public void setDbUpdateDate(Timestamp dbUpdateDate) {
         this.dbUpdateDate = dbUpdateDate;
-    }
-
-    public String getValidationMessage() {
-        return validationMessage;
-    }
-
-    public void setValidationMessage(String validationMessage) {
-        this.validationMessage = validationMessage;
     }
 
     public enum DOIStatus { NOT_REQUESTED, REQUESTED, CREATED }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionValidation.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionValidation.java
@@ -1,0 +1,124 @@
+/*
+ *    Copyright 2018 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.dockstore.webservice.core;
+
+import java.sql.Timestamp;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.collect.ComparisonChain;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/**
+ * This describes the validation information associated with one or more files for a version
+ * @author aduncan
+ * @since 1.6.0
+ */
+@ApiModel("VersionValidation")
+@Entity
+@Table(name = "versionvalidation")
+@SuppressWarnings("checkstyle:magicnumber")
+public class VersionValidation implements Comparable<VersionValidation> {
+
+    public VersionValidation(SourceFile.FileType fileType, boolean valid, String message) {
+        this.type = fileType;
+        this.valid = valid;
+        this.message = message;
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @ApiModelProperty(value = "Implementation specific ID for the source file in this web service", required = true, position = 0)
+    private long id;
+
+    @Enumerated(EnumType.STRING)
+    @ApiModelProperty(value = "Enumerates the type of file", required = true, position = 1)
+    private SourceFile.FileType type;
+
+    @Column
+    @ApiModelProperty(value = "Is the file type valid", required = true, position = 2)
+    private boolean valid = false;
+
+    @Column(columnDefinition = "TEXT")
+    @ApiModelProperty(value = "Validation message", required = true, position = 3)
+    private String message = null;
+
+    // database timestamps
+    @Column(updatable = false)
+    @CreationTimestamp
+    private Timestamp dbCreateDate;
+
+    @Column()
+    @UpdateTimestamp
+    private Timestamp dbUpdateDate;
+
+    @JsonIgnore
+    public Timestamp getDbCreateDate() {
+        return dbCreateDate;
+    }
+
+    @JsonIgnore
+    public Timestamp getDbUpdateDate() {
+        return dbUpdateDate;
+    }
+
+    public boolean isValid() {
+        return valid;
+    }
+
+    public void setValid(boolean valid) {
+        this.valid = valid;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public SourceFile.FileType getType() {
+        return type;
+    }
+
+    public void setType(SourceFile.FileType type) {
+        this.type = type;
+    }
+
+    public void update(VersionValidation versionValidation) {
+        type = versionValidation.type;
+        valid = versionValidation.valid;
+        message = versionValidation.message;
+    }
+    @Override
+
+    public int compareTo(VersionValidation that) {
+        return ComparisonChain.start().compare(this.type, that.type).result();
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionValidation.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionValidation.java
@@ -17,6 +17,7 @@
 package io.dockstore.webservice.core;
 
 import java.sql.Timestamp;
+import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -45,12 +46,6 @@ import org.hibernate.annotations.UpdateTimestamp;
 @SuppressWarnings("checkstyle:magicnumber")
 public class VersionValidation implements Comparable<VersionValidation> {
 
-    public VersionValidation(SourceFile.FileType fileType, boolean valid, String message) {
-        this.type = fileType;
-        this.valid = valid;
-        this.message = message;
-    }
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @ApiModelProperty(value = "Implementation specific ID for the source file in this web service", required = true, position = 0)
@@ -76,6 +71,26 @@ public class VersionValidation implements Comparable<VersionValidation> {
     @Column()
     @UpdateTimestamp
     private Timestamp dbUpdateDate;
+
+    public VersionValidation() {
+
+    }
+
+    public VersionValidation(SourceFile.FileType fileType, boolean valid, String message) {
+        this.type = fileType;
+        this.valid = valid;
+        this.message = message;
+    }
+
+    public VersionValidation(VersionValidation versionValidation) {
+        this.type = versionValidation.getType();
+        this.valid = versionValidation.isValid();
+        this.message = versionValidation.getMessage();
+    }
+
+    public long getId() {
+        return id;
+    }
 
     @JsonIgnore
     public Timestamp getDbCreateDate() {
@@ -116,9 +131,19 @@ public class VersionValidation implements Comparable<VersionValidation> {
         valid = versionValidation.valid;
         message = versionValidation.message;
     }
-    @Override
 
+    @Override
     public int compareTo(VersionValidation that) {
         return ComparisonChain.start().compare(this.type, that.type).result();
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return Objects.equals(((VersionValidation)obj).getType(), getType());
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -44,6 +44,10 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
     @ApiModelProperty(value = "Path for the workflow", position = 12)
     private String workflowPath;
 
+    @Column(columnDefinition = "TEXT")
+    @ApiModelProperty(value = "Error message for file validation.", position = 22)
+    private String validationMessage;
+
     public WorkflowVersion() {
         super();
     }
@@ -63,6 +67,7 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
 
     public void update(WorkflowVersion workflowVersion) {
         super.update(workflowVersion);
+        validationMessage = workflowVersion.getValidationMessage();
         super.setReference(workflowVersion.getReference());
         workflowPath = workflowVersion.getWorkflowPath();
     }
@@ -70,6 +75,14 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
     public void clone(WorkflowVersion tag) {
         super.clone(tag);
         super.setReference(tag.getReference());
+    }
+
+    public String getValidationMessage() {
+        return validationMessage;
+    }
+
+    public void setValidationMessage(String validationMessage) {
+        this.validationMessage = validationMessage;
     }
 
     @JsonProperty

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -44,10 +44,6 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
     @ApiModelProperty(value = "Path for the workflow", position = 12)
     private String workflowPath;
 
-    @Column(columnDefinition = "TEXT")
-    @ApiModelProperty(value = "Error message for file validation.", position = 22)
-    private String validationMessage;
-
     public WorkflowVersion() {
         super();
     }
@@ -67,7 +63,6 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
 
     public void update(WorkflowVersion workflowVersion) {
         super.update(workflowVersion);
-        validationMessage = workflowVersion.getValidationMessage();
         super.setReference(workflowVersion.getReference());
         workflowPath = workflowVersion.getWorkflowPath();
     }
@@ -75,14 +70,6 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
     public void clone(WorkflowVersion tag) {
         super.clone(tag);
         super.setReference(tag.getReference());
-    }
-
-    public String getValidationMessage() {
-        return validationMessage;
-    }
-
-    public void setValidationMessage(String validationMessage) {
-        this.validationMessage = validationMessage;
     }
 
     @JsonProperty

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -428,7 +428,7 @@ public abstract class AbstractImageRegistry {
         // Remove all existing validations
         tag.getValidations().clear();
 
-        boolean hasDockerfile = tag.getSourceFiles().stream().anyMatch(sf -> Objects.equals(sf.getPath(), "/Dockerfile"));
+        boolean hasDockerfile = tag.getSourceFiles().stream().anyMatch(sf -> Objects.equals(sf.getType(), SourceFile.FileType.DOCKERFILE));
         Pair<Boolean, String> validDockerfile;
         // Private tools don't require a dockerfile
         if (hasDockerfile || tool.isPrivateAccess()) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -494,9 +494,13 @@ public abstract class AbstractImageRegistry {
         VersionValidation descriptorValidation = new VersionValidation(fileType, isValidDescriptor.getKey(), isValidDescriptor.getValue());
         tag.addVersionValidation(descriptorValidation);
 
+        SourceFile.FileType testParamType = SourceFile.FileType.CWL_TEST_JSON;
+        if (Objects.equals(fileType, SourceFile.FileType.DOCKSTORE_WDL)) {
+            testParamType = SourceFile.FileType.WDL_TEST_JSON;
+        }
         Pair<Boolean, String> isValidTestParameter = LanguageHandlerFactory.getInterface(fileType)
                 .validateTestParameterSet(tag.getSourceFiles());
-        VersionValidation testParameterValidation = new VersionValidation(fileType, isValidTestParameter.getKey(), isValidTestParameter.getValue());
+        VersionValidation testParameterValidation = new VersionValidation(testParamType, isValidTestParameter.getKey(), isValidTestParameter.getValue());
         tag.addVersionValidation(testParameterValidation);
 
         return tag;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -436,8 +436,8 @@ public abstract class AbstractImageRegistry {
         VersionValidation dockerfileValidation = new VersionValidation(SourceFile.FileType.DOCKERFILE, validDockerfile.getKey(), validDockerfile.getValue());
         tag.addVersionValidation(dockerfileValidation);
 
-        tag = validateTag(tag, SourceFile.FileType.DOCKSTORE_CWL, tag.getCwlPath());
-        tag = validateTag(tag, SourceFile.FileType.DOCKSTORE_WDL, tag.getWdlPath());
+        tag = validateTagDescriptorType(tag, SourceFile.FileType.DOCKSTORE_CWL, tag.getCwlPath());
+        tag = validateTagDescriptorType(tag, SourceFile.FileType.DOCKSTORE_WDL, tag.getWdlPath());
 
         boolean isValidVersion = isValidVersion(tag);
         tag.setValid(isValidVersion);
@@ -485,7 +485,7 @@ public abstract class AbstractImageRegistry {
      * @param primaryDescriptorPath Path to the primary descriptor
      * @return Validated tag
      */
-    private Tag validateTag(Tag tag, SourceFile.FileType fileType, String primaryDescriptorPath) {
+    private Tag validateTagDescriptorType(Tag tag, SourceFile.FileType fileType, String primaryDescriptorPath) {
         Pair<Boolean, String> isValidDescriptor = LanguageHandlerFactory.getInterface(fileType)
                 .validateToolSet(tag.getSourceFiles(), primaryDescriptorPath);
         VersionValidation descriptorValidation = new VersionValidation(fileType, isValidDescriptor.getKey(), isValidDescriptor.getValue());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -428,14 +428,16 @@ public abstract class AbstractImageRegistry {
         boolean hasWdl = tag.getSourceFiles().stream().anyMatch(file -> Objects.equals(file.getPath(), tag.getWdlPath()));
 
         if (hasCwl || hasWdl) {
-            Pair<Boolean, String> validCwl = isValidTool(tag, SourceFile.FileType.DOCKSTORE_CWL);
-            Pair<Boolean, String> validWdl = isValidTool(tag, SourceFile.FileType.DOCKSTORE_WDL);
+            Pair<Boolean, String> validCwl = isValidTool(tag, SourceFile.FileType.DOCKSTORE_CWL, tag.getCwlPath());
+            Pair<Boolean, String> validWdl = isValidTool(tag, SourceFile.FileType.DOCKSTORE_WDL, tag.getWdlPath());
 
+            tag.setCwlValidationMessage(null);
+            tag.setWdlValidationMessage(null);
             if (hasCwl) {
-                tag.setValidationMessage(validCwl.getValue());
+                tag.setCwlValidationMessage(validCwl.getValue());
             }
             if (hasWdl) {
-                tag.setValidationMessage(validWdl.getValue());
+                tag.setWdlValidationMessage(validWdl.getValue());
             }
             // Private tools don't require a dockerfile
             if (tool.isPrivateAccess()) {
@@ -453,12 +455,12 @@ public abstract class AbstractImageRegistry {
      * @param fileType
      * @return true if valid, false otherwise with validation message
      */
-    private Pair<Boolean, String> isValidTool(Tag tag, SourceFile.FileType fileType) {
+    private Pair<Boolean, String> isValidTool(Tag tag, SourceFile.FileType fileType, String primaryDescriptorPath) {
         boolean isValid = false;
         String validationMessage = null;
         try {
             isValid = LanguageHandlerFactory.getInterface(fileType)
-                    .isValidToolSet(tag.getSourceFiles(), tag.getCwlPath());
+                    .isValidToolSet(tag.getSourceFiles(), primaryDescriptorPath);
         } catch (CustomWebApplicationException ex) {
             validationMessage = ex.getErrorMessage();
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -425,9 +425,6 @@ public abstract class AbstractImageRegistry {
             tag.addSourceFile(file);
         }
 
-        // Remove all existing validations
-        tag.getValidations().clear();
-
         boolean hasDockerfile = tag.getSourceFiles().stream().anyMatch(sf -> Objects.equals(sf.getType(), SourceFile.FileType.DOCKERFILE));
         Pair<Boolean, String> validDockerfile;
         // Private tools don't require a dockerfile

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
@@ -300,15 +300,19 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
                     // TODO: No exceptions are caught here in the event of a failed call
                     SourceFile sourceFile = getSourceFile(calculatedPath, repositoryId, branchName, identifiedType);
 
-                    // validity is checked just for the root description
-                    if (sourceFile != null) {
-                        version.setValid(LanguageHandlerFactory.getInterface(identifiedType).isValidWorkflow(sourceFile.getContent()));
-                    }
-
                     // Use default test parameter file if either new version or existing version that hasn't been edited
                     createTestParameterFiles(workflow, repositoryId, branchName, version, identifiedType);
                     workflow.addWorkflowVersion(
                         combineVersionAndSourcefile(repositoryId, sourceFile, workflow, identifiedType, version, existingDefaults));
+
+                    try {
+                        version.setValid(LanguageHandlerFactory.getInterface(identifiedType)
+                                .isValidWorkflowSet(version.getSourceFiles(), calculatedPath));
+                        version.setValidationMessage(null);
+                    } catch (CustomWebApplicationException ex) {
+                        String message = ex.getErrorMessage();
+                        version.setValidationMessage(message);
+                    }
                 });
 
                 if (paginatedRefs.getNext() != null) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
@@ -37,7 +37,6 @@ import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowVersion;
-import io.dockstore.webservice.languages.LanguageHandlerFactory;
 import io.swagger.bitbucket.client.ApiClient;
 import io.swagger.bitbucket.client.ApiException;
 import io.swagger.bitbucket.client.Configuration;
@@ -305,14 +304,8 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
                     workflow.addWorkflowVersion(
                         combineVersionAndSourcefile(repositoryId, sourceFile, workflow, identifiedType, version, existingDefaults));
 
-                    try {
-                        version.setValid(LanguageHandlerFactory.getInterface(identifiedType)
-                                .isValidWorkflowSet(version.getSourceFiles(), calculatedPath));
-                        version.setValidationMessage(null);
-                    } catch (CustomWebApplicationException ex) {
-                        String message = ex.getErrorMessage();
-                        version.setValidationMessage(message);
-                    }
+                    version = versionValidation(version, workflow, calculatedPath);
+                    version.setValid(isValidVersion(version));
                 });
 
                 if (paginatedRefs.getNext() != null) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -29,7 +29,6 @@ import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowVersion;
-import io.dockstore.webservice.languages.LanguageHandlerFactory;
 import okhttp3.OkHttpClient;
 import okhttp3.OkUrlFactory;
 import org.apache.commons.io.FilenameUtils;
@@ -342,15 +341,6 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
                     file.setPath(calculatedPath);
                     file.setType(identifiedType);
                     version = combineVersionAndSourcefile(repositoryId, file, workflow, identifiedType, version, existingDefaults);
-                    version.setValidationMessage(null);
-
-                    try {
-                        version.setValid(LanguageHandlerFactory.getInterface(identifiedType)
-                                .isValidWorkflowSet(version.getSourceFiles(), calculatedPath));
-                    } catch (CustomWebApplicationException ex) {
-                        String message = ex.getErrorMessage();
-                        version.setValidationMessage(message);
-                    }
 
                     // Use default test parameter file if either new version or existing version that hasn't been edited
                     // TODO: why is this here? Does this code not have a counterpart in BitBucket and GitLab?
@@ -384,6 +374,8 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
                 LOG.info(gitUsername + ": " + workflow.getDefaultWorkflowPath() + " on " + ref + " was not valid workflow", ex);
             }
 
+            version = versionValidation(version, workflow, calculatedPath);
+            version.setValid(isValidVersion(version));
 
             workflow.addWorkflowVersion(version);
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -337,15 +337,20 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
                 // Get contents of descriptor file and store
                 String decodedContent = this.readFileFromRepo(calculatedPath, ref.getLeft(), repository);
                 if (decodedContent != null) {
-                    boolean validWorkflow = LanguageHandlerFactory.getInterface(identifiedType).isValidWorkflow(decodedContent);
-                    // if we have a valid workflow document
                     SourceFile file = new SourceFile();
                     file.setContent(decodedContent);
                     file.setPath(calculatedPath);
                     file.setType(identifiedType);
-                    version.setValid(validWorkflow);
                     version = combineVersionAndSourcefile(repositoryId, file, workflow, identifiedType, version, existingDefaults);
+                    version.setValidationMessage(null);
 
+                    try {
+                        version.setValid(LanguageHandlerFactory.getInterface(identifiedType)
+                                .isValidWorkflowSet(version.getSourceFiles(), calculatedPath));
+                    } catch (CustomWebApplicationException ex) {
+                        String message = ex.getErrorMessage();
+                        version.setValidationMessage(message);
+                    }
 
                     // Use default test parameter file if either new version or existing version that hasn't been edited
                     // TODO: why is this here? Does this code not have a counterpart in BitBucket and GitLab?

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
@@ -160,17 +160,16 @@ public class GitLabSourceCodeRepo extends SourceCodeRepoInterface {
         // TODO: No exceptions are caught here in the event of a failed call
         SourceFile sourceFile = getSourceFile(calculatedPath, id, branchName, identifiedType);
 
-        // Non-null sourcefile means that the sourcefile is valid
-        if (sourceFile != null) {
-            version.setValid(true);
-        }
         version.setReferenceType(type);
         version.setLastModified(committedDate);
         // Use default test parameter file if either new version or existing version that hasn't been edited
         createTestParameterFiles(workflow, id, branchName, version, identifiedType);
+        version = combineVersionAndSourcefile(repositoryId, sourceFile, workflow, identifiedType, version, existingDefaults);
 
-        workflow.addWorkflowVersion(
-                combineVersionAndSourcefile(repositoryId, sourceFile, workflow, identifiedType, version, existingDefaults));
+        version = versionValidation(version, workflow, calculatedPath);
+        version.setValid(isValidVersion(version));
+
+        workflow.addWorkflowVersion(version);
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -353,6 +353,7 @@ public abstract class SourceCodeRepoInterface {
         version.setName(branch);
         version.setReference(branch);
         version.setValid(false);
+        version.setValidationMessage(null);
 
         // Determine workflow version from previous
         String calculatedPath;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -646,11 +646,28 @@ public class CWLHandler implements LanguageHandlerInterface {
 
     @Override
     public boolean isValidWorkflowSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
-        return true;
+        Optional<SourceFile> mainDescriptor = sourcefiles.stream().filter((sourceFile -> Objects.equals(sourceFile.getPath(), primaryDescriptorFilePath))).findFirst();
+
+        if (mainDescriptor.isPresent()) {
+            Yaml yaml = new Yaml();
+            String content = mainDescriptor.get().getContent();
+            return content.contains("class: Workflow") && this.isValidCwl(content, yaml);
+        } else {
+            return false;
+        }
     }
 
     @Override
     public boolean isValidToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
-        return true;
+        Optional<SourceFile> mainDescriptor = sourcefiles.stream().filter((sourceFile -> Objects.equals(sourceFile.getPath(), primaryDescriptorFilePath))).findFirst();
+        String content;
+
+        if (mainDescriptor.isPresent()) {
+            Yaml yaml = new Yaml();
+            content = mainDescriptor.get().getContent();
+            return this.isValidCwl(content, yaml);
+        } else {
+            return false;
+        }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -647,11 +647,12 @@ public class CWLHandler implements LanguageHandlerInterface {
 
     @Override
     public javafx.util.Pair<Boolean, String> validateWorkflowSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
-        Boolean isValid = true;
-        String validationMessage = null;
         List<SourceFile.FileType> fileTypes = new ArrayList<>(Arrays.asList(SourceFile.FileType.DOCKSTORE_CWL));
         sourcefiles = filterSourcefiles(sourcefiles, fileTypes);
         Optional<SourceFile> mainDescriptor = sourcefiles.stream().filter((sourceFile -> Objects.equals(sourceFile.getPath(), primaryDescriptorFilePath))).findFirst();
+
+        Boolean isValid = true;
+        String validationMessage = null;
 
         if (mainDescriptor.isPresent()) {
             Yaml yaml = new Yaml();
@@ -659,8 +660,7 @@ public class CWLHandler implements LanguageHandlerInterface {
             if (!content.contains("class: Workflow")) {
                 isValid = false;
                 validationMessage = "Requires class: Workflow.";
-            }
-            if (!this.isValidCwl(content, yaml)) {
+            } else if (!this.isValidCwl(content, yaml)) {
                 isValid = false;
                 validationMessage = "Invalid CWL version.";
             }
@@ -677,19 +677,25 @@ public class CWLHandler implements LanguageHandlerInterface {
         sourcefiles = filterSourcefiles(sourcefiles, fileTypes);
         Optional<SourceFile> mainDescriptor = sourcefiles.stream().filter((sourceFile -> Objects.equals(sourceFile.getPath(), primaryDescriptorFilePath))).findFirst();
 
+        Boolean isValid = true;
+        String validationMessage = null;
+
         if (mainDescriptor.isPresent()) {
             Yaml yaml = new Yaml();
             String content = mainDescriptor.get().getContent();
             if (!content.contains("class: CommandLineTool") && !content.contains("class: ExpressionTool")) {
-                return new javafx.util.Pair<>(false, "Requires class: CommandLineTool or ExpressionTool.");
+                isValid = false;
+                validationMessage = "Requires class: CommandLineTool or ExpressionTool.";
             }
             if (!this.isValidCwl(content, yaml)) {
-                return new javafx.util.Pair<>(false, "Invalid CWL version.");
+                isValid = false;
+                validationMessage = "Invalid CWL version.";
             }
         } else {
-            return new javafx.util.Pair<>(false, "Primary descriptor is not present.");
+            isValid = false;
+            validationMessage = "Primary descriptor is not present.";
         }
-        return new javafx.util.Pair<>(true, null);
+        return new javafx.util.Pair<>(isValid, validationMessage);
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -666,7 +666,7 @@ public class CWLHandler implements LanguageHandlerInterface {
                     throw new CustomWebApplicationException("Requires class: Workflow.", HttpStatus.SC_NOT_ACCEPTABLE);
                 }
             } else {
-                if(!content.contains("class: CommandLineTool") && !content.contains("class: ExpressionTool")) {
+                if (!content.contains("class: CommandLineTool") && !content.contains("class: ExpressionTool")) {
                     throw new CustomWebApplicationException("Requires class: CommandLineTool or ExpressionTool.", HttpStatus.SC_NOT_ACCEPTABLE);
                 }
             }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -620,7 +620,7 @@ public class CWLHandler implements LanguageHandlerInterface {
                 }
                 return equals;
             }
-        } catch (ClassCastException e) {
+        } catch (ClassCastException | YAMLException e) {
             return false;
         }
         return false;
@@ -657,7 +657,10 @@ public class CWLHandler implements LanguageHandlerInterface {
         if (mainDescriptor.isPresent()) {
             Yaml yaml = new Yaml();
             String content = mainDescriptor.get().getContent();
-            if (!content.contains("class: Workflow")) {
+            if (content == null || content.isEmpty()) {
+                isValid = false;
+                validationMessage = "Primary descriptor is empty.";
+            } else if (!content.contains("class: Workflow")) {
                 isValid = false;
                 validationMessage = "Requires class: Workflow.";
             } else if (!this.isValidCwl(content, yaml)) {
@@ -665,7 +668,7 @@ public class CWLHandler implements LanguageHandlerInterface {
                 validationMessage = "Invalid CWL version.";
             }
         } else {
-            validationMessage = "Primary descriptor is not present.";
+            validationMessage = "Primary CWL descriptor is not present.";
             isValid = false;
         }
         return new javafx.util.Pair<>(isValid, validationMessage);
@@ -683,17 +686,19 @@ public class CWLHandler implements LanguageHandlerInterface {
         if (mainDescriptor.isPresent()) {
             Yaml yaml = new Yaml();
             String content = mainDescriptor.get().getContent();
-            if (!content.contains("class: CommandLineTool") && !content.contains("class: ExpressionTool")) {
+            if (content == null || content.isEmpty()) {
+                isValid = false;
+                validationMessage = "Primary CWL descriptor is empty.";
+            } else if (!content.contains("class: CommandLineTool") && !content.contains("class: ExpressionTool")) {
                 isValid = false;
                 validationMessage = "Requires class: CommandLineTool or ExpressionTool.";
-            }
-            if (!this.isValidCwl(content, yaml)) {
+            } else if (!this.isValidCwl(content, yaml)) {
                 isValid = false;
                 validationMessage = "Invalid CWL version.";
             }
         } else {
             isValid = false;
-            validationMessage = "Primary descriptor is not present.";
+            validationMessage = "Primary CWL descriptor is not present.";
         }
         return new javafx.util.Pair<>(isValid, validationMessage);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -16,6 +16,7 @@
 package io.dockstore.webservice.languages;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -644,30 +645,29 @@ public class CWLHandler implements LanguageHandlerInterface {
         return filteredArray;
     }
 
-    @Override
-    public boolean isValidWorkflowSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
+    public boolean isValidEntry(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath, String entryType) {
+        List<SourceFile.FileType> fileTypes = new ArrayList<>(
+                Arrays.asList(SourceFile.FileType.DOCKSTORE_CWL, SourceFile.FileType.CWL_TEST_JSON));
+        sourcefiles = filterSourcefiles(sourcefiles, fileTypes);
         Optional<SourceFile> mainDescriptor = sourcefiles.stream().filter((sourceFile -> Objects.equals(sourceFile.getPath(), primaryDescriptorFilePath))).findFirst();
 
         if (mainDescriptor.isPresent()) {
             Yaml yaml = new Yaml();
             String content = mainDescriptor.get().getContent();
-            return content.contains("class: Workflow") && this.isValidCwl(content, yaml);
+            return (Objects.equals(entryType, "workflow") ? content.contains("class: Workflow") : true && this.isValidCwl(content, yaml)
+                    && checkValidJsonAndYamlFiles(sourcefiles, SourceFile.FileType.CWL_TEST_JSON));
         } else {
             return false;
         }
     }
 
     @Override
-    public boolean isValidToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
-        Optional<SourceFile> mainDescriptor = sourcefiles.stream().filter((sourceFile -> Objects.equals(sourceFile.getPath(), primaryDescriptorFilePath))).findFirst();
-        String content;
+    public boolean isValidWorkflowSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
+        return isValidEntry(sourcefiles, primaryDescriptorFilePath, "workflow");
+    }
 
-        if (mainDescriptor.isPresent()) {
-            Yaml yaml = new Yaml();
-            content = mainDescriptor.get().getContent();
-            return this.isValidCwl(content, yaml);
-        } else {
-            return false;
-        }
+    @Override
+    public boolean isValidToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
+        return isValidEntry(sourcefiles, primaryDescriptorFilePath, "tool");
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -645,53 +645,8 @@ public class CWLHandler implements LanguageHandlerInterface {
         return filteredArray;
     }
 
-    /**
-     * Determines if the CWL entry is valid
-     * @param sourcefiles
-     * @param primaryDescriptorFilePath
-     * @param entryType
-     * @return true if the entry is valid, throws error otherwise
-     */
-    public boolean isValidEntry(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath, String entryType) {
-        List<SourceFile.FileType> fileTypes = new ArrayList<>(
-                Arrays.asList(SourceFile.FileType.DOCKSTORE_CWL, SourceFile.FileType.CWL_TEST_JSON));
-        sourcefiles = filterSourcefiles(sourcefiles, fileTypes);
-        Optional<SourceFile> mainDescriptor = sourcefiles.stream().filter((sourceFile -> Objects.equals(sourceFile.getPath(), primaryDescriptorFilePath))).findFirst();
-
-        if (mainDescriptor.isPresent()) {
-            Yaml yaml = new Yaml();
-            String content = mainDescriptor.get().getContent();
-            if (Objects.equals(entryType, "workflow")) {
-                if (!content.contains("class: Workflow")) {
-                    throw new CustomWebApplicationException("Requires class: Workflow.", HttpStatus.SC_NOT_ACCEPTABLE);
-                }
-            } else {
-                if (!content.contains("class: CommandLineTool") && !content.contains("class: ExpressionTool")) {
-                    throw new CustomWebApplicationException("Requires class: CommandLineTool or ExpressionTool.", HttpStatus.SC_NOT_ACCEPTABLE);
-                }
-            }
-            if (!this.isValidCwl(content, yaml)) {
-                throw new CustomWebApplicationException("Invalid CWL version.", HttpStatus.SC_NOT_ACCEPTABLE);
-            }
-            checkValidJsonAndYamlFiles(sourcefiles, SourceFile.FileType.CWL_TEST_JSON);
-            return true;
-        } else {
-            throw new CustomWebApplicationException("Missing primary descriptor.", HttpStatus.SC_NOT_ACCEPTABLE);
-        }
-    }
-
     @Override
-    public boolean isValidWorkflowSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
-        return isValidEntry(sourcefiles, primaryDescriptorFilePath, "workflow");
-    }
-
-    @Override
-    public boolean isValidToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
-        return isValidEntry(sourcefiles, primaryDescriptorFilePath, "tool");
-    }
-
-    @Override
-    public Pair<Boolean, String> validateWorkflowSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
+    public javafx.util.Pair<Boolean, String> validateWorkflowSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
         Boolean isValid = true;
         String validationMessage = null;
         List<SourceFile.FileType> fileTypes = new ArrayList<>(Arrays.asList(SourceFile.FileType.DOCKSTORE_CWL));
@@ -710,14 +665,14 @@ public class CWLHandler implements LanguageHandlerInterface {
                 validationMessage = "Invalid CWL version.";
             }
         } else {
-           validationMessage = "Primary descriptor is not present.";
-           isValid = false;
+            validationMessage = "Primary descriptor is not present.";
+            isValid = false;
         }
-        return new MutablePair<>(isValid, validationMessage);
+        return new javafx.util.Pair<>(isValid, validationMessage);
     }
 
     @Override
-    public Pair<Boolean, String> validateToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
+    public javafx.util.Pair<Boolean, String> validateToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
         List<SourceFile.FileType> fileTypes = new ArrayList<>(Arrays.asList(SourceFile.FileType.DOCKSTORE_CWL));
         sourcefiles = filterSourcefiles(sourcefiles, fileTypes);
         Optional<SourceFile> mainDescriptor = sourcefiles.stream().filter((sourceFile -> Objects.equals(sourceFile.getPath(), primaryDescriptorFilePath))).findFirst();
@@ -726,14 +681,19 @@ public class CWLHandler implements LanguageHandlerInterface {
             Yaml yaml = new Yaml();
             String content = mainDescriptor.get().getContent();
             if (!content.contains("class: CommandLineTool") && !content.contains("class: ExpressionTool")) {
-                return new MutablePair<>(false, "Requires class: CommandLineTool or ExpressionTool.");
+                return new javafx.util.Pair<>(false, "Requires class: CommandLineTool or ExpressionTool.");
             }
             if (!this.isValidCwl(content, yaml)) {
-                return new MutablePair<>(false, "Invalid CWL version.");
+                return new javafx.util.Pair<>(false, "Invalid CWL version.");
             }
         } else {
-            return new MutablePair<>(false, "Primary descriptor is not present.");
+            return new javafx.util.Pair<>(false, "Primary descriptor is not present.");
         }
-        return new MutablePair<>(true, null);
+        return new javafx.util.Pair<>(true, null);
+    }
+
+    @Override
+    public javafx.util.Pair<Boolean, String> validateTestParameterSet(Set<SourceFile> sourceFiles) {
+        return checkValidJsonAndYamlFiles(sourceFiles, SourceFile.FileType.CWL_TEST_JSON);
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -137,12 +137,6 @@ public class CWLHandler implements LanguageHandlerInterface {
     }
 
     @Override
-    public boolean isValidWorkflow(String content) {
-        Yaml yaml = new Yaml();
-        return content.contains("class: Workflow") && this.isValidCwl(content, yaml);
-    }
-
-    @Override
     public Map<String, SourceFile> processImports(String repositoryId, String content, Version version, SourceCodeRepoInterface sourceCodeRepoInterface) {
         return processImports(repositoryId, "", content, version, sourceCodeRepoInterface);
     }
@@ -608,6 +602,12 @@ public class CWLHandler implements LanguageHandlerInterface {
         return false;
     }
 
+    /**
+     * Checks that the CWL file is the correct version
+     * @param content
+     * @param yaml
+     * @return true if file is valid CWL version, false otherwise
+     */
     private boolean isValidCwl(String content, Yaml yaml) {
         try {
             Map<String, Object> mapping = yaml.loadAs(content, Map.class);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -645,6 +645,13 @@ public class CWLHandler implements LanguageHandlerInterface {
         return filteredArray;
     }
 
+    /**
+     * Determines if the CWL entry is valid
+     * @param sourcefiles
+     * @param primaryDescriptorFilePath
+     * @param entryType
+     * @return true if the entry is valid, false otherwise
+     */
     public boolean isValidEntry(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath, String entryType) {
         List<SourceFile.FileType> fileTypes = new ArrayList<>(
                 Arrays.asList(SourceFile.FileType.DOCKSTORE_CWL, SourceFile.FileType.CWL_TEST_JSON));
@@ -654,8 +661,8 @@ public class CWLHandler implements LanguageHandlerInterface {
         if (mainDescriptor.isPresent()) {
             Yaml yaml = new Yaml();
             String content = mainDescriptor.get().getContent();
-            return (Objects.equals(entryType, "workflow") ? content.contains("class: Workflow") : true && this.isValidCwl(content, yaml)
-                    && checkValidJsonAndYamlFiles(sourcefiles, SourceFile.FileType.CWL_TEST_JSON));
+            return (!Objects.equals(entryType, "workflow") || content.contains("class: Workflow")) && this.isValidCwl(content, yaml)
+                    && checkValidJsonAndYamlFiles(sourcefiles, SourceFile.FileType.CWL_TEST_JSON);
         } else {
             return false;
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -643,4 +643,14 @@ public class CWLHandler implements LanguageHandlerInterface {
 
         return filteredArray;
     }
+
+    @Override
+    public boolean isValidWorkflowSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
+        return true;
+    }
+
+    @Override
+    public boolean isValidToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
+        return true;
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -64,6 +64,20 @@ public interface LanguageHandlerInterface {
     boolean isValidWorkflow(String content);
 
     /**
+     * Returns true if valid workflow, will throw an error if invalid Workflow
+     * @param sourcefiles
+     * @param primaryDescriptorFilePath
+     */
+    boolean isValidWorkflowSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath);
+
+    /**
+     * Returns true if valid tool, will throw an error if invalid Tool
+     * @param sourcefiles
+     * @param primaryDescriptorFilePath
+     */
+    boolean isValidToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath);
+
+    /**
      * Look at the content of a descriptor and update its imports
      *
      * @param repositoryId            identifies the git repository that we wish to use, normally something like 'organization/repo_name`

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -75,6 +75,20 @@ public interface LanguageHandlerInterface {
      */
     boolean isValidToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath);
 
+    Pair<Boolean, String> validateWorkflowSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath);
+
+    Pair<Boolean, String> validateToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath);
+
+    default Pair<Boolean, String> validateTestParameterSet(Set<SourceFile> sourceFiles) {
+        // Filter so only test params
+        return new MutablePair<>(true, "empty message");
+    }
+
+    default Pair<Boolean, String> validateDockerfile(Set<SourceFile> sourceFiles) {
+        // filter so only dockerfile
+        return new MutablePair<>(true, "empty message");
+    }
+
     /**
      * Look at the content of a descriptor and update its imports
      *

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -59,20 +59,28 @@ public interface LanguageHandlerInterface {
      */
     Entry parseWorkflowContent(Entry entry, String content, Set<SourceFile> sourceFiles);
 
+    /**
+     * Validates a workflow set for the workflow described by with primaryDescriptorFilePath
+     * @param sourcefiles Set of sourcefiles
+     * @param primaryDescriptorFilePath Primary descriptor path
+     * @return Is a valid workflow set, error message
+     */
     Pair<Boolean, String> validateWorkflowSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath);
 
+    /**
+     * Validates a tool set for the workflow described by with primaryDescriptorFilePath
+     * @param sourcefiles Set of sourcefiles
+     * @param primaryDescriptorFilePath Primary descriptor path
+     * @return Is a valid tool set, error message
+     */
     Pair<Boolean, String> validateToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath);
 
+    /**
+     * Validates a test parameter set
+     * @param sourceFiles Set of sourcefiles
+     * @return Are all test parameter files valid, collection of error messages
+     */
     Pair<Boolean, String> validateTestParameterSet(Set<SourceFile> sourceFiles);
-
-    default Pair<Boolean, String> validateDockerfile(Set<SourceFile> sourceFiles) {
-        boolean hasDockerfile = sourceFiles.stream().anyMatch(sf -> Objects.equals(sf.getType(), SourceFile.FileType.DOCKERFILE));
-        String validationMessage = null;
-        if (!hasDockerfile) {
-            validationMessage = "Missing Dockerfile.";
-        }
-        return new Pair<>(hasDockerfile, validationMessage);
-    }
 
     /**
      * Look at the content of a descriptor and update its imports
@@ -102,8 +110,8 @@ public interface LanguageHandlerInterface {
     /**
      * Checks that the test parameter files are valid JSON or YAML
      * Note: If even one is invalid, return invalid. Also merges all validation messages into one.
-     * @param sourcefiles
-     * @param fileType
+     * @param sourcefiles Set of sourcefiles
+     * @param fileType Test parameter file type
      * @return Pair of isValid and validationMessage
      */
     default Pair<Boolean, String> checkValidJsonAndYamlFiles(Set<SourceFile> sourcefiles, SourceFile.FileType fileType) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -122,6 +122,12 @@ public interface LanguageHandlerInterface {
         return true;
     }
 
+    /**
+     * Removes any sourcefiles of some file types from a set
+     * @param sourcefiles
+     * @param fileTypes
+     * @return Filtered sourcefile set
+     */
     default Set<SourceFile> filterSourcefiles(Set<SourceFile> sourcefiles, List<SourceFile.FileType> fileTypes) {
         return sourcefiles.stream()
                 .filter(sourcefile -> fileTypes.contains(sourcefile.getType()))

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -60,15 +60,7 @@ public interface LanguageHandlerInterface {
      * @return the updated entry
      */
     Entry parseWorkflowContent(Entry entry, String content, Set<SourceFile> sourceFiles);
-
-    /**
-     * Confirms whether the content of a descriptor contains a valid workflow
-     *
-     * @param content the content of a descriptor
-     * @return true iff the workflow looks like a valid workflow
-     */
-    boolean isValidWorkflow(String content);
-
+    
     /**
      * Returns true if valid workflow, will throw an error if invalid Workflow
      * @param sourcefiles

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -60,7 +60,7 @@ public interface LanguageHandlerInterface {
      * @return the updated entry
      */
     Entry parseWorkflowContent(Entry entry, String content, Set<SourceFile> sourceFiles);
-    
+
     /**
      * Returns true if valid workflow, will throw an error if invalid Workflow
      * @param sourcefiles

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
@@ -412,12 +412,12 @@ public class NextFlowHandler implements LanguageHandlerInterface {
     @Override
     public javafx.util.Pair<Boolean, String> validateToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
         // Throw exception instead?
-        return new javafx.util.Pair<>(false, "Nextflow does not support tools.");
+        return new javafx.util.Pair<>(true, "Nextflow does not support tools.");
     }
 
     @Override
     public javafx.util.Pair<Boolean, String> validateTestParameterSet(Set<SourceFile> sourceFiles) {
         // Throw exception instead?
-        return new javafx.util.Pair<>(false, "Nextflow does not support test parameter files.");
+        return new javafx.util.Pair<>(true, "Nextflow does not support test parameter files.");
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
@@ -398,4 +398,14 @@ public class NextFlowHandler implements LanguageHandlerInterface {
         }
         return map;
     }
+
+    @Override
+    public boolean isValidWorkflowSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
+        return true;
+    }
+
+    @Override
+    public boolean isValidToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
+        return true;
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
@@ -39,6 +39,8 @@ import io.dockstore.webservice.helpers.SourceCodeRepoInterface;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.codehaus.groovy.antlr.GroovySourceAST;
 import org.codehaus.groovy.antlr.parser.GroovyLexer;
 import org.codehaus.groovy.antlr.parser.GroovyRecognizer;
@@ -407,5 +409,17 @@ public class NextFlowHandler implements LanguageHandlerInterface {
     @Override
     public boolean isValidToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
         return false;
+    }
+
+    @Override
+    public Pair<Boolean, String> validateWorkflowSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
+        // Filter so only descriptor files?
+        return new MutablePair<>(true, "empty message");
+    }
+
+    @Override
+    public Pair<Boolean, String> validateToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
+        // Filter so only descriptor files?
+        return new MutablePair<>(true, "empty message");
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
@@ -64,11 +64,6 @@ public class NextFlowHandler implements LanguageHandlerInterface {
     }
 
     @Override
-    public boolean isValidWorkflow(String content) {
-        return content.contains("manifest");
-    }
-
-    @Override
     public Map<String, SourceFile> processImports(String repositoryId, String content, Version version,
         SourceCodeRepoInterface sourceCodeRepoInterface) {
         ConfigObject parse = getConfigObject(content);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
@@ -397,7 +397,7 @@ public class NextFlowHandler implements LanguageHandlerInterface {
     @Override
     public javafx.util.Pair<Boolean, String> validateWorkflowSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
         Optional<SourceFile> mainDescriptor = sourcefiles.stream().filter((sourceFile -> Objects.equals(sourceFile.getPath(), primaryDescriptorFilePath))).findFirst();
-        String content = null;
+        String content;
         if (mainDescriptor.isPresent()) {
             content = mainDescriptor.get().getContent();
             if (content.contains("manifest")) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
@@ -39,8 +39,6 @@ import io.dockstore.webservice.helpers.SourceCodeRepoInterface;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.tuple.MutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.codehaus.groovy.antlr.GroovySourceAST;
 import org.codehaus.groovy.antlr.parser.GroovyLexer;
 import org.codehaus.groovy.antlr.parser.GroovyRecognizer;
@@ -397,29 +395,29 @@ public class NextFlowHandler implements LanguageHandlerInterface {
     }
 
     @Override
-    public boolean isValidWorkflowSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
+    public javafx.util.Pair<Boolean, String> validateWorkflowSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
         Optional<SourceFile> mainDescriptor = sourcefiles.stream().filter((sourceFile -> Objects.equals(sourceFile.getPath(), primaryDescriptorFilePath))).findFirst();
         String content = null;
         if (mainDescriptor.isPresent()) {
             content = mainDescriptor.get().getContent();
+            if (content.contains("manifest")) {
+                return new javafx.util.Pair<>(true, null);
+            } else {
+                return new javafx.util.Pair<>(false, "Descriptor file " + primaryDescriptorFilePath + " is missing the manifest section.");
+            }
         }
-        return content.contains("manifest");
+        return new javafx.util.Pair<>(false, "Descriptor file " + primaryDescriptorFilePath + " not found.");
     }
 
     @Override
-    public boolean isValidToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
-        return false;
+    public javafx.util.Pair<Boolean, String> validateToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
+        // Throw exception instead?
+        return new javafx.util.Pair<>(false, "Nextflow does not support tools.");
     }
 
     @Override
-    public Pair<Boolean, String> validateWorkflowSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
-        // Filter so only descriptor files?
-        return new MutablePair<>(true, "empty message");
-    }
-
-    @Override
-    public Pair<Boolean, String> validateToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
-        // Filter so only descriptor files?
-        return new MutablePair<>(true, "empty message");
+    public javafx.util.Pair<Boolean, String> validateTestParameterSet(Set<SourceFile> sourceFiles) {
+        // Throw exception instead?
+        return new javafx.util.Pair<>(false, "Nextflow does not support test parameter files.");
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
@@ -401,11 +401,16 @@ public class NextFlowHandler implements LanguageHandlerInterface {
 
     @Override
     public boolean isValidWorkflowSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
-        return true;
+        Optional<SourceFile> mainDescriptor = sourcefiles.stream().filter((sourceFile -> Objects.equals(sourceFile.getPath(), primaryDescriptorFilePath))).findFirst();
+        String content = null;
+        if (mainDescriptor.isPresent()) {
+            content = mainDescriptor.get().getContent();
+        }
+        return content.contains("manifest");
     }
 
     @Override
     public boolean isValidToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
-        return true;
+        return false;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -203,7 +203,7 @@ public class WDLHandler implements LanguageHandlerInterface {
                 for (SourceFile sourceFile : sourcefiles) {
                     if (Objects.equals(sourceFile.getPath(), primaryDescriptorFilePath)) {
                         mainDescriptor = sourceFile.getContent();
-                        if (mainDescriptor == null || mainDescriptor.isEmpty()) {
+                        if (mainDescriptor == null || mainDescriptor.trim().replaceAll("\n", "").isEmpty()) {
                             throw new WdlParser.SyntaxError("The primary descriptor '" + sourceFile.getPath() + "' has no content. Please make it a valid WDL document if you want to save.");
                         }
                     }
@@ -211,18 +211,19 @@ public class WDLHandler implements LanguageHandlerInterface {
 
                 Map<String, String> secondaryDescContent = new HashMap<>();
                 for (SourceFile sourceFile : sourcefiles) {
-                    if (sourceFile.getContent() != null) {
-                        String val = sourceFile.getContent().trim().replaceAll("\n", "");
-                        if (sourceFile.getContent().trim().replaceAll("\n", "").isEmpty()) {
-                            if (Objects.equals(sourceFile.getType(), SourceFile.FileType.DOCKSTORE_WDL)) {
-                                throw new WdlParser.SyntaxError("File '" + sourceFile.getPath() + "' has no content. Either delete the file or make it a valid WDL document.");
-                            } else if (Objects.equals(sourceFile.getType(), SourceFile.FileType.WDL_TEST_JSON)) {
-                                throw new WdlParser.SyntaxError("File '" + sourceFile.getPath() + "' has no content. Either delete the file or make it a valid WDL JSON/YAML file.");
-                            } else {
-                                throw new WdlParser.SyntaxError("File '" + sourceFile.getPath() + "' has no content. Either delete the file or make it valid.");
+                    if (!Objects.equals(sourceFile.getPath(), primaryDescriptorFilePath)) {
+                        if (sourceFile.getContent() != null) {
+                            if (sourceFile.getContent().trim().replaceAll("\n", "").isEmpty()) {
+                                if (Objects.equals(sourceFile.getType(), SourceFile.FileType.DOCKSTORE_WDL)) {
+                                    throw new WdlParser.SyntaxError("File '" + sourceFile.getPath() + "' has no content. Either delete the file or make it a valid WDL document.");
+                                } else if (Objects.equals(sourceFile.getType(), SourceFile.FileType.WDL_TEST_JSON)) {
+                                    throw new WdlParser.SyntaxError("File '" + sourceFile.getPath() + "' has no content. Either delete the file or make it a valid WDL JSON/YAML file.");
+                                } else {
+                                    throw new WdlParser.SyntaxError("File '" + sourceFile.getPath() + "' has no content. Either delete the file or make it valid.");
+                                }
                             }
+                            secondaryDescContent.put(sourceFile.getPath(), sourceFile.getContent());
                         }
-                        secondaryDescContent.put(sourceFile.getPath(), sourceFile.getContent());
                     }
                 }
                 tempMainDescriptor = File.createTempFile("main", "descriptor", Files.createTempDir());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -247,6 +247,8 @@ public class WDLHandler implements LanguageHandlerInterface {
             } finally {
                 FileUtils.deleteQuietly(tempMainDescriptor);
             }
+        } else {
+            return false;
         }
         return true;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -182,11 +182,6 @@ public class WDLHandler implements LanguageHandlerInterface {
         return null;
     }
 
-    @Override
-    public boolean isValidWorkflow(String content) {
-        return true;
-    }
-
     /**
      * Helper function that checks if a WDL descriptor is a valid tool or workflow
      * @param sourcefiles
@@ -216,19 +211,18 @@ public class WDLHandler implements LanguageHandlerInterface {
 
                 Map<String, String> secondaryDescContent = new HashMap<>();
                 for (SourceFile sourceFile : sourcefiles) {
-                    if (!Objects.equals(sourceFile.getPath(), primaryDescriptorFilePath)) {
-                        if (sourceFile.getContent() != null) {
-                            if (sourceFile.getContent().isEmpty()) {
-                                if (Objects.equals(sourceFile.getType(), SourceFile.FileType.DOCKSTORE_WDL)) {
-                                    throw new WdlParser.SyntaxError("File '" + sourceFile.getPath() + "' has no content. Either delete the file or make it a valid WDL document.");
-                                } else if (Objects.equals(sourceFile.getType(), SourceFile.FileType.WDL_TEST_JSON)) {
-                                    throw new WdlParser.SyntaxError("File '" + sourceFile.getPath() + "' has no content. Either delete the file or make it a valid WDL JSON/YAML file.");
-                                } else {
-                                    throw new WdlParser.SyntaxError("File '" + sourceFile.getPath() + "' has no content. Either delete the file or make it valid.");
-                                }
+                    if (sourceFile.getContent() != null) {
+                        String val = sourceFile.getContent().trim().replaceAll("\n", "");
+                        if (sourceFile.getContent().trim().replaceAll("\n", "").isEmpty()) {
+                            if (Objects.equals(sourceFile.getType(), SourceFile.FileType.DOCKSTORE_WDL)) {
+                                throw new WdlParser.SyntaxError("File '" + sourceFile.getPath() + "' has no content. Either delete the file or make it a valid WDL document.");
+                            } else if (Objects.equals(sourceFile.getType(), SourceFile.FileType.WDL_TEST_JSON)) {
+                                throw new WdlParser.SyntaxError("File '" + sourceFile.getPath() + "' has no content. Either delete the file or make it a valid WDL JSON/YAML file.");
+                            } else {
+                                throw new WdlParser.SyntaxError("File '" + sourceFile.getPath() + "' has no content. Either delete the file or make it valid.");
                             }
-                            secondaryDescContent.put(sourceFile.getPath(), sourceFile.getContent());
                         }
+                        secondaryDescContent.put(sourceFile.getPath(), sourceFile.getContent());
                     }
                 }
                 tempMainDescriptor = File.createTempFile("main", "descriptor", Files.createTempDir());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -199,6 +199,7 @@ public class WDLHandler implements LanguageHandlerInterface {
                     if (primaryDescriptor.get().getContent() == null || primaryDescriptor.get().getContent().trim().replaceAll("\n", "").isEmpty()) {
                         return new javafx.util.Pair<>(false, "The primary descriptor '" + primaryDescriptorFilePath + "' has no content. Please make it a valid WDL document if you want to save.");
                     }
+                    mainDescriptor = primaryDescriptor.get().getContent();
                 } else {
                     return new Pair<>(false, "The primary descriptor '" + primaryDescriptorFilePath + "' could not be found.");
                 }
@@ -239,7 +240,7 @@ public class WDLHandler implements LanguageHandlerInterface {
                 FileUtils.deleteQuietly(tempMainDescriptor);
             }
         } else {
-            return new javafx.util.Pair<>(false, "Primary descriptor is not present.");
+            return new javafx.util.Pair<>(false, "Primary WDL descriptor is not present.");
         }
         return new javafx.util.Pair<>(true, null);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -180,10 +180,14 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
 
         U version = getVersion(entry);
         Set<SourceFile> versionSourceFiles = handleSourceFileMerger(entryId, sourceFiles, entry, version);
-        boolean isValidVersion = checkValidVersion(versionSourceFiles, entry);
+
+        version = versionValidation(version, entry);
+
+        boolean isValidVersion = isValidVersion(version);
         if (!isValidVersion) {
             throw new CustomWebApplicationException("Your edited files are invalid. No new version was created. Please check your syntax and try again.", HttpStatus.SC_BAD_REQUEST);
         }
+
         version.setValid(true);
         version.setVersionEditor(user);
         populateMetadata(versionSourceFiles, entry, version);
@@ -197,9 +201,17 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
         return newTool;
     }
 
+    protected abstract boolean isValidVersion(U version);
+
     protected abstract void populateMetadata(Set<SourceFile> sourceFiles, T entry, U version);
 
-    protected abstract boolean checkValidVersion(Set<SourceFile> sourceFiles, T entry);
+    /**
+     * Will update the version with validation information
+     * @param version Version to validate
+     * @param entry Entry for the version
+     * @return Version with updated validation information
+     */
+    protected abstract U versionValidation(U version, T entry);
 
     private void checkHosted(T entry) {
         if (entry instanceof Tool) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -186,12 +186,10 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
 
         boolean isValidVersion = isValidVersion(version);
         if (!isValidVersion) {
+            String fallbackMessage = "Your edited files are invalid. No new version was created. Please check your syntax and try again.";
             String validationMessages = createValidationMessages(version);
-            if (validationMessages != null && !validationMessages.isEmpty()) {
-                throw new CustomWebApplicationException(validationMessages, HttpStatus.SC_BAD_REQUEST);
-            } else {
-                throw new CustomWebApplicationException("Your edited files are invalid. No new version was created. Please check your syntax and try again.", HttpStatus.SC_BAD_REQUEST);
-            }
+            validationMessages = (validationMessages != null && !validationMessages.isEmpty()) ? validationMessages : fallbackMessage;
+            throw new CustomWebApplicationException(validationMessages, HttpStatus.SC_BAD_REQUEST);
         }
 
         version.setValid(true); // Hosted entry versions must be valid to save
@@ -207,11 +205,19 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
         return newTool;
     }
 
+    /**
+     * Prints out all of the invalid validations
+     * Used for returning error messages on attempting to save
+     * @param version version of interest
+     * @return String containing all invalid validation messages
+     */
     protected String createValidationMessages(U version) {
         StringBuilder result = new StringBuilder();
+        int count = 1;
         for (VersionValidation versionValidation : version.getValidations()) {
-            if (versionValidation.getMessage() != null) {
-                result.append(versionValidation.getMessage());
+            if (!versionValidation.isValid() && versionValidation.getMessage() != null) {
+                result.append(count + ") " + versionValidation.getMessage());
+                count++;
             }
         }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
@@ -143,6 +143,7 @@ public class HostedToolResource extends AbstractHostedEntryResource<Tool, Tag, T
         boolean isValidCWL = LanguageHandlerFactory.getInterface(SourceFile.FileType.DOCKSTORE_CWL).isValidToolSet(sourceFiles, "/Dockstore.cwl");
         boolean isValidWDL = LanguageHandlerFactory.getInterface(SourceFile.FileType.DOCKSTORE_WDL).isValidToolSet(sourceFiles, "/Dockstore.wdl");
 
+        // TODO: Dockerfile validation
         boolean hasDockerfile = sourceFiles.stream().anyMatch(sf -> Objects.equals(sf.getPath(), "/Dockerfile"));
         return (isValidCWL || isValidWDL) && hasDockerfile;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
@@ -140,7 +140,7 @@ public class HostedToolResource extends AbstractHostedEntryResource<Tool, Tag, T
 
     @Override
     protected boolean checkValidVersion(Set<SourceFile> sourceFiles, Tool entry) {
-        boolean isValidCWL = sourceFiles.stream().anyMatch(sf -> Objects.equals(sf.getPath(), "/Dockstore.cwl"));
+        boolean isValidCWL = LanguageHandlerFactory.getInterface(SourceFile.FileType.DOCKSTORE_CWL).isValidToolSet(sourceFiles, "/Dockstore.cwl");
         boolean isValidWDL = LanguageHandlerFactory.getInterface(SourceFile.FileType.DOCKSTORE_WDL).isValidToolSet(sourceFiles, "/Dockstore.wdl");
 
         boolean hasDockerfile = sourceFiles.stream().anyMatch(sf -> Objects.equals(sf.getPath(), "/Dockerfile"));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
@@ -141,7 +141,8 @@ public class HostedToolResource extends AbstractHostedEntryResource<Tool, Tag, T
     @Override
     protected boolean checkValidVersion(Set<SourceFile> sourceFiles, Tool entry) {
         boolean isValidCWL = sourceFiles.stream().anyMatch(sf -> Objects.equals(sf.getPath(), "/Dockstore.cwl"));
-        boolean isValidWDL = sourceFiles.stream().anyMatch(sf -> Objects.equals(sf.getPath(), "/Dockstore.wdl"));
+        boolean isValidWDL = LanguageHandlerFactory.getInterface(SourceFile.FileType.DOCKSTORE_WDL).isValidToolSet(sourceFiles, "/Dockstore.wdl");
+
         boolean hasDockerfile = sourceFiles.stream().anyMatch(sf -> Objects.equals(sf.getPath(), "/Dockerfile"));
         return (isValidCWL || isValidWDL) && hasDockerfile;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
@@ -45,8 +45,8 @@ import io.dockstore.webservice.permissions.Role;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.Authorization;
+import javafx.util.Pair;
 import org.apache.commons.lang3.tuple.MutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.HttpStatus;
 import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
@@ -190,13 +190,18 @@ public class HostedWorkflowResource extends AbstractHostedEntryResource<Workflow
             VersionValidation descriptorValidation = new VersionValidation(identifiedType, validDescriptorSet.getKey(), validDescriptorSet.getValue());
             version.addVersionValidation(descriptorValidation);
         } else {
-            Pair<Boolean, String> noPrimaryDescriptor = new MutablePair<>(false, "Missing the primary descriptor.");
+            Pair<Boolean, String> noPrimaryDescriptor = new Pair<>(false, "Missing the primary descriptor.");
             VersionValidation noPrimaryDescriptorValidation = new VersionValidation(identifiedType, noPrimaryDescriptor.getKey(), noPrimaryDescriptor.getValue());
             version.addVersionValidation(noPrimaryDescriptorValidation);
         }
 
+        SourceFile.FileType testParameterType = SourceFile.FileType.CWL_TEST_JSON;
+        if (Objects.equals(identifiedType, SourceFile.FileType.DOCKSTORE_WDL)) {
+            testParameterType = SourceFile.FileType.WDL_TEST_JSON;
+        }
+
         Pair<Boolean, String> validTestParameterSet = LanguageHandlerFactory.getInterface(identifiedType).validateTestParameterSet(sourceFiles);
-        VersionValidation testParameterValidation = new VersionValidation(identifiedType, validTestParameterSet.getKey(), validTestParameterSet.getValue());
+        VersionValidation testParameterValidation = new VersionValidation(testParameterType, validTestParameterSet.getKey(), validTestParameterSet.getValue());
         version.addVersionValidation(testParameterValidation);
 
         return version;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
@@ -182,7 +182,6 @@ public class HostedWorkflowResource extends AbstractHostedEntryResource<Workflow
 
         Optional<SourceFile> mainDescriptor = sourceFiles.stream().filter((sourceFile -> Objects.equals(sourceFile.getPath(), mainDescriptorPath))).findFirst();
 
-        return mainDescriptor.isPresent() && LanguageHandlerFactory.getInterface(identifiedType).isValidWorkflow(mainDescriptor.get().getContent())
-                 && LanguageHandlerFactory.getInterface(identifiedType).isValidWorkflowSet(sourceFiles, mainDescriptorPath);
+        return mainDescriptor.isPresent() && LanguageHandlerFactory.getInterface(identifiedType).isValidWorkflowSet(sourceFiles, mainDescriptorPath);
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
@@ -179,11 +179,10 @@ public class HostedWorkflowResource extends AbstractHostedEntryResource<Workflow
     protected boolean checkValidVersion(Set<SourceFile> sourceFiles, Workflow entry) {
         SourceFile.FileType identifiedType = entry.getFileType();
         String mainDescriptorPath = this.descriptorTypeToDefaultDescriptorPath.get(entry.getDescriptorType().toLowerCase());
-        for (SourceFile sourceFile : sourceFiles) {
-            if (Objects.equals(sourceFile.getPath(), mainDescriptorPath)) {
-                return LanguageHandlerFactory.getInterface(identifiedType).isValidWorkflow(sourceFile.getContent());
-            }
-        }
-        return false;
+
+        Optional<SourceFile> mainDescriptor = sourceFiles.stream().filter((sourceFile -> Objects.equals(sourceFile.getPath(), mainDescriptorPath))).findFirst();
+
+        return mainDescriptor.isPresent() && LanguageHandlerFactory.getInterface(identifiedType).isValidWorkflow(mainDescriptor.get().getContent())
+                 && LanguageHandlerFactory.getInterface(identifiedType).isValidWorkflowSet(sourceFiles, mainDescriptorPath);
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -439,6 +439,9 @@ public class WorkflowResource
                     workflowVersionFromDB.getSourceFiles().remove(entry.getValue());
                 }
             }
+
+            // Update the validations
+            workflowVersionFromDB.upsertVersionValidations(version.getValidations());
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1165,12 +1165,6 @@ public class WorkflowResource
 
         WorkflowVersion workflowVersion = potentialWorfklowVersion.get();
 
-        if (!workflowVersion.isValid()) {
-            String msg = "The version \'" + version + "\' for workflow \'" + workflow.getWorkflowPath() + "\' is invalid.";
-            LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
-        }
-
         Set<SourceFile> sourceFiles = workflowVersion.getSourceFiles();
 
         // Add new test parameter files
@@ -1206,13 +1200,6 @@ public class WorkflowResource
         }
 
         WorkflowVersion workflowVersion = potentialWorfklowVersion.get();
-
-        if (!workflowVersion.isValid()) {
-            LOG.info("The version \'" + version + "\' for workflow \'" + workflow.getWorkflowPath() + "\' is invalid.");
-            throw new CustomWebApplicationException(
-                "The version \'" + version + "\' for workflow \'" + workflow.getWorkflowPath() + "\' is invalid.",
-                HttpStatus.SC_BAD_REQUEST);
-        }
 
         Set<SourceFile> sourceFiles = workflowVersion.getSourceFiles();
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -383,6 +383,8 @@ public class WorkflowResource
     }
 
     /**
+     * Updates the existing workflow in the database with new information from newWorkflow, including new, updated, and removed
+     * workflow verions.
      * @param workflow    workflow to be updated
      * @param newWorkflow workflow to grab new content from
      */
@@ -441,7 +443,8 @@ public class WorkflowResource
             }
 
             // Update the validations
-            workflowVersionFromDB.upsertVersionValidations(version.getValidations());
+            workflowVersionFromDB.getValidations().clear();
+            workflowVersionFromDB.getValidations().addAll(version.getValidations());
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -67,6 +67,7 @@ import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Version;
+import io.dockstore.webservice.core.VersionValidation;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowMode;
 import io.dockstore.webservice.core.WorkflowVersion;
@@ -443,8 +444,10 @@ public class WorkflowResource
             }
 
             // Update the validations
-            workflowVersionFromDB.getValidations().clear();
             workflowVersionFromDB.getValidations().addAll(version.getValidations());
+            for (VersionValidation versionValidation : version.getValidations()) {
+                workflowVersionFromDB.addVersionValidation(versionValidation);
+            }
         }
     }
 

--- a/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
@@ -29,4 +29,36 @@
         </addColumn>
     </changeSet>
 
+    <changeSet author="aduncan (generated)" id="1537982702952-1">
+        <createTable tableName="version_versionvalidation">
+            <column name="versionid" type="BIGINT">
+                <constraints primaryKey="true" primaryKeyName="version_versionvalidation_pkey"/>
+            </column>
+            <column name="versionvalidationid" type="BIGINT">
+                <constraints primaryKey="true" primaryKeyName="version_versionvalidation_pkey"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="aduncan (generated)" id="1537982702952-2">
+        <createTable tableName="versionvalidation">
+            <column autoIncrement="true" name="id" type="BIGSERIAL">
+                <constraints primaryKey="true" primaryKeyName="versionvalidation_pkey"/>
+            </column>
+            <column name="dbcreatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="dbupdatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="message" type="TEXT"/>
+            <column name="type" type="VARCHAR(255)"/>
+            <column name="valid" type="BOOLEAN"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="aduncan (generated)" id="1537982702952-3">
+        <addUniqueConstraint columnNames="versionvalidationid" constraintName="uk_1vljugb1gn7ji34c7hj86lito" tableName="version_versionvalidation"/>
+    </changeSet>
+    <changeSet author="aduncan (generated)" id="1537982702952-4">
+        <addUniqueConstraint columnNames="sourcecontrol, organization, repository, workflowname" constraintName="ukf7t1is17055ui265oq4vh3y3q" tableName="workflow"/>
+    </changeSet>
+    <changeSet author="aduncan (generated)" id="1537982702952-5">
+        <addForeignKeyConstraint baseColumnNames="versionvalidationid" baseTableName="version_versionvalidation" constraintName="fk99oeofctecbuetaje96dx1g2q" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="versionvalidation"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
@@ -19,16 +19,6 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd"
                    context="1.6.0">
 
-    <changeSet author="aduncan" id="createVersionValidationMessage">
-        <addColumn tableName="tag">
-            <column name="cwlvalidationmessage" type="TEXT"/>
-            <column name="wdlvalidationmessage" type="TEXT"/>
-        </addColumn>
-        <addColumn tableName="workflowversion">
-            <column name="validationmessage" type="TEXT"/>
-        </addColumn>
-    </changeSet>
-
     <changeSet author="aduncan (generated)" id="1537982702952-1">
         <createTable tableName="version_versionvalidation">
             <column name="versionid" type="BIGINT">
@@ -53,9 +43,6 @@
     </changeSet>
     <changeSet author="aduncan (generated)" id="1537982702952-3">
         <addUniqueConstraint columnNames="versionvalidationid" constraintName="uk_1vljugb1gn7ji34c7hj86lito" tableName="version_versionvalidation"/>
-    </changeSet>
-    <changeSet author="aduncan (generated)" id="1537982702952-4">
-        <addUniqueConstraint columnNames="sourcecontrol, organization, repository, workflowname" constraintName="ukf7t1is17055ui265oq4vh3y3q" tableName="workflow"/>
     </changeSet>
     <changeSet author="aduncan (generated)" id="1537982702952-5">
         <addForeignKeyConstraint baseColumnNames="versionvalidationid" baseTableName="version_versionvalidation" constraintName="fk99oeofctecbuetaje96dx1g2q" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="versionvalidation"/>

--- a/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
@@ -1,0 +1,31 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<!--
+  ~    Copyright 2017 OICR
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd"
+                   context="1.6.0">
+
+    <changeSet author="aduncan" id="createVersionValidationMessage">
+        <addColumn tableName="tag">
+            <column name="validationmessage" type="TEXT"/>
+        </addColumn>
+        <addColumn tableName="workflowversion">
+            <column name="validationmessage" type="TEXT"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
@@ -21,7 +21,8 @@
 
     <changeSet author="aduncan" id="createVersionValidationMessage">
         <addColumn tableName="tag">
-            <column name="validationmessage" type="TEXT"/>
+            <column name="cwlvalidationmessage" type="TEXT"/>
+            <column name="wdlvalidationmessage" type="TEXT"/>
         </addColumn>
         <addColumn tableName="workflowversion">
             <column name="validationmessage" type="TEXT"/>

--- a/dockstore-webservice/src/main/resources/migrations.xml
+++ b/dockstore-webservice/src/main/resources/migrations.xml
@@ -24,6 +24,7 @@
     <include file="migrations.test.confidential2.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.4.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.5.0.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.1.6.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.samepaths.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.testworkflow.xml" relativeToChangelogFile="true"/>

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -5937,6 +5937,9 @@ components:
           description: >-
             This is the commit id for the source control that the files belong
             to
+        validationMessage:
+          type: string
+          description: Error message for file validation.
       description: This describes one tag associated with a container.
     Token:
       type: object
@@ -6592,4 +6595,7 @@ components:
           description: >-
             This is the commit id for the source control that the files belong
             to
+        validationMessage:
+          type: string
+          description: Error message for file validation.
       description: This describes one workflow version associated with a workflow.

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -5937,9 +5937,12 @@ components:
           description: >-
             This is the commit id for the source control that the files belong
             to
-        validationMessage:
+        cwlValidationMessage:
           type: string
-          description: Error message for file validation.
+          description: Error message for CWL file validation.
+        wdlValidationMessage:
+          type: string
+          description: Error message for WDL file validation.
       description: This describes one tag associated with a container.
     Token:
       type: object

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -5842,6 +5842,12 @@ components:
             - BRANCH
             - NOT_APPLICABLE
             - UNSET
+        validations:
+          type: array
+          description: Cached validations for each version.
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/VersionValidation'
         last_modified:
           type: string
           format: date-time
@@ -6332,6 +6338,8 @@ components:
         verifiedSource:
           type: string
           readOnly: true
+    VersionValidation:
+      type: object
     Workflow:
       type: object
       required:
@@ -6520,6 +6528,12 @@ components:
             - BRANCH
             - NOT_APPLICABLE
             - UNSET
+        validations:
+          type: array
+          description: Cached validations for each version.
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/VersionValidation'
         workingDirectory:
           type: string
         last_modified:

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ info:
     This describes the dockstore API, a webservice that manages pairs of Docker
     images and associated metadata such as CWL documents and Dockerfiles used to
     build those images
-  version: 1.5.0-rc.2-SNAPSHOT
+  version: 1.6.0-alpha.0-SNAPSHOT
   title: Dockstore API
   termsOfService: TBD
   contact:

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -5943,12 +5943,6 @@ components:
           description: >-
             This is the commit id for the source control that the files belong
             to
-        cwlValidationMessage:
-          type: string
-          description: Error message for CWL file validation.
-        wdlValidationMessage:
-          type: string
-          description: Error message for WDL file validation.
       description: This describes one tag associated with a container.
     Token:
       type: object
@@ -6340,6 +6334,34 @@ components:
           readOnly: true
     VersionValidation:
       type: object
+      required:
+        - id
+        - message
+        - type
+        - valid
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Implementation specific ID for the source file in this web service
+        type:
+          type: string
+          description: Enumerates the type of file
+          enum:
+            - DOCKSTORE_CWL
+            - DOCKSTORE_WDL
+            - DOCKERFILE
+            - CWL_TEST_JSON
+            - WDL_TEST_JSON
+            - NEXTFLOW
+            - NEXTFLOW_CONFIG
+            - NEXTFLOW_TEST_PARAMS
+        valid:
+          type: boolean
+          description: Is the file type valid
+        message:
+          type: string
+          description: Validation message
     Workflow:
       type: object
       required:
@@ -6612,7 +6634,4 @@ components:
           description: >-
             This is the commit id for the source control that the files belong
             to
-        validationMessage:
-          type: string
-          description: Error message for file validation.
       description: This describes one workflow version associated with a workflow.

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5507,6 +5507,10 @@ definitions:
         position: 22
         description: "This is the commit id for the source control that the files\
           \ belong to"
+      validationMessage:
+        type: "string"
+        position: 22
+        description: "Error message for file validation."
     description: "This describes one tag associated with a container."
   Token:
     type: "object"
@@ -6168,6 +6172,10 @@ definitions:
         position: 22
         description: "This is the commit id for the source control that the files\
           \ belong to"
+      validationMessage:
+        type: "string"
+        position: 22
+        description: "Error message for file validation."
     description: "This describes one workflow version associated with a workflow."
 externalDocs:
   description: "Dockstore documentation"

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.5.0-rc.2-SNAPSHOT"
+  version: "1.6.0-alpha.0-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5507,10 +5507,14 @@ definitions:
         position: 22
         description: "This is the commit id for the source control that the files\
           \ belong to"
-      validationMessage:
+      cwlValidationMessage:
         type: "string"
         position: 22
-        description: "Error message for file validation."
+        description: "Error message for CWL file validation."
+      wdlValidationMessage:
+        type: "string"
+        position: 23
+        description: "Error message for WDL file validation."
     description: "This describes one tag associated with a container."
   Token:
     type: "object"

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5513,14 +5513,6 @@ definitions:
         position: 22
         description: "This is the commit id for the source control that the files\
           \ belong to"
-      cwlValidationMessage:
-        type: "string"
-        position: 22
-        description: "Error message for CWL file validation."
-      wdlValidationMessage:
-        type: "string"
-        position: 23
-        description: "Error message for WDL file validation."
     description: "This describes one tag associated with a container."
   Token:
     type: "object"
@@ -5895,6 +5887,37 @@ definitions:
         readOnly: true
   VersionValidation:
     type: "object"
+    required:
+    - "id"
+    - "message"
+    - "type"
+    - "valid"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+        description: "Implementation specific ID for the source file in this web service"
+      type:
+        type: "string"
+        position: 1
+        description: "Enumerates the type of file"
+        enum:
+        - "DOCKSTORE_CWL"
+        - "DOCKSTORE_WDL"
+        - "DOCKERFILE"
+        - "CWL_TEST_JSON"
+        - "WDL_TEST_JSON"
+        - "NEXTFLOW"
+        - "NEXTFLOW_CONFIG"
+        - "NEXTFLOW_TEST_PARAMS"
+      valid:
+        type: "boolean"
+        position: 2
+        description: "Is the file type valid"
+      message:
+        type: "string"
+        position: 3
+        description: "Validation message"
   Workflow:
     type: "object"
     required:
@@ -6190,10 +6213,6 @@ definitions:
         position: 22
         description: "This is the commit id for the source control that the files\
           \ belong to"
-      validationMessage:
-        type: "string"
-        position: 22
-        description: "Error message for file validation."
     description: "This describes one workflow version associated with a workflow."
 externalDocs:
   description: "Dockstore documentation"

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5397,6 +5397,12 @@ definitions:
         - "BRANCH"
         - "NOT_APPLICABLE"
         - "UNSET"
+      validations:
+        type: "array"
+        description: "Cached validations for each version."
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/VersionValidation"
       last_modified:
         type: "string"
         format: "date-time"
@@ -5887,6 +5893,8 @@ definitions:
       verifiedSource:
         type: "string"
         readOnly: true
+  VersionValidation:
+    type: "object"
   Workflow:
     type: "object"
     required:
@@ -6088,6 +6096,12 @@ definitions:
         - "BRANCH"
         - "NOT_APPLICABLE"
         - "UNSET"
+      validations:
+        type: "array"
+        description: "Cached validations for each version."
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/VersionValidation"
       workingDirectory:
         type: "string"
       last_modified:

--- a/propose_migration.sh
+++ b/propose_migration.sh
@@ -14,7 +14,7 @@ rm dockstore-webservice/target/detected-migrations.xml || true
 
 ## load up the old database based on current migration
 rm dockstore-webservice/target/dockstore-webservice-*sources.jar || true
-java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstoreTest.yml --include 1.3.0.generated,1.4.0,1.5.0
+java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstoreTest.yml --include 1.3.0.generated,1.4.0,1.5.0,1.6.0
 ## create the new database based on JPA (ugly, should really create a proper dw command if this works)
 timeout 15 java -Ddw.database.url=jdbc:postgresql://localhost:5432/webservice_test_proposed -Ddw.database.properties.hibernate.hbm2ddl.auto=create -jar dockstore-webservice/target/dockstore-webservice-*.jar server dockstore-integration-testing/src/test/resources/dockstoreTest.yml || true
 


### PR DESCRIPTION
This is a redesign of how we do file validation. For CWL and Nextflow the file validation is the same as before in terms of what we check for for validity, but for WDL we do some more syntax checks. We also check to see that the test parameter files are valid.

A version has many versionvalidations. Each version validation has a corresponding version, file type, message, and isValid boolean. For each version, version validation file types must be unique. For example, you cannot have two versionvalidations for the same version that are both DOCKSTORE_CWL. There would be one entry, which says whether the CWL descriptor set for a version is valid or not.

There will be a UI2 PR that goes with this that shows basic validation information on the files tab.

This is NOT ready for merge. I have yet to write the migrations for existing tools and workflows. I am opening this PR to get some feedback, since validation will become an integral part of using Dockstore in the future (especially with hosted workflows).

This also adds the 1.6.0 migrations.

[Add and clear issue for version validations](https://stackoverflow.com/a/25251602)