### PR TITLE
1850/cwl relative import fix

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
@@ -117,10 +117,12 @@ public class CRUDClientIT extends BaseIT {
         descriptorFile.setContent(FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("tar-param.cwl")), StandardCharsets.UTF_8));
         descriptorFile.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
         descriptorFile.setPath("/Dockstore.cwl");
+        descriptorFile.setAbsolutePath("/Dockstore.cwl");
         SourceFile dockerfile = new SourceFile();
         dockerfile.setContent("FROM ubuntu:latest");
         dockerfile.setType(SourceFile.TypeEnum.DOCKERFILE);
         dockerfile.setPath("/Dockerfile");
+        dockerfile.setAbsolutePath("/Dockerfile");
         DockstoreTool dockstoreTool = api.editHostedTool(hostedTool.getId(), Lists.newArrayList(descriptorFile, dockerfile));
         Optional<Tag> first = dockstoreTool.getTags().stream().max(Comparator.comparingInt((Tag t) -> Integer.parseInt(t.getName())));
         assertEquals("correct number of source files", 2, first.get().getSourceFiles().size());
@@ -130,6 +132,7 @@ public class CRUDClientIT extends BaseIT {
         file2.setContent("{\"message\": \"Hello world!\"}");
         file2.setType(SourceFile.TypeEnum.CWL_TEST_JSON);
         file2.setPath("/test.json");
+        file2.setAbsolutePath("/test.json");
         // add one file and include the old one implicitly
         dockstoreTool = api.editHostedTool(hostedTool.getId(), Lists.newArrayList(file2));
         first = dockstoreTool.getTags().stream().max(Comparator.comparingInt((Tag t) -> Integer.parseInt(t.getName())));
@@ -204,6 +207,7 @@ public class CRUDClientIT extends BaseIT {
         file.setContent(FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("1st-workflow.cwl")), StandardCharsets.UTF_8));
         file.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
         file.setPath("/Dockstore.cwl");
+        file.setAbsolutePath("/Dockstore.cwl");
         Workflow dockstoreWorkflow = api.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file));
         Optional<WorkflowVersion> first = dockstoreWorkflow.getWorkflowVersions().stream().max(Comparator.comparingInt((WorkflowVersion t) -> Integer.parseInt(t.getName())));
         assertEquals("correct number of source files", 1, first.get().getSourceFiles().size());
@@ -213,6 +217,7 @@ public class CRUDClientIT extends BaseIT {
         file2.setContent(FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("arguments.cwl")), StandardCharsets.UTF_8));
         file2.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
         file2.setPath("/arguments.cwl");
+        file2.setAbsolutePath("/arguments.cwl");
         // add one file and include the old one implicitly
         dockstoreWorkflow = api.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file2));
         first = dockstoreWorkflow .getWorkflowVersions().stream().max(Comparator.comparingInt((WorkflowVersion t) -> Integer.parseInt(t.getName())));
@@ -222,6 +227,7 @@ public class CRUDClientIT extends BaseIT {
         file3.setContent(FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("tar-param.cwl")), StandardCharsets.UTF_8));
         file3.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
         file3.setPath("/tar-param.cwl");
+        file3.setAbsolutePath("/tar-param.cwl");
         // add one file and include the old one implicitly
         dockstoreWorkflow = api.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file3));
         first = dockstoreWorkflow .getWorkflowVersions().stream().max(Comparator.comparingInt((WorkflowVersion t) -> Integer.parseInt(t.getName())));
@@ -269,6 +275,7 @@ public class CRUDClientIT extends BaseIT {
         file.setContent(FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("hosted_metadata/Dockstore.cwl")), StandardCharsets.UTF_8));
         file.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
         file.setPath("/Dockstore.cwl");
+        file.setAbsolutePath("/Dockstore.cwl");
         Workflow dockstoreWorkflow = api.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file));
         assertTrue(!dockstoreWorkflow.getAuthor().isEmpty() && !dockstoreWorkflow.getEmail().isEmpty());
     }
@@ -280,6 +287,7 @@ public class CRUDClientIT extends BaseIT {
         file.setContent(FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("metadata_example2.wdl")), StandardCharsets.UTF_8));
         file.setType(SourceFile.TypeEnum.DOCKSTORE_WDL);
         file.setPath("/Dockstore.wdl");
+        file.setAbsolutePath("/Dockstore.wdl");
         Workflow dockstoreWorkflow = api.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file));
         assertTrue(!dockstoreWorkflow.getAuthor().isEmpty() && !dockstoreWorkflow.getEmail().isEmpty());
     }
@@ -341,10 +349,12 @@ public class CRUDClientIT extends BaseIT {
         descriptorFile.setContent(FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("tar-param.cwl")), StandardCharsets.UTF_8));
         descriptorFile.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
         descriptorFile.setPath("/Dockstore.cwl");
+        descriptorFile.setAbsolutePath("/Dockstore.cwl");
         SourceFile dockerfile = new SourceFile();
         dockerfile.setContent("FROM ubuntu:latest");
         dockerfile.setType(SourceFile.TypeEnum.DOCKERFILE);
         dockerfile.setPath("/Dockerfile");
+        dockerfile.setAbsolutePath("/Dockerfile");
         DockstoreTool dockstoreTool = hostedApi.editHostedTool(hostedTool.getId(), Lists.newArrayList(descriptorFile, dockerfile));
         Optional<Tag> first = dockstoreTool.getTags().stream().max(Comparator.comparingInt((Tag t) -> Integer.parseInt(t.getName())));
         assertTrue(first.isPresent());
@@ -368,6 +378,7 @@ public class CRUDClientIT extends BaseIT {
         file.setContent(FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("1st-workflow.cwl")), StandardCharsets.UTF_8));
         file.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
         file.setPath("/Dockstore.cwl");
+        file.setAbsolutePath("/Dockstore.cwl");
         Workflow dockstoreWorkflow = hostedApi.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file));
         Optional<WorkflowVersion> first = dockstoreWorkflow.getWorkflowVersions().stream().max(Comparator.comparingInt((WorkflowVersion t) -> Integer.parseInt(t.getName())));
         assertTrue(first.isPresent());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
@@ -253,8 +253,8 @@ public class DAGWorkflowTestIT extends BaseIT {
         Assert.assertTrue("should have end with filter and normalize",
             strings.get(0).contains("\"source\":\"dockstore_filter\",\"target\":\"dockstore_normalize\""));
         Assert.assertTrue("should have docker requirement for vcf_merge", strings.get(0).contains(
-            "\"name\":\"merge_vcfs\",\"run\":\"vcf_merge.cwl\",\"id\":\"dockstore_merge_vcfs\",\"type\":\"tool\",\"tool\":\"https://hub.docker.com/r/pancancer/pcawg-oxog-tools\",\"docker\":\"pancancer/pcawg-oxog-tools\""));
+            "\"name\":\"merge_vcfs\",\"run\":\"/vcf_merge.cwl\",\"id\":\"dockstore_merge_vcfs\",\"type\":\"tool\",\"tool\":\"https://hub.docker.com/r/pancancer/pcawg-oxog-tools\",\"docker\":\"pancancer/pcawg-oxog-tools\""));
         Assert.assertTrue("should have docker requirement for clean", strings.get(0).contains(
-            "\"name\":\"clean\",\"run\":\"clean_vcf.cwl\",\"id\":\"dockstore_clean\",\"type\":\"tool\",\"tool\":\"https://hub.docker.com/r/pancancer/pcawg-oxog-tools\",\"docker\":\"pancancer/pcawg-oxog-tools:1.0.0\""));
+            "\"name\":\"clean\",\"run\":\"/clean_vcf.cwl\",\"id\":\"dockstore_clean\",\"type\":\"tool\",\"tool\":\"https://hub.docker.com/r/pancancer/pcawg-oxog-tools\",\"docker\":\"pancancer/pcawg-oxog-tools:1.0.0\""));
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
@@ -257,4 +257,44 @@ public class DAGWorkflowTestIT extends BaseIT {
         Assert.assertTrue("should have docker requirement for clean", strings.get(0).contains(
             "\"name\":\"clean\",\"run\":\"clean_vcf.cwl\",\"id\":\"dockstore_clean\",\"type\":\"tool\",\"tool\":\"https://hub.docker.com/r/pancancer/pcawg-oxog-tools\",\"docker\":\"pancancer/pcawg-oxog-tools:1.0.0\""));
     }
