### PR TITLE
Feature/dos-file-provision set configuration added to PreProvisionInterface

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/common/FileProvisioning.java
+++ b/dockstore-client/src/main/java/io/dockstore/common/FileProvisioning.java
@@ -102,10 +102,10 @@ public class FileProvisioning {
             // Map of ProvisionInterface & PreProvisionInterface plugins
             this.pluginsMap = this.plugins
                     .stream()
-                    .collect(Collectors.toMap(plugin -> plugin.getClass().getName().split("\\$")[0], plugin -> plugin));
+                    .collect(Collectors.toMap(plugin -> findPluginName(plugin.getClass().getName()), plugin -> plugin));
             this.preProvisionMap = this.preProvisionPlugins
                     .stream()
-                    .collect(Collectors.toMap(plugin -> plugin.getClass().getName().split("\\$")[0], plugin -> plugin));
+                    .collect(Collectors.toMap(plugin -> findPluginName(plugin.getClass().getName()), plugin -> plugin));
 
             List<PluginWrapper> pluginWrappers = pluginManager.getPlugins();
             for (PluginWrapper pluginWrapper : pluginWrappers) {
@@ -145,6 +145,10 @@ public class FileProvisioning {
     private static boolean isCacheOn(INIConfiguration config) {
         final String useCache = config.getString("use-cache", "false");
         return "true".equalsIgnoreCase(useCache) || "use".equalsIgnoreCase(useCache) || "T".equalsIgnoreCase(useCache);
+    }
+
+    static String findPluginName(String classObj) {
+        return classObj.split("\\$")[0];
     }
 
     public static void main(String[] args) {

--- a/dockstore-client/src/main/java/io/dockstore/common/FileProvisioning.java
+++ b/dockstore-client/src/main/java/io/dockstore/common/FileProvisioning.java
@@ -81,9 +81,6 @@ public class FileProvisioning {
     private List<ProvisionInterface> plugins = new ArrayList<>();
     private List<PreProvisionInterface> preProvisionPlugins = new ArrayList<>();
 
-    private Map<String, ProvisionInterface> pluginsMap = new HashMap<>();
-    private Map<String, PreProvisionInterface> preProvisionMap = new HashMap<>();
-
     private INIConfiguration config;
 
     /**
@@ -100,12 +97,13 @@ public class FileProvisioning {
             this.preProvisionPlugins = pluginManager.getExtensions(PreProvisionInterface.class);
 
             // Map of ProvisionInterface & PreProvisionInterface plugins
-            this.pluginsMap = this.plugins
-                    .stream()
-                    .collect(Collectors.toMap(plugin -> findPluginName(plugin.getClass().getName()), plugin -> plugin));
-            this.preProvisionMap = this.preProvisionPlugins
-                    .stream()
-                    .collect(Collectors.toMap(plugin -> findPluginName(plugin.getClass().getName()), plugin -> plugin));
+            Map<String, ProvisionInterface> pluginsMap = this.plugins
+                .stream()
+                .collect(Collectors.toMap(plugin -> findPluginName(plugin.getClass().getName()), plugin -> plugin));
+
+            Map<String, PreProvisionInterface> preProvisionMap = this.preProvisionPlugins
+                .stream()
+                .collect(Collectors.toMap(plugin -> findPluginName(plugin.getClass().getName()), plugin -> plugin));
 
             List<PluginWrapper> pluginWrappers = pluginManager.getPlugins();
             for (PluginWrapper pluginWrapper : pluginWrappers) {
@@ -147,7 +145,12 @@ public class FileProvisioning {
         return "true".equalsIgnoreCase(useCache) || "use".equalsIgnoreCase(useCache) || "T".equalsIgnoreCase(useCache);
     }
 
-    static String findPluginName(String classObj) {
+    /*
+     * Retrieves plugin name given object class name.
+     * Splits outer plugin class name (which extends Plugin abstract class) and inner class name (which extends
+     * ProvisionInterface or PreProvisionInterface), then returns outer plugin name
+    */
+    public static String findPluginName(String classObj) {
         return classObj.split("\\$")[0];
     }
 

--- a/dockstore-client/src/main/java/io/dockstore/common/VersionAwarePluginManager.java
+++ b/dockstore-client/src/main/java/io/dockstore/common/VersionAwarePluginManager.java
@@ -41,8 +41,8 @@ import ro.fortsoft.pf4j.util.NotFileFilter;
 public class VersionAwarePluginManager extends DefaultPluginManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(VersionAwarePluginManager.class);
-    // Version 0.0.0 -> Up to 1.4; Version 0.0.1 -> 1.5
-    private static final Version SYSTEM_VERSION = Version.forIntegers(0, 0, 1);
+    // Version 0.0.0 -> Up to 1.4; Version 0.0.1 -> 1.5; Version 0.0.2 -> 1.6
+    private static final Version SYSTEM_VERSION = Version.forIntegers(0, 0, 2);
     // maps plugin id -> version, directory path
     private Map<String, Pair<Version, File>> pluginVersionMap = new HashMap<>();
 

--- a/dockstore-client/src/test/java/io/dockstore/common/FileProvisionTest.java
+++ b/dockstore-client/src/test/java/io/dockstore/common/FileProvisionTest.java
@@ -32,4 +32,13 @@ public class FileProvisionTest {
         assertEquals(FileProvisioning.findSupportedTargetPath(Arrays.asList(s3Mock, httpMock),
                 Arrays.asList("gcs://something")), Optional.empty());
     }
+
+    @Test
+    public void testFindPluginName() {
+        String s3Class = "io.dockstore.provision.S3Plugin$S3Provision";
+        String dosClass = "io.dockstore.provision.DOSPlugin$DOSPreProvision";
+
+        assertEquals("io.dockstore.provision.S3Plugin", FileProvisioning.findPluginName(s3Class));
+        assertEquals("io.dockstore.provision.DOSPlugin", FileProvisioning.findPluginName(dosClass));
+    }
 }

--- a/dockstore-file-plugin-parent/src/main/java/io/dockstore/provision/PreProvisionInterface.java
+++ b/dockstore-file-plugin-parent/src/main/java/io/dockstore/provision/PreProvisionInterface.java
@@ -1,6 +1,7 @@
 package io.dockstore.provision;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import ro.fortsoft.pf4j.ExtensionPoint;
@@ -46,4 +47,12 @@ public interface PreProvisionInterface extends ExtensionPoint {
      * @return return schemes that this preprovisioning interface handles (ex: dos)
      */
     Set<String> schemesHandled();
+
+    /**
+     * Optional method that can be overridden.
+     *
+     */
+    default void setConfiguration(Map<String, String> config) {
+
+    };
 }

--- a/dockstore-file-plugin-parent/src/main/java/io/dockstore/provision/PreProvisionInterface.java
+++ b/dockstore-file-plugin-parent/src/main/java/io/dockstore/provision/PreProvisionInterface.java
@@ -53,6 +53,6 @@ public interface PreProvisionInterface extends ExtensionPoint {
      *
      */
     default void setConfiguration(Map<String, String> config) {
-
+        // No default implementation necessary
     };
 }


### PR DESCRIPTION
* Adds a default method to the PreProvisionInterface class that enables passing in configuration settings from config file
* Uses map objects to store references to all plugins & pre-provision plugins for faster look up time
* Changes the system version of the VersionAwarePluginManager to 0.0.2 so that Dockstore will not fetch existing plugins that extend old PreProvisionInterfaces (i.e. DOS File Provisioning Plugin v0.0.1)