+
+    /**
+     * This tests the NCI-GDC DNASeq workflow. This workflow has a huge dag and about 30+ files. It also has secondary, tertiary, etc imports.\
+     * This also tests that absolute paths are correctly used for improted files.
+     * @throws ApiException
+     */
+    @Test
+    public void testHugeWorkflowWithManyImports() throws ApiException {
+        // Input: /workflows/dnaseq/transform.cwl
+        // Repo: gdc-dnaseq-cwl
+        // Branch: master
+        // Return: DAG with 110 nodes
+
+        final List<String> strings = getJSON("DockstoreTestUser2/gdc-dnaseq-cwl", "/workflows/dnaseq/transform.cwl", "cwl",
+                "master");
+        int countNode = countNodeInJSON(strings);
+
+        Assert.assertTrue("JSON should not be blank", strings.size() > 0);
+        Assert.assertEquals("JSON should have 110 nodes", countNode, 110);
+    }
+
+    /**
+     * This tests the CWL Gene Prioritization workflow. The getSteps function returns an array instead of the previously assumed object. This has been fixed,
+     * and this is testing that it is fixed.
+     * @throws ApiException
+     */
+    @Test
+    public void testGetStepsArrayInsteadOfObject() throws ApiException {
+        // Input: /gp_workflow.cwl
+        // Repo: cwl-gene-prioritization
+        // Branch: master
+        // Return: DAG with 5 nodes
+
+        final List<String> strings = getJSON("DockstoreTestUser2/cwl-gene-prioritization", "/gp_workflow.cwl", "cwl",
+                "master");
+        int countNode = countNodeInJSON(strings);
+
+        Assert.assertTrue("JSON should not be blank", strings.size() > 0);
+        Assert.assertEquals("JSON should have 5 nodes", countNode, 5);
+    }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
@@ -260,7 +260,7 @@ public class DAGWorkflowTestIT extends BaseIT {
 
     /**
      * This tests the NCI-GDC DNASeq workflow. This workflow has a huge dag and about 30+ files. It also has secondary, tertiary, etc imports.\
-     * This also tests that absolute paths are correctly used for improted files.
+     * This also tests that absolute paths are correctly used for imported files.
      * @throws ApiException
      */
     @Test
@@ -271,7 +271,7 @@ public class DAGWorkflowTestIT extends BaseIT {
         // Return: DAG with 110 nodes
 
         final List<String> strings = getJSON("DockstoreTestUser2/gdc-dnaseq-cwl", "/workflows/dnaseq/transform.cwl", "cwl",
-                "master");
+                "test");
         int countNode = countNodeInJSON(strings);
 
         Assert.assertTrue("JSON should not be blank", strings.size() > 0);
@@ -291,10 +291,29 @@ public class DAGWorkflowTestIT extends BaseIT {
         // Return: DAG with 5 nodes
 
         final List<String> strings = getJSON("DockstoreTestUser2/cwl-gene-prioritization", "/gp_workflow.cwl", "cwl",
-                "master");
+                "test");
         int countNode = countNodeInJSON(strings);
 
         Assert.assertTrue("JSON should not be blank", strings.size() > 0);
         Assert.assertEquals("JSON should have 5 nodes", countNode, 5);
+    }
+
+    /**
+     * This tests that a WDL workflow with complex imports is properly imported (also tests absolute paths)
+     * @throws ApiException
+     */
+    @Test
+    public void testComplexImportWdlWorkflow() throws ApiException {
+        // Input: /parent/parent.wdl
+        // Repo: ComplexImportsWdl
+        // Branch: master
+        // Return: DAG with 7 nodes
+
+        final List<String> strings = getJSON("DockstoreTestUser2/ComplexImportsWdl", "/parent/parent.wdl", "wdl",
+                "test");
+        int countNode = countNodeInJSON(strings);
+
+        Assert.assertTrue("JSON should not be blank", strings.size() > 0);
+        Assert.assertEquals("JSON should have 7 nodes", countNode, 7);
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
@@ -253,8 +253,8 @@ public class DAGWorkflowTestIT extends BaseIT {
         Assert.assertTrue("should have end with filter and normalize",
             strings.get(0).contains("\"source\":\"dockstore_filter\",\"target\":\"dockstore_normalize\""));
         Assert.assertTrue("should have docker requirement for vcf_merge", strings.get(0).contains(
-            "\"name\":\"merge_vcfs\",\"run\":\"/vcf_merge.cwl\",\"id\":\"dockstore_merge_vcfs\",\"type\":\"tool\",\"tool\":\"https://hub.docker.com/r/pancancer/pcawg-oxog-tools\",\"docker\":\"pancancer/pcawg-oxog-tools\""));
+            "\"name\":\"merge_vcfs\",\"run\":\"vcf_merge.cwl\",\"id\":\"dockstore_merge_vcfs\",\"type\":\"tool\",\"tool\":\"https://hub.docker.com/r/pancancer/pcawg-oxog-tools\",\"docker\":\"pancancer/pcawg-oxog-tools\""));
         Assert.assertTrue("should have docker requirement for clean", strings.get(0).contains(
-            "\"name\":\"clean\",\"run\":\"/clean_vcf.cwl\",\"id\":\"dockstore_clean\",\"type\":\"tool\",\"tool\":\"https://hub.docker.com/r/pancancer/pcawg-oxog-tools\",\"docker\":\"pancancer/pcawg-oxog-tools:1.0.0\""));
+            "\"name\":\"clean\",\"run\":\"clean_vcf.cwl\",\"id\":\"dockstore_clean\",\"type\":\"tool\",\"tool\":\"https://hub.docker.com/r/pancancer/pcawg-oxog-tools\",\"docker\":\"pancancer/pcawg-oxog-tools:1.0.0\""));
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -108,6 +108,7 @@ public class GeneralIT extends BaseIT {
         fileCWL.setContent("cwlstuff");
         fileCWL.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
         fileCWL.setPath("/dockstore.cwl");
+        fileCWL.setAbsolutePath("/dockstore.cwl");
         List<SourceFile> list = new ArrayList<>();
         list.add(fileCWL);
         tag.setSourceFiles(list);
@@ -115,6 +116,7 @@ public class GeneralIT extends BaseIT {
         fileDockerFile.setContent("dockerstuff");
         fileDockerFile.setType(SourceFile.TypeEnum.DOCKERFILE);
         fileDockerFile.setPath("/Dockerfile");
+        fileDockerFile.setAbsolutePath("/Dockerfile");
         tag.getSourceFiles().add(fileDockerFile);
         List<Tag> tags = new ArrayList<>();
         tags.add(tag);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralRegressionIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralRegressionIT.java
@@ -117,6 +117,7 @@ public class GeneralRegressionIT extends BaseIT {
         fileCWL.setContent("cwlstuff");
         fileCWL.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
         fileCWL.setPath("/Dockstore.cwl");
+        fileCWL.setAbsolutePath("/Dockstore.cwl");
         List<SourceFile> list = new ArrayList<>();
         list.add(fileCWL);
         tag.setSourceFiles(list);
@@ -124,6 +125,7 @@ public class GeneralRegressionIT extends BaseIT {
         fileDockerFile.setContent("dockerstuff");
         fileDockerFile.setType(SourceFile.TypeEnum.DOCKERFILE);
         fileDockerFile.setPath("/Dockerfile");
+        fileDockerFile.setAbsolutePath("/Dockerfile");
         tag.getSourceFiles().add(fileDockerFile);
         List<Tag> tags = new ArrayList<>();
         tags.add(tag);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/LimitedCRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/LimitedCRUDClientIT.java
@@ -146,10 +146,12 @@ public class LimitedCRUDClientIT {
         descriptorFile.setContent(FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("tar-param.cwl")), StandardCharsets.UTF_8));
         descriptorFile.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
         descriptorFile.setPath("/Dockstore.cwl");
+        descriptorFile.setAbsolutePath("/Dockstore.cwl");
         SourceFile dockerfile = new SourceFile();
         dockerfile.setContent("FROM ubuntu:latest");
         dockerfile.setType(SourceFile.TypeEnum.DOCKERFILE);
         dockerfile.setPath("/Dockerfile");
+        dockerfile.setAbsolutePath("/Dockerfile");
         api.editHostedTool(hostedTool.getId(), Lists.newArrayList(descriptorFile, dockerfile));
 
         // test repeated workflow version creation up to limit

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -222,6 +222,7 @@ public class SwaggerClientIT extends BaseIT {
         fileCWL.setContent("cwlstuff");
         fileCWL.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
         fileCWL.setPath("/Dockstore.cwl");
+        fileCWL.setAbsolutePath("/Dockstore.cwl");
         List<SourceFile> files = new ArrayList<>();
         files.add(fileCWL);
         tag.setSourceFiles(files);
@@ -229,16 +230,19 @@ public class SwaggerClientIT extends BaseIT {
         fileDockerFile.setContent("dockerstuff");
         fileDockerFile.setType(SourceFile.TypeEnum.DOCKERFILE);
         fileDockerFile.setPath("/Dockerfile");
+        fileDockerFile.setAbsolutePath("/Dockerfile");
         tag.getSourceFiles().add(fileDockerFile);
         SourceFile testParameterFile = new SourceFile();
         testParameterFile.setContent("testparameterstuff");
         testParameterFile.setType(SourceFile.TypeEnum.CWL_TEST_JSON);
         testParameterFile.setPath("/test1.json");
+        testParameterFile.setAbsolutePath("/test1.json");
         tag.getSourceFiles().add(testParameterFile);
         SourceFile testParameterFile2 = new SourceFile();
         testParameterFile2.setContent("moretestparameterstuff");
         testParameterFile2.setType(SourceFile.TypeEnum.CWL_TEST_JSON);
         testParameterFile2.setPath("/test2.json");
+        testParameterFile2.setAbsolutePath("/test2.json");
         tag.getSourceFiles().add(testParameterFile2);
         List<Tag> tags = new ArrayList<>();
         tags.add(tag);
@@ -916,6 +920,7 @@ public class SwaggerClientIT extends BaseIT {
         fileCWL.setContent("class: Workflow\ncwlVersion: v1.0"); // Need this for CWLHandler:isValidWorkflow
         fileCWL.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
         fileCWL.setPath("/Dockstore.cwl");
+        fileCWL.setAbsolutePath("/Dockstore.cwl");
         return fileCWL;
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -263,7 +263,7 @@ public class WorkflowIT extends BaseIT {
         final ApiClient webClient = getWebClient(USER_2_USERNAME);
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
         Workflow workflow = workflowApi
-            .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "checker-workflow-wrapping-workflow.cwl",
+            .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "/checker-workflow-wrapping-workflow.cwl",
                 "test", "cwl", null);
         assertEquals("There should be one user of the workflow after manually registering it.", 1, workflow.getUsers().size());
         Workflow refresh = workflowApi.refresh(workflow.getId());
@@ -481,7 +481,7 @@ public class WorkflowIT extends BaseIT {
         Workflow refresh = workflowApi.refresh(workflow.getId());
         Assert.assertTrue("workflow is already published for some reason", !refresh.isIsPublished());
 
-        workflowApi.registerCheckerWorkflow("checker-workflow-wrapping-workflow.cwl", workflow.getId(), "cwl", "checker-input-cwl.json");
+        workflowApi.registerCheckerWorkflow("/checker-workflow-wrapping-workflow.cwl", workflow.getId(), "cwl", "checker-input-cwl.json");
 
         workflowApi.refresh(workflow.getId());
 
@@ -812,15 +812,18 @@ public class WorkflowIT extends BaseIT {
         // make a couple garbage edits
         SourceFile source = new SourceFile();
         source.setPath("/Dockstore.cwl");
+        source.setAbsolutePath("/Dockstore.cwl");
         source.setContent("cwlVersion: v1.0\nclass: Workflow");
         source.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
         SourceFile source1 = new SourceFile();
         source1.setPath("sorttool.cwl");
         source1.setContent("foo");
+        source1.setAbsolutePath("/sorttool.cwl");
         source1.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
         SourceFile source2 = new SourceFile();
         source2.setPath("revtool.cwl");
         source2.setContent("foo");
+        source2.setAbsolutePath("/revtool.cwl");
         source2.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
         hostedApi.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(source, source1, source2));
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -100,6 +100,7 @@ public class WorkflowIT extends BaseIT {
     public static final String DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW = SourceControl.GITHUB.toString() + "/DockstoreTestUser2/dockstore_workflow_cnv";
     private static final String DOCKSTORE_TEST_USER2_DOCKSTORE_WORKFLOW = SourceControl.BITBUCKET.toString() + "/dockstore_testuser2/dockstore-workflow";
     private static final String DOCKSTORE_TEST_USER2_IMPORTS_DOCKSTORE_WORKFLOW = SourceControl.GITHUB.toString() + "/DockstoreTestUser2/dockstore-whalesay-imports";
+    private static final String DOCKSTORE_TEST_USER2_GDC_DNASEQ_CWL_WORKFLOW = SourceControl.GITHUB.toString() + "/DockstoreTestUser2/gdc-dnaseq-cwl";
     // workflow with external library in lib directory
     private static final String DOCKSTORE_TEST_USER2_NEXTFLOW_LIB_WORKFLOW = SourceControl.GITHUB.toString() + "/DockstoreTestUser2/rnatoy";
     // workflow that uses containers
@@ -1217,5 +1218,35 @@ public class WorkflowIT extends BaseIT {
         // remove a few aliases
         entry = genericApi.updateAliases(workflow.getId(), "foobar, test workflow", "");
         Assert.assertTrue("entry is missing expected aliases", entry.getAliases().containsKey("foobar") && entry.getAliases().containsKey("test workflow") && entry.getAliases().size() == 2);
+    }
+
+    /**
+     * This tests that the absolute path is properly set for CWL workflow sourcefiles for the primary descriptor and any imported files
+     */
+    @Test
+    public void testAbsolutePathForImportedFilesCWL() {
+        final ApiClient webClient = getWebClient(USER_2_USERNAME);
+        WorkflowsApi workflowApi = new WorkflowsApi(webClient);
+        workflowApi.manualRegister("github", "DockstoreTestUser2/gdc-dnaseq-cwl", "/workflows/dnaseq/transform.cwl", "", "cwl", "/workflows/dnaseq/transform.cwl.json");
+        final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_GDC_DNASEQ_CWL_WORKFLOW);
+        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId());
+
+        Assert.assertEquals("should have 1 version", 1, workflow.getWorkflowVersions().size());
+        WorkflowVersion workflowVersion = workflow.getWorkflowVersions().get(0);
+        List<SourceFile> sourceFiles = workflowVersion.getSourceFiles();
+        Optional<SourceFile> primarySourceFile = sourceFiles.stream().filter(sourceFile -> Objects.equals(sourceFile.getPath(), "/workflows/dnaseq/transform.cwl") && Objects.equals(sourceFile.getAbsolutePath(), "/workflows/dnaseq/transform.cwl")).findFirst();
+        if (!primarySourceFile.isPresent()) {
+            Assert.fail("Does not properly set the absolute path of the primary descriptor.");
+        }
+
+        Optional<SourceFile> importedSourceFileOne = sourceFiles.stream().filter(sourceFile -> Objects.equals(sourceFile.getPath(), "../../tools/bam_readgroup_to_json.cwl") && Objects.equals(sourceFile.getAbsolutePath(), "/tools/bam_readgroup_to_json.cwl")).findFirst();
+        if (!importedSourceFileOne.isPresent()) {
+            Assert.fail("Does not properly set the absolute path of the imported file.");
+        }
+
+        Optional<SourceFile> importedSourceFileTwo = sourceFiles.stream().filter(sourceFile -> Objects.equals(sourceFile.getPath(), "integrity.cwl") && Objects.equals(sourceFile.getAbsolutePath(), "/workflows/dnaseq/integrity.cwl")).findFirst();
+        if (!importedSourceFileTwo.isPresent()) {
+            Assert.fail("Does not properly set the absolute path of the imported file.");
+        }
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -1231,9 +1231,13 @@ public class WorkflowIT extends BaseIT {
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_GDC_DNASEQ_CWL_WORKFLOW);
         final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId());
 
-        Assert.assertEquals("should have 1 version", 1, workflow.getWorkflowVersions().size());
-        WorkflowVersion workflowVersion = workflow.getWorkflowVersions().get(0);
-        List<SourceFile> sourceFiles = workflowVersion.getSourceFiles();
+        Assert.assertEquals("should have 2 version", 2, workflow.getWorkflowVersions().size());
+        Optional<WorkflowVersion> workflowVersion = workflow.getWorkflowVersions().stream().filter(version -> Objects.equals(version.getName(), "test")).findFirst();
+        if (!workflowVersion.isPresent()) {
+            Assert.fail("Missing the test release");
+        }
+
+        List<SourceFile> sourceFiles = workflowVersion.get().getSourceFiles();
         Optional<SourceFile> primarySourceFile = sourceFiles.stream().filter(sourceFile -> Objects.equals(sourceFile.getPath(), "/workflows/dnaseq/transform.cwl") && Objects.equals(sourceFile.getAbsolutePath(), "/workflows/dnaseq/transform.cwl")).findFirst();
         if (!primarySourceFile.isPresent()) {
             Assert.fail("Does not properly set the absolute path of the primary descriptor.");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -191,7 +191,14 @@ public final class CommonTestUtilities {
     public static void setupTestWorkflow(DropwizardTestSupport<DockstoreWebserviceConfiguration> support) throws Exception {
         LOG.info("Migrating testworkflow migrations");
         Application<DockstoreWebserviceConfiguration> application = support.getApplication();
+        application.run("db", "drop-all", "--confirm-delete-everything", CONFIDENTIAL_CONFIG_PATH);
+        application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "1.3.0.generated");
+        application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "1.3.1.consistency");
+        application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "test");
+        application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "1.4.0");
         application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "testworkflow");
+        application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "1.5.0");
+        application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "test_1.5.0");
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -192,13 +192,8 @@ public final class CommonTestUtilities {
         LOG.info("Migrating testworkflow migrations");
         Application<DockstoreWebserviceConfiguration> application = support.getApplication();
         application.run("db", "drop-all", "--confirm-delete-everything", CONFIDENTIAL_CONFIG_PATH);
-        application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "1.3.0.generated");
-        application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "1.3.1.consistency");
-        application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "test");
-        application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "1.4.0");
-        application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "testworkflow");
-        application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "1.5.0");
-        application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "test_1.5.0");
+        List<String> migrationList = Arrays.asList("1.3.0.generated", "1.3.1.consistency", "test", "1.4.0", "testworkflow", "1.5.0", "test_1.5.0");
+        runMigration(migrationList, application, CONFIDENTIAL_CONFIG_PATH);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -167,7 +167,11 @@ public class SourceFile implements Comparable<SourceFile> {
 
     @Override
     public int compareTo(@NotNull SourceFile that) {
-        return ComparisonChain.start().compare(this.path, that.path).compare(this.absolutePath, that.absolutePath).result();
+        if (this.absolutePath == null || that.absolutePath == null) {
+            return ComparisonChain.start().compare(this.path, that.path).result();
+        } else {
+            return ComparisonChain.start().compare(this.absolutePath, that.absolutePath).result();
+        }
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -82,8 +82,12 @@ public class SourceFile implements Comparable<SourceFile> {
     private String content;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "Path to source file in git repo", required = true, position = 3)
+    @ApiModelProperty(value = "Path to sourcefile relative to its parent", required = true, position = 3)
     private String path;
+
+    @Column(nullable = false)
+    @ApiModelProperty(value = "Absolute path of sourcefile in git repo", required = true, position = 4)
+    private String absolutePath;
 
     // database timestamps
     @Column(updatable = false)
@@ -141,6 +145,14 @@ public class SourceFile implements Comparable<SourceFile> {
         this.path = path;
     }
 
+    public String getAbsolutePath() {
+        return absolutePath;
+    }
+
+    public void setAbsolutePath(String absolutePath) {
+        this.absolutePath = absolutePath;
+    }
+
     @JsonIgnore
     public Timestamp getDbCreateDate() {
         return dbCreateDate;
@@ -155,12 +167,12 @@ public class SourceFile implements Comparable<SourceFile> {
 
     @Override
     public int compareTo(@NotNull SourceFile that) {
-        return ComparisonChain.start().compare(this.path, that.path).result();
+        return ComparisonChain.start().compare(this.path, that.path).compare(this.absolutePath, that.absolutePath).result();
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("id", id).add("type", type).add("path", path).toString();
+        return MoreObjects.toStringHelper(this).add("id", id).add("type", type).add("path", path).add("absolutePath", absolutePath).toString();
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -462,11 +462,11 @@ public abstract class AbstractImageRegistry {
                     } else if (f == SourceFile.FileType.DOCKSTORE_CWL) {
                         dockstoreFile.setPath(tag.getCwlPath());
                         // see if there are imported files and resolve them
-                        Map<String, SourceFile> importedFiles = sourceCodeRepo.resolveImports(repositoryId, fileResponse, f, tag);
+                        Map<String, SourceFile> importedFiles = sourceCodeRepo.resolveImports(repositoryId, fileResponse, f, tag, tag.getCwlPath());
                         files.addAll(importedFiles.values());
                     } else if (f == SourceFile.FileType.DOCKSTORE_WDL) {
                         dockstoreFile.setPath(tag.getWdlPath());
-                        Map<String, SourceFile> importedFiles = sourceCodeRepo.resolveImports(repositoryId, fileResponse, f, tag);
+                        Map<String, SourceFile> importedFiles = sourceCodeRepo.resolveImports(repositoryId, fileResponse, f, tag, tag.getWdlPath());
                         files.addAll(importedFiles.values());
                     } else {
                         //TODO add nextflow work here

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -459,13 +459,16 @@ public abstract class AbstractImageRegistry {
                     dockstoreFile.setContent(fileResponse);
                     if (f == SourceFile.FileType.DOCKERFILE) {
                         dockstoreFile.setPath(tag.getDockerfilePath());
+                        dockstoreFile.setAbsolutePath(tag.getDockerfilePath());
                     } else if (f == SourceFile.FileType.DOCKSTORE_CWL) {
                         dockstoreFile.setPath(tag.getCwlPath());
+                        dockstoreFile.setAbsolutePath(tag.getCwlPath());
                         // see if there are imported files and resolve them
                         Map<String, SourceFile> importedFiles = sourceCodeRepo.resolveImports(repositoryId, fileResponse, f, tag, tag.getCwlPath());
                         files.addAll(importedFiles.values());
                     } else if (f == SourceFile.FileType.DOCKSTORE_WDL) {
                         dockstoreFile.setPath(tag.getWdlPath());
+                        dockstoreFile.setAbsolutePath(tag.getWdlPath());
                         Map<String, SourceFile> importedFiles = sourceCodeRepo.resolveImports(repositoryId, fileResponse, f, tag, tag.getWdlPath());
                         files.addAll(importedFiles.values());
                     } else {
@@ -488,6 +491,7 @@ public abstract class AbstractImageRegistry {
     private SourceFile createSourceFile(String path, SourceFile.FileType type) {
         SourceFile sourcefile = new SourceFile();
         sourcefile.setPath(path);
+        sourcefile.setAbsolutePath(path);
         sourcefile.setType(type);
         return sourcefile;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
@@ -189,6 +189,7 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
             file.setType(type);
             file.setContent(content);
             file.setPath(path);
+            file.setAbsolutePath(path);
         }
         return file;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -313,6 +313,7 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
                 // Sourcefile doesn't exist, add a stub which will have it's content filled on refresh
                 SourceFile sourceFile = new SourceFile();
                 sourceFile.setPath(path);
+                sourceFile.setAbsolutePath(path);
                 sourceFile.setType(fileType);
 
                 long id = fileDAO.create(sourceFile);
@@ -331,7 +332,7 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
         try (ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
             // Write each sourcefile
             for (SourceFile sourceFile : sourceFiles) {
-                Path resolve = workingDirectory.resolve(sourceFile.getPath());
+                Path resolve = workingDirectory.resolve(sourceFile.getAbsolutePath());
                 // remove quirk of working directory
                 String stripStart = StringUtils.stripStart(resolve.toFile().toString(), "./");
                 ZipEntry secondaryZipEntry = new ZipEntry(stripStart);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -342,6 +342,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
                     SourceFile file = new SourceFile();
                     file.setContent(decodedContent);
                     file.setPath(calculatedPath);
+                    file.setAbsolutePath(calculatedPath);
                     file.setType(identifiedType);
                     version.setValid(validWorkflow);
                     version = combineVersionAndSourcefile(repositoryId, file, workflow, identifiedType, version, existingDefaults);
@@ -364,6 +365,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
                             }
 
                             testJson.setPath(workflow.getDefaultTestParameterFilePath());
+                            testJson.setAbsolutePath(workflow.getDefaultTestParameterFilePath());
                             testJson.setContent(testJsonContent);
 
                             // Check if test parameter file has already been added

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
@@ -238,6 +238,7 @@ public class GitLabSourceCodeRepo extends SourceCodeRepoInterface {
                 file.setType(type);
                 file.setContent(new String(Base64.getDecoder().decode(repositoryFile.getContent()), StandardCharsets.UTF_8));
                 file.setPath(path);
+                file.setAbsolutePath(path);
                 return file;
             }
         } catch (IOException e) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -482,7 +482,7 @@ public abstract class SourceCodeRepoInterface {
         }
     }
 
-    Map<String, SourceFile> resolveImports(String repositoryId, String content, SourceFile.FileType fileType, Version version, String filepath) {
+    public Map<String, SourceFile> resolveImports(String repositoryId, String content, SourceFile.FileType fileType, Version version, String filepath) {
         LanguageHandlerInterface languageInterface = LanguageHandlerFactory.getInterface(fileType);
         return languageInterface.processImports(repositoryId, content, version, this, filepath);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -105,6 +105,7 @@ public abstract class SourceCodeRepoInterface {
             }
             dockstoreFile.setContent(fileResponse);
             dockstoreFile.setPath(path);
+            dockstoreFile.setAbsolutePath(path);
             return Optional.of(dockstoreFile);
         }
         return Optional.empty();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -293,7 +293,7 @@ public abstract class SourceCodeRepoInterface {
 
         // Parse file content and update
         LanguageHandlerInterface anInterface = LanguageHandlerFactory.getInterface(type);
-        entry = anInterface.parseWorkflowContent(entry, firstFileContent, sourceFiles);
+        entry = anInterface.parseWorkflowContent(entry, finalFilePath, firstFileContent, sourceFiles);
         return entry;
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -391,7 +391,7 @@ public abstract class SourceCodeRepoInterface {
 
         if (sourceFile != null && sourceFile.getContent() != null) {
             final Map<String, SourceFile> stringSourceFileMap = this
-                .resolveImports(repositoryId, sourceFile.getContent(), identifiedType, version);
+                .resolveImports(repositoryId, sourceFile.getContent(), identifiedType, version, sourceFile.getPath());
             sourceFileSet.addAll(stringSourceFileMap.values());
         }
 
@@ -481,9 +481,9 @@ public abstract class SourceCodeRepoInterface {
         }
     }
 
-    Map<String, SourceFile> resolveImports(String repositoryId, String content, SourceFile.FileType fileType, Version version) {
+    Map<String, SourceFile> resolveImports(String repositoryId, String content, SourceFile.FileType fileType, Version version, String filepath) {
         LanguageHandlerInterface languageInterface = LanguageHandlerFactory.getInterface(fileType);
-        return languageInterface.processImports(repositoryId, content, version, this);
+        return languageInterface.processImports(repositoryId, content, version, this, filepath);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -430,7 +430,7 @@ public class CWLHandler implements LanguageHandlerInterface {
             if (importKeywords.contains(e.getKey().toLowerCase())) {
                 // handle imports and includes
                 if (mapValue instanceof String) {
-                    absoluteImportPath = convertImportPathToAbsolutePath(parentFilePath, (String)mapValue);
+                    absoluteImportPath = convertRelativePathToAbsolutePath(parentFilePath, (String)mapValue);
                     handleImport(repositoryId, version, imports, (String)mapValue, sourceCodeRepoInterface, absoluteImportPath);
                 }
             } else if (e.getKey().equalsIgnoreCase("run")) {
@@ -439,7 +439,7 @@ public class CWLHandler implements LanguageHandlerInterface {
                 //  run: {import: revtool.cwl}
                 //  run: revtool.cwl
                 if (mapValue instanceof String) {
-                    absoluteImportPath = convertImportPathToAbsolutePath(parentFilePath, (String)mapValue);
+                    absoluteImportPath = convertRelativePathToAbsolutePath(parentFilePath, (String)mapValue);
                     handleImport(repositoryId, version, imports, (String)mapValue, sourceCodeRepoInterface, absoluteImportPath);
                 } else if (mapValue instanceof Map) {
                     // this handles the case where an import is used

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -64,7 +64,7 @@ public class CWLHandler implements LanguageHandlerInterface {
     public static final Logger LOG = LoggerFactory.getLogger(CWLHandler.class);
 
     @Override
-    public Entry parseWorkflowContent(Entry entry, String content, Set<SourceFile> sourceFiles) {
+    public Entry parseWorkflowContent(Entry entry, String filepath, String content, Set<SourceFile> sourceFiles) {
         // parse the collab.cwl file to get important metadata
         if (content != null && !content.isEmpty()) {
             try {
@@ -80,7 +80,14 @@ public class CWLHandler implements LanguageHandlerInterface {
                         Map docMap = (Map)doc;
                         if (docMap.containsKey("$include")) {
                             String enclosingFile = (String)docMap.get("$include");
-                            Optional<SourceFile> first = sourceFiles.stream().filter(file -> file.getPath().equals(enclosingFile))
+                            // convert enclosing file to abs path
+                            Path workDir = Paths.get(filepath);
+                            if (!Objects.equals(filepath, workDir.getRoot().toString())) {
+                                workDir = workDir.getParent();
+                            }
+                            String enclosingFileAbsolute = workDir.resolve(enclosingFile).normalize().toString();
+
+                            Optional<SourceFile> first = sourceFiles.stream().filter(file -> file.getPath().equals(enclosingFileAbsolute))
                                 .findFirst();
                             if (first.isPresent()) {
                                 description = first.get().getContent();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -459,7 +459,7 @@ public class CWLHandler implements LanguageHandlerInterface {
         SourceFile sourceFile = new SourceFile();
         sourceFile.setType(fileType);
         sourceFile.setContent(fileResponse);
-        sourceFile.setPath(constructedPath);
+        sourceFile.setPath(mapValue);
         imports.put(constructedPath, sourceFile);
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -492,6 +492,7 @@ public class CWLHandler implements LanguageHandlerInterface {
         sourceFile.setType(fileType);
         sourceFile.setContent(fileResponse);
         sourceFile.setPath(givenImportPath);
+        sourceFile.setAbsolutePath(absoluteImportPath);
         imports.put(absoluteImportPath, sourceFile);
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -338,7 +338,6 @@ public class CWLHandler implements LanguageHandlerInterface {
 
                     // Check secondary file for docker pull
                     if (secondaryFile != null) {
-                        secondaryFile = convertImportPathToAbsolutePath(mainDescriptorPath, secondaryFile);
                         stepDockerRequirement = parseSecondaryFile(stepDockerRequirement, secondaryDescContent.get(secondaryFile), gson,
                             yaml);
                         if (isExpressionTool(secondaryDescContent.get(secondaryFile), yaml)) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -15,6 +15,7 @@
  */
 package io.dockstore.webservice.languages;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -142,8 +143,9 @@ public class CWLHandler implements LanguageHandlerInterface {
     }
 
     @Override
-    public Map<String, SourceFile> processImports(String repositoryId, String content, Version version, SourceCodeRepoInterface sourceCodeRepoInterface) {
-        return processImports(repositoryId, "", content, version, sourceCodeRepoInterface);
+    public Map<String, SourceFile> processImports(String repositoryId, String content, Version version, SourceCodeRepoInterface sourceCodeRepoInterface, String filepath) {
+        String parentPath = Paths.get(filepath).getParent().toString();
+        return processImports(repositoryId, parentPath, content, version, sourceCodeRepoInterface);
     }
 
     private Map<String, SourceFile> processImports(String repositoryId, String workingDirectoryForFile, String content, Version version,
@@ -448,7 +450,7 @@ public class CWLHandler implements LanguageHandlerInterface {
     private void handleImport(String repositoryId, String workingDirectoryForFile, Version version, Map<String, SourceFile> imports, String mapValue, SourceCodeRepoInterface sourceCodeRepoInterface) {
         SourceFile.FileType fileType = SourceFile.FileType.DOCKSTORE_CWL;
         // create a new source file
-        String constructedPath = workingDirectoryForFile + mapValue;
+        String constructedPath = Paths.get(workingDirectoryForFile).resolve(mapValue).normalize().toString();
         final String fileResponse = sourceCodeRepoInterface.readGitRepositoryFile(repositoryId, fileType, version, constructedPath);
         if (fileResponse == null) {
             LOG.error("Could not read: " + mapValue);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -15,8 +15,6 @@
  */
 package io.dockstore.webservice.languages;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -45,7 +43,6 @@ import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.helpers.SourceCodeRepoInterface;
 import io.dockstore.webservice.jdbi.ToolDAO;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.MutableTriple;
 import org.apache.commons.lang3.tuple.Pair;
@@ -654,24 +651,5 @@ public class CWLHandler implements LanguageHandlerInterface {
         }
 
         return filteredArray;
-    }
-
-    /**
-     * Resolves a relative path based on an absolute parent path
-     * @param parentPath Absolute path to parent file
-     * @param importPath Relative path the parent file
-     * @return
-     */
-    private String convertImportPathToAbsolutePath(String parentPath, String importPath) {
-        if (importPath.startsWith("/")) {
-            return importPath;
-        }
-
-        Path workingDirectory = Paths.get(parentPath);
-        if (!Objects.equals(parentPath, workingDirectory.getRoot().toString())) {
-            workingDirectory = workingDirectory.getParent();
-        }
-
-        return workingDirectory.resolve(importPath).normalize().toString();
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -68,13 +68,13 @@ public interface LanguageHandlerInterface {
     boolean isValidWorkflow(String content);
 
     /**
-     * Look at the content of a descriptor and update its imports
+     * Parse a descriptor file and return a recursive mapping of its imports
      *
      * @param repositoryId            identifies the git repository that we wish to use, normally something like 'organization/repo_name`
      * @param content                 content of the primary descriptor
      * @param version                 version of the files to get
      * @param sourceCodeRepoInterface used too retrieve imports
-     * @param filepath                used to help find relative imports
+     * @param filepath                used to help find relative imports, must be absolute
      * @return map of file paths to SourceFile objects
      */
     Map<String, SourceFile> processImports(String repositoryId, String content, Version version,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -15,6 +15,7 @@
  */
 package io.dockstore.webservice.languages;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -260,6 +261,20 @@ public interface LanguageHandlerInterface {
         }
 
         return url;
+    }
+
+    /**
+     * Resolves a relative path based on an absolute parent path
+     * @param parentPath Absolute path to parent file
+     * @param importPath Relative path the parent file
+     * @return Absolute version of relative path
+     */
+    default String convertImportPathToAbsolutePath(String parentPath, String importPath) {
+        if (importPath.startsWith("/")) {
+            return importPath;
+        }
+
+        return Paths.get(parentPath).getParent().resolve(importPath).normalize().toString();
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -15,6 +15,7 @@
  */
 package io.dockstore.webservice.languages;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -22,6 +23,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -274,7 +276,10 @@ public interface LanguageHandlerInterface {
             return importPath;
         }
 
-        return Paths.get(parentPath).getParent().resolve(importPath).normalize().toString();
+        Path workDir = Paths.get(parentPath);
+        workDir = !Objects.equals(parentPath, workDir.getRoot().toString()) ? workDir.getParent() : workDir;
+
+        return workDir.resolve(importPath).normalize().toString();
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -81,14 +81,14 @@ public interface LanguageHandlerInterface {
      * Processes a descriptor and its associated secondary descriptors to either return the tools that a workflow has or a DAG representation
      * of a workflow
      *
-     * @param mainDescName         the name of the main descriptor
+     * @param mainDescriptorPath   the path of the main descriptor
      * @param mainDescriptor       the content of the main descriptor
      * @param secondaryDescContent the content of the secondary descriptors in a map, looks like file paths -> content
      * @param type                 tools or DAG
      * @param dao                  used to retrieve information on tools
      * @return either a DAG or some form of a list of tools for a workflow
      */
-    String getContent(String mainDescName, String mainDescriptor, Map<String, String> secondaryDescContent, Type type, ToolDAO dao);
+    String getContent(String mainDescriptorPath, String mainDescriptor, Map<String, String> secondaryDescContent, Type type, ToolDAO dao);
 
     /**
      * This method will setup the nodes (nodePairs) and edges (stepToDependencies) into Cytoscape compatible JSON

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -268,18 +268,20 @@ public interface LanguageHandlerInterface {
     /**
      * Resolves a relative path based on an absolute parent path
      * @param parentPath Absolute path to parent file
-     * @param importPath Relative path the parent file
+     * @param relativePath Relative path the parent file
      * @return Absolute version of relative path
      */
-    default String convertImportPathToAbsolutePath(String parentPath, String importPath) {
-        if (importPath.startsWith("/")) {
-            return importPath;
+    default String convertRelativePathToAbsolutePath(String parentPath, String relativePath) {
+        if (relativePath.startsWith("/")) {
+            return relativePath;
         }
 
         Path workDir = Paths.get(parentPath);
+
+        // If the workDir is the root, leave it. If it is not the root, set workDir to the parent of parentPath
         workDir = !Objects.equals(parentPath, workDir.getRoot().toString()) ? workDir.getParent() : workDir;
 
-        return workDir.resolve(importPath).normalize().toString();
+        return workDir.resolve(relativePath).normalize().toString();
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -70,10 +70,11 @@ public interface LanguageHandlerInterface {
      * @param content                 content of the primary descriptor
      * @param version                 version of the files to get
      * @param sourceCodeRepoInterface used too retrieve imports
+     * @param filepath                used to help find relative imports
      * @return map of file paths to SourceFile objects
      */
     Map<String, SourceFile> processImports(String repositoryId, String content, Version version,
-        SourceCodeRepoInterface sourceCodeRepoInterface);
+        SourceCodeRepoInterface sourceCodeRepoInterface, String filepath);
 
     /**
      * Processes a descriptor and its associated secondary descriptors to either return the tools that a workflow has or a DAG representation

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -49,11 +49,12 @@ public interface LanguageHandlerInterface {
     /**
      * Parses the content of the primary descriptor to get author, email, and description
      *
-     * @param entry   an entry to be updated
-     * @param content a cwl document
+     * @param entry    an entry to be updated
+     * @param filepath path to file
+     * @param content  a cwl document
      * @return the updated entry
      */
-    Entry parseWorkflowContent(Entry entry, String content, Set<SourceFile> sourceFiles);
+    Entry parseWorkflowContent(Entry entry, String filepath, String content, Set<SourceFile> sourceFiles);
 
     /**
      * Confirms whether the content of a descriptor contains a valid workflow

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
@@ -80,8 +80,11 @@ public class NextFlowHandler implements LanguageHandlerInterface {
         if (manifest != null && manifest.containsKey("mainScript")) {
             mainScriptPath = (String)manifest.get("mainScript");
         }
-        Optional<SourceFile> sourceFile = sourceCodeRepoInterface.readFile(repositoryId, version, SourceFile.FileType.NEXTFLOW, mainScriptPath);
+        String mainScriptAbsolutePath = convertImportPathToAbsolutePath(filepath, mainScriptPath);
+
+        Optional<SourceFile> sourceFile = sourceCodeRepoInterface.readFile(repositoryId, version, SourceFile.FileType.NEXTFLOW, mainScriptAbsolutePath);
         if (sourceFile.isPresent()) {
+            sourceFile.get().setPath(mainScriptPath);
             imports.put(mainScriptPath, sourceFile.get());
         }
         // source files in /lib seem to be automatically added to the script classpath

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
@@ -70,7 +70,7 @@ public class NextFlowHandler implements LanguageHandlerInterface {
 
     @Override
     public Map<String, SourceFile> processImports(String repositoryId, String content, Version version,
-        SourceCodeRepoInterface sourceCodeRepoInterface) {
+        SourceCodeRepoInterface sourceCodeRepoInterface, String filepath) {
         ConfigObject parse = getConfigObject(content);
         Map<String, SourceFile> imports = new HashMap<>();
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
@@ -49,7 +49,7 @@ import org.codehaus.groovy.antlr.parser.GroovyRecognizer;
 public class NextFlowHandler implements LanguageHandlerInterface {
 
     @Override
-    public Entry parseWorkflowContent(Entry entry, String content, Set<SourceFile> sourceFiles) {
+    public Entry parseWorkflowContent(Entry entry, String filepath, String content, Set<SourceFile> sourceFiles) {
         // this is where we can look for things like NextFlow config files or maybe a future Dockstore.yml
         ConfigObject parse = getConfigObject(content);
         ConfigObject manifest = (ConfigObject)parse.get("manifest");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextFlowHandler.java
@@ -80,7 +80,7 @@ public class NextFlowHandler implements LanguageHandlerInterface {
         if (manifest != null && manifest.containsKey("mainScript")) {
             mainScriptPath = (String)manifest.get("mainScript");
         }
-        String mainScriptAbsolutePath = convertImportPathToAbsolutePath(filepath, mainScriptPath);
+        String mainScriptAbsolutePath = convertRelativePathToAbsolutePath(filepath, mainScriptPath);
 
         Optional<SourceFile> sourceFile = sourceCodeRepoInterface.readFile(repositoryId, version, SourceFile.FileType.NEXTFLOW, mainScriptAbsolutePath);
         if (sourceFile.isPresent()) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -197,8 +197,7 @@ public class WDLHandler implements LanguageHandlerInterface {
     @Override
     public Map<String, SourceFile> processImports(String repositoryId, String content, Version version,
         SourceCodeRepoInterface sourceCodeRepoInterface, String filepath) {
-        String parentPath = Paths.get(filepath).getParent().toString();
-        return processImports(repositoryId, content, version, sourceCodeRepoInterface, new HashMap<>(), parentPath);
+        return processImports(repositoryId, content, version, sourceCodeRepoInterface, new HashMap<>(), filepath);
     }
 
     private Map<String, SourceFile> processImports(String repositoryId, String content, Version version,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -232,10 +232,10 @@ public class WDLHandler implements LanguageHandlerInterface {
                     continue;
                 }
                 importFile.setContent(fileResponse);
-                importFile.setPath(constructedPath);
+                importFile.setPath(importPath);
                 importFile.setType(SourceFile.FileType.DOCKSTORE_WDL);
                 imports.put(importFile.getPath(), importFile);
-                imports.putAll(processImports(repositoryId, importFile.getContent(), version, sourceCodeRepoInterface, imports, importFile.getPath()));
+                imports.putAll(processImports(repositoryId, importFile.getContent(), version, sourceCodeRepoInterface, imports, constructedPath));
             }
         }
         return imports;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -200,7 +200,7 @@ public class WDLHandler implements LanguageHandlerInterface {
     }
 
     private Map<String, SourceFile> processImports(String repositoryId, String content, Version version,
-        SourceCodeRepoInterface sourceCodeRepoInterface, Map<String, SourceFile> imports, String workingDirectoryForFile) {
+        SourceCodeRepoInterface sourceCodeRepoInterface, Map<String, SourceFile> imports, String currentFilePath) {
         SourceFile.FileType fileType = SourceFile.FileType.DOCKSTORE_WDL;
 
         // Use matcher to get imports
@@ -221,7 +221,7 @@ public class WDLHandler implements LanguageHandlerInterface {
         for (String importPath : currentFileImports) {
             if (!imports.containsKey(importPath)) {
                 SourceFile importFile = new SourceFile();
-                String absoluteImportPath = convertImportPathToAbsolutePath(workingDirectoryForFile, importPath);
+                String absoluteImportPath = convertImportPathToAbsolutePath(currentFilePath, importPath);
 
                 final String fileResponse = sourceCodeRepoInterface.readGitRepositoryFile(repositoryId, fileType, version, absoluteImportPath);
                 if (fileResponse == null) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -231,6 +231,7 @@ public class WDLHandler implements LanguageHandlerInterface {
                 importFile.setContent(fileResponse);
                 importFile.setPath(importPath);
                 importFile.setType(SourceFile.FileType.DOCKSTORE_WDL);
+                importFile.setAbsolutePath(absoluteImportPath);
                 imports.put(importFile.getPath(), importFile);
                 imports.putAll(processImports(repositoryId, importFile.getContent(), version, sourceCodeRepoInterface, imports, absoluteImportPath));
             }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -221,11 +221,11 @@ public class WDLHandler implements LanguageHandlerInterface {
         for (String importPath : currentFileImports) {
             if (!imports.containsKey(importPath)) {
                 SourceFile importFile = new SourceFile();
-                String constructedPath = convertImportPathToAbsolutePath(workingDirectoryForFile, importPath);
+                String absoluteImportPath = convertImportPathToAbsolutePath(workingDirectoryForFile, importPath);
 
-                final String fileResponse = sourceCodeRepoInterface.readGitRepositoryFile(repositoryId, fileType, version, constructedPath);
+                final String fileResponse = sourceCodeRepoInterface.readGitRepositoryFile(repositoryId, fileType, version, absoluteImportPath);
                 if (fileResponse == null) {
-                    SourceCodeRepoInterface.LOG.error("Could not read: " + constructedPath);
+                    SourceCodeRepoInterface.LOG.error("Could not read: " + absoluteImportPath);
                     continue;
                 }
                 importFile.setContent(fileResponse);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -226,7 +226,7 @@ public class WDLHandler implements LanguageHandlerInterface {
 
                 String constructedPath = Paths.get(workingDirectoryForFile).resolve(importPath).normalize().toString();
 
-                final String fileResponse = sourceCodeRepoInterface.readGitRepositoryFile(repositoryId, fileType, version, constructedPath);
+                final String fileResponse = sourceCodeRepoInterface.readGitRepositoryFile(repositoryId, fileType, version, importPath);
                 if (fileResponse == null) {
                     SourceCodeRepoInterface.LOG.error("Could not read: " + constructedPath);
                     continue;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -18,7 +18,6 @@ package io.dockstore.webservice.languages;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -221,7 +221,7 @@ public class WDLHandler implements LanguageHandlerInterface {
         for (String importPath : currentFileImports) {
             if (!imports.containsKey(importPath)) {
                 SourceFile importFile = new SourceFile();
-                String absoluteImportPath = convertImportPathToAbsolutePath(currentFilePath, importPath);
+                String absoluteImportPath = convertRelativePathToAbsolutePath(currentFilePath, importPath);
 
                 final String fileResponse = sourceCodeRepoInterface.readGitRepositoryFile(repositoryId, fileType, version, absoluteImportPath);
                 if (fileResponse == null) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -56,7 +56,7 @@ public class WDLHandler implements LanguageHandlerInterface {
     public static final Logger LOG = LoggerFactory.getLogger(WDLHandler.class);
     private static final Pattern IMPORT_PATTERN = Pattern.compile("^import\\s+\"(\\S+)\"");
     @Override
-    public Entry parseWorkflowContent(Entry entry, String content, Set<SourceFile> sourceFiles) {
+    public Entry parseWorkflowContent(Entry entry, String filepath, String content, Set<SourceFile> sourceFiles) {
         // Use Broad WDL parser to grab data
         // Todo: Currently just checks validity of file.  In the future pull data such as author from the WDL file
         try {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -232,7 +232,7 @@ public class WDLHandler implements LanguageHandlerInterface {
                 importFile.setPath(importPath);
                 importFile.setType(SourceFile.FileType.DOCKSTORE_WDL);
                 imports.put(importFile.getPath(), importFile);
-                imports.putAll(processImports(repositoryId, importFile.getContent(), version, sourceCodeRepoInterface, imports, workingDirectoryForFile));
+                imports.putAll(processImports(repositoryId, importFile.getContent(), version, sourceCodeRepoInterface, imports, absoluteImportPath));
             }
         }
         return imports;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -223,10 +223,9 @@ public class WDLHandler implements LanguageHandlerInterface {
         for (String importPath : currentFileImports) {
             if (!imports.containsKey(importPath)) {
                 SourceFile importFile = new SourceFile();
+                String constructedPath = convertImportPathToAbsolutePath(workingDirectoryForFile, importPath);
 
-                String constructedPath = Paths.get(workingDirectoryForFile).resolve(importPath).normalize().toString();
-
-                final String fileResponse = sourceCodeRepoInterface.readGitRepositoryFile(repositoryId, fileType, version, importPath);
+                final String fileResponse = sourceCodeRepoInterface.readGitRepositoryFile(repositoryId, fileType, version, constructedPath);
                 if (fileResponse == null) {
                     SourceCodeRepoInterface.LOG.error("Could not read: " + constructedPath);
                     continue;
@@ -235,7 +234,7 @@ public class WDLHandler implements LanguageHandlerInterface {
                 importFile.setPath(importPath);
                 importFile.setType(SourceFile.FileType.DOCKSTORE_WDL);
                 imports.put(importFile.getPath(), importFile);
-                imports.putAll(processImports(repositoryId, importFile.getContent(), version, sourceCodeRepoInterface, imports, constructedPath));
+                imports.putAll(processImports(repositoryId, importFile.getContent(), version, sourceCodeRepoInterface, imports, workingDirectoryForFile));
             }
         }
         return imports;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -259,6 +259,7 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
             versionWithTheLargestName.getSourceFiles().forEach(v -> {
                 SourceFile newfile = new SourceFile();
                 newfile.setPath(v.getPath());
+                newfile.setAbsolutePath(v.getAbsolutePath());
                 newfile.setContent(v.getContent());
                 newfile.setType(v.getType());
                 map.put(newfile.getPath(), newfile);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
@@ -104,7 +104,7 @@ public class HostedToolResource extends AbstractHostedEntryResource<Tool, Tag, T
         for (SourceFile file : sourceFiles) {
             if (file.getPath().equals(tag.getCwlPath()) || file.getPath().equals(tag.getWdlPath())) {
                 LOG.info("refreshing metadata based on " + file.getPath() + " from " + tag.getName());
-                LanguageHandlerFactory.getInterface(file.getType()).parseWorkflowContent(entry, file.getContent(), sourceFiles);
+                LanguageHandlerFactory.getInterface(file.getType()).parseWorkflowContent(entry, file.getPath(), file.getContent(), sourceFiles);
             }
         }
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
@@ -156,7 +156,7 @@ public class HostedWorkflowResource extends AbstractHostedEntryResource<Workflow
         LanguageHandlerInterface anInterface = LanguageHandlerFactory.getInterface(workflow.getFileType());
         Optional<SourceFile> first = sourceFiles.stream().filter(file -> file.getPath().equals(version.getWorkflowPath())).findFirst();
         first.ifPresent(sourceFile -> LOG.info("refreshing metadata based on " + sourceFile.getPath() + " from " + version.getName()));
-        first.ifPresent(sourceFile -> anInterface.parseWorkflowContent(workflow, sourceFile.getContent(), sourceFiles));
+        first.ifPresent(sourceFile -> anInterface.parseWorkflowContent(workflow, sourceFile.getPath(), sourceFile.getContent(), sourceFiles));
     }
 
     @Override

--- a/dockstore-webservice/src/main/resources/migrations.1.5.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.5.0.xml
@@ -216,4 +216,12 @@
             UPDATE workflow SET descriptorType='nfl' WHERE descriptorType='nextflow'
         </sql>
     </changeSet>
+    <changeSet id="addSourcefileAbsolutePath" author="agduncan">
+        <addColumn tableName="sourcefile">
+            <column name="absolutepath" type="varchar(255 BYTE)"/>
+        </addColumn>
+        <sql dbms="postgresql">
+            UPDATE sourcefile SET absolutepath=path
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -5784,6 +5784,7 @@ components:
     SourceFile:
       type: object
       required:
+        - absolutePath
         - path
         - type
       properties:
@@ -5815,7 +5816,10 @@ components:
           description: Cache for the contents of the target file
         path:
           type: string
-          description: Path to source file in git repo
+          description: Path to sourcefile relative to its parent
+        absolutePath:
+          type: string
+          description: Absolute path of sourcefile in git repo
     StarRequest:
       type: object
       properties:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5337,6 +5337,7 @@ definitions:
   SourceFile:
     type: "object"
     required:
+    - "absolutePath"
     - "path"
     - "type"
     properties:
@@ -5370,7 +5371,11 @@ definitions:
       path:
         type: "string"
         position: 3
-        description: "Path to source file in git repo"
+        description: "Path to sourcefile relative to its parent"
+      absolutePath:
+        type: "string"
+        position: 4
+        description: "Absolute path of sourcefile in git repo"
   StarRequest:
     type: "object"
     properties:

--- a/dockstore-webservice/src/test/java/core/CWLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/CWLParseTest.java
@@ -37,7 +37,7 @@ public class CWLParseTest {
     public void testOldMetadataExample() throws IOException {
         String filePath = ResourceHelpers.resourceFilePath("metadata_example0.cwl");
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(SourceFile.FileType.DOCKSTORE_CWL);
-        Entry entry = sInterface.parseWorkflowContent(new Tool(), FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+        Entry entry = sInterface.parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
         Assert.assertEquals("incorrect author", "Keiran Raine", entry.getAuthor());
         Assert.assertEquals("incorrect email", "keiranmraine@gmail.com", entry.getEmail());
     }
@@ -46,7 +46,7 @@ public class CWLParseTest {
     public void testNewMetadataExample() throws IOException {
         String filePath = ResourceHelpers.resourceFilePath("metadata_example2.cwl");
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(SourceFile.FileType.DOCKSTORE_CWL);
-        Entry entry = sInterface.parseWorkflowContent(new Tool(), FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+        Entry entry = sInterface.parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
         Assert.assertEquals("incorrect author", "Denis Yuen", entry.getAuthor());
         Assert.assertEquals("incorrect email", "dyuen@oicr.on.ca", entry.getEmail());
     }
@@ -55,7 +55,7 @@ public class CWLParseTest {
     public void testCombinedMetadataExample() throws IOException {
         String filePath = ResourceHelpers.resourceFilePath("metadata_example3.cwl");
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(SourceFile.FileType.DOCKSTORE_CWL);
-        Entry entry = sInterface.parseWorkflowContent(new Tool(), FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+        Entry entry = sInterface.parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
         Assert.assertEquals("incorrect author", "Denis Yuen", entry.getAuthor());
         Assert.assertEquals("incorrect email", "dyuen@oicr.on.ca", entry.getEmail());
     }

--- a/dockstore-webservice/src/test/java/core/ElasticManagerIT.java
+++ b/dockstore-webservice/src/test/java/core/ElasticManagerIT.java
@@ -66,6 +66,7 @@ public class ElasticManagerIT {
         String cwlContent = Files.asCharSource(cwlFile, Charsets.UTF_8).read();
 
         file.setPath("dummypath");
+        file.setAbsolutePath("/dummypath");
         file.setContent(cwlContent);
         file.setType(DOCKSTORE_CWL);
         tag.addSourceFile(file);

--- a/dockstore-webservice/src/test/java/core/SortTest.java
+++ b/dockstore-webservice/src/test/java/core/SortTest.java
@@ -29,11 +29,11 @@ public class SortTest {
         // for the GUI, we should try to sort `/Dockstore.cwl` first before relative files
         SortedSet<SourceFile> files = new TreeSet<>();
 
-        createAndAddFile(files, "foo2.cwl");
-        createAndAddFile(files, "foo.cwl");
-        createAndAddFile(files, "/Dockstore.cwl");
-        createAndAddFile(files, "tool.cwl");
-        createAndAddFile(files, "extra.js");
+        createAndAddFile(files, "foo2.cwl", "/foo2.cwl");
+        createAndAddFile(files, "foo.cwl", "/foo.cwl");
+        createAndAddFile(files, "/Dockstore.cwl", "/Dockstore.cwl");
+        createAndAddFile(files, "tool.cwl", "/tool.cwl");
+        createAndAddFile(files, "extra.js", "/extra.js");
 
         Assert.assertEquals("/Dockstore.cwl", files.iterator().next().getPath());
     }
@@ -43,18 +43,19 @@ public class SortTest {
         // for the GUI, we should try to sort `/Dockstore.wdl` first before relative files
         SortedSet<SourceFile> files = new TreeSet<>();
 
-        createAndAddFile(files, "foo2.cwl");
-        createAndAddFile(files, "foo.cwl");
-        createAndAddFile(files, "/Dockstore.wdl");
-        createAndAddFile(files, "tool.cwl");
-        createAndAddFile(files, "extra.js");
+        createAndAddFile(files, "foo2.cwl", "/foo2.cwl");
+        createAndAddFile(files, "foo.cwl", "/foo.cwl");
+        createAndAddFile(files, "/Dockstore.wdl", "/Dockstore.wdl");
+        createAndAddFile(files, "tool.cwl", "/tool.cwl");
+        createAndAddFile(files, "extra.js", "/extra.js");
 
         Assert.assertEquals("/Dockstore.wdl", files.iterator().next().getPath());
     }
 
-    private void createAndAddFile(SortedSet<SourceFile> files, String path) {
+    private void createAndAddFile(SortedSet<SourceFile> files, String path, String absolutePath) {
         SourceFile file = new SourceFile();
         file.setPath(path);
+        file.setAbsolutePath(absolutePath);
         files.add(file);
     }
 }

--- a/dockstore-webservice/src/test/java/core/WDLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/WDLParseTest.java
@@ -39,7 +39,7 @@ public class WDLParseTest {
         String filePath = ResourceHelpers.resourceFilePath("metadata_example0.wdl");
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(SourceFile.FileType.DOCKSTORE_WDL);
         Entry entry = sInterface
-            .parseWorkflowContent(new Tool(), FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+            .parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
         assertTrue("incorrect author", entry.getAuthor().contains("Chip Stewart"));
         assertTrue("incorrect email", entry.getEmail().contains("stewart@broadinstitute.org"));
     }
@@ -49,7 +49,7 @@ public class WDLParseTest {
         String filePath = ResourceHelpers.resourceFilePath("metadata_example1.wdl");
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(SourceFile.FileType.DOCKSTORE_WDL);
         Entry entry = sInterface
-            .parseWorkflowContent(new Tool(), FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+            .parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
         assertTrue("incorrect author", entry.getAuthor().split(",").length >= 2);
         assertTrue("incorrect email", entry.getEmail().isEmpty());
     }
@@ -59,7 +59,7 @@ public class WDLParseTest {
         String filePath = ResourceHelpers.resourceFilePath("metadata_example2.wdl");
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(SourceFile.FileType.DOCKSTORE_WDL);
         Entry entry = sInterface
-            .parseWorkflowContent(new Tool(), FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+            .parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
         assertTrue("incorrect author", entry.getAuthor().split(",").length >= 2);
         assertEquals("incorrect email", "This is a cool workflow", entry.getDescription());
     }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/JsonLdRetrieverTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/JsonLdRetrieverTest.java
@@ -46,6 +46,7 @@ public class JsonLdRetrieverTest {
         file.setContent(cwlContent);
         file.setType(DOCKSTORE_CWL);
         file.setPath("dummy path");
+        file.setAbsolutePath("/dummy path");
         tag.addSourceFile(file);
         tag.setReference("master");
         tool.addTag(tag);

--- a/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
+++ b/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
@@ -60,6 +60,7 @@ public class ToolsImplCommonTest {
         SourceFile sourceFile = new SourceFile();
         sourceFile.setType(SourceFile.FileType.DOCKSTORE_WDL);
         sourceFile.setPath("/Dockstore.wdl");
+        sourceFile.setAbsolutePath("/Dockstore.wdl");
         sourceFile.setContent(PLACEHOLDER_CONTENT);
         sourceFile.setId(9001);
         FileWrapper actualToolDescriptor = ToolsImplCommon.sourceFileToToolDescriptor("",sourceFile);
@@ -74,6 +75,7 @@ public class ToolsImplCommonTest {
         SourceFile sourceFile = new SourceFile();
         sourceFile.setType(SourceFile.FileType.DOCKSTORE_CWL);
         sourceFile.setPath("/Dockstore.cwl");
+        sourceFile.setAbsolutePath("/Dockstore.cwl");
         sourceFile.setContent(PLACEHOLDER_CONTENT);
         sourceFile.setId(9001);
         FileWrapper actualToolDescriptor = ToolsImplCommon.sourceFileToToolDescriptor("",sourceFile);
@@ -123,11 +125,13 @@ public class ToolsImplCommonTest {
         sourceFile.setType(SourceFile.FileType.DOCKERFILE);
         sourceFile.setContent("TEST DOCKERFILE");
         sourceFile.setPath("/Dockerfile");
+        sourceFile.setAbsolutePath("/Dockerfile");
         SourceFile sourceFile2 = new SourceFile();
         sourceFile2.setId(1);
         sourceFile2.setType(SourceFile.FileType.DOCKSTORE_CWL);
         sourceFile2.setContent("TEST CWL");
         sourceFile2.setPath("/Dockstore.cwl");
+        sourceFile2.setAbsolutePath("/Dockstore.cwl");
         tag.addSourceFile(sourceFile);
         tag.addSourceFile(sourceFile2);
         tool.addTag(tag);
@@ -212,6 +216,7 @@ public class ToolsImplCommonTest {
         actualSourceFile1.setType(SourceFile.FileType.DOCKSTORE_WDL);
         actualSourceFile1.setContent(PLACEHOLDER_CONTENT);
         actualSourceFile1.setPath("/pcawg-cgp-somatic-workflow.wdl");
+        actualSourceFile1.setAbsolutePath("/pcawg-cgp-somatic-workflow.wdl");
         WorkflowVersion actualWorkflowVersion1 = new WorkflowVersion();
         actualWorkflowVersion1.setWorkflowPath("/pcawg-cgp-somatic-workflow.wdl");
         actualWorkflowVersion1.setLastModified(null);
@@ -342,6 +347,7 @@ public class ToolsImplCommonTest {
         SourceFile sourceFile = new SourceFile();
         sourceFile.setType(SourceFile.FileType.CWL_TEST_JSON);
         sourceFile.setPath("/test.cwl.json");
+        sourceFile.setAbsolutePath("/test.cwl.json");
         sourceFile.setContent(PLACEHOLDER_CONTENT);
         sourceFile.setId(9001);
         FileWrapper actualToolTests = ToolsImplCommon.sourceFileToToolTests("", sourceFile);

--- a/expand_confidential_bundle.sh
+++ b/expand_confidential_bundle.sh
@@ -7,6 +7,9 @@ set -o pipefail
 set -o nounset
 set -o xtrace
 
+# bash expand_confidential_bundle.sh /path/to/zip/archive folder_name
+# ex. bash expand_confidential_bundle.sh /home/aduncan/Downloads/add_curator.zip add_curator
+
 zipArchive=$1
 zipFolder=$2
 

--- a/expand_confidential_bundle.sh
+++ b/expand_confidential_bundle.sh
@@ -8,11 +8,12 @@ set -o nounset
 set -o xtrace
 
 zipArchive=$1
+zipFolder=$2
 
-unzip -p $zipArchive config_file.txt >dockstore-integration-testing/src/test/resources/config_file.txt
-unzip -p $zipArchive config_file2.txt >dockstore-integration-testing/src/test/resources/config_file2.txt
-unzip -p $zipArchive migrations.test.confidential1.xml >dockstore-webservice/src/main/resources/migrations.test.confidential1.xml
-unzip -p $zipArchive migrations.test.confidential2.xml >dockstore-webservice/src/main/resources/migrations.test.confidential2.xml
-unzip -p $zipArchive migrations.test.confidential1_1.5.0.xml >dockstore-webservice/src/main/resources/migrations.test.confidential1_1.5.0.xml
-unzip -p $zipArchive migrations.test.confidential2_1.5.0.xml >dockstore-webservice/src/main/resources/migrations.test.confidential2_1.5.0.xml
-unzip -p $zipArchive dockstoreTest.yml >dockstore-integration-testing/src/test/resources/dockstoreTest.yml
+unzip -p $zipArchive $zipFolder/config_file.txt >dockstore-integration-testing/src/test/resources/config_file.txt
+unzip -p $zipArchive $zipFolder/config_file2.txt >dockstore-integration-testing/src/test/resources/config_file2.txt
+unzip -p $zipArchive $zipFolder/migrations.test.confidential1.xml >dockstore-webservice/src/main/resources/migrations.test.confidential1.xml
+unzip -p $zipArchive $zipFolder/migrations.test.confidential2.xml >dockstore-webservice/src/main/resources/migrations.test.confidential2.xml
+unzip -p $zipArchive $zipFolder/migrations.test.confidential1_1.5.0.xml >dockstore-webservice/src/main/resources/migrations.test.confidential1_1.5.0.xml
+unzip -p $zipArchive $zipFolder/migrations.test.confidential2_1.5.0.xml >dockstore-webservice/src/main/resources/migrations.test.confidential2_1.5.0.xml
+unzip -p $zipArchive $zipFolder/dockstoreTest.yml >dockstore-integration-testing/src/test/resources/dockstoreTest.yml


### PR DESCRIPTION
* Now store absolute path of sourcefile to use for reading from Git
* Solves the issue of not being able to read files from Git since absolute paths are now used
* Solves issue with CWL getSteps() returning either an array or an object.
* Fixes tests and adds some more

Currently the migrations is just copying the existing path. I think this is the best and simplest solution since the absolute path only impacts download zip and launch for existing entries. So before a refresh, download zip and launch will work for those entries they already worked for, but also won't work for the entries they do not work for. Once the user refreshes an entry, the proper absolute path will be found and everything should be working as expected. What do you guys think? 

https://github.com/ga4gh/dockstore/issues/1850
https://github.com/ga4gh/dockstore/issues/1456
https://github.com/ga4gh/dockstore/issues/741