### PR TITLE
Feature/1849/checker workflow url

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV1IT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV1IT.java
@@ -52,7 +52,7 @@ public class GA4GHV1IT extends GA4GHIT {
     @Test
     @Override
     public void testMetadata() throws Exception {
-        Response response = checkedResponse(basePath + "metadata");
+        Response response = checkedResponse(baseURL + "metadata");
         MetadataV1 metadata = response.readEntity(MetadataV1.class);
         assertThat(SUPPORT.getObjectMapper().writeValueAsString(metadata)).contains("api-version");
         assertThat(SUPPORT.getObjectMapper().writeValueAsString(metadata)).contains("friendly-name");
@@ -63,7 +63,7 @@ public class GA4GHV1IT extends GA4GHIT {
     @Test
     @Override
     public void testTools() throws Exception {
-        Response response = checkedResponse(basePath + "tools");
+        Response response = checkedResponse(baseURL + "tools");
         List<ToolV1> responseObject = response.readEntity(new GenericType<List<ToolV1>>() {
         });
         assertTool(SUPPORT.getObjectMapper().writeValueAsString(responseObject), true);
@@ -77,22 +77,22 @@ public class GA4GHV1IT extends GA4GHIT {
     }
 
     private void toolsIdTool() throws Exception {
-        Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6");
+        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6");
         ToolV1 responseObject = response.readEntity(ToolV1.class);
         assertTool(SUPPORT.getObjectMapper().writeValueAsString(responseObject), true);
         // also try search by id
-        response = checkedResponse(basePath + "tools?id=quay.io%2Ftest_org%2Ftest6");
+        response = checkedResponse(baseURL + "tools?id=quay.io%2Ftest_org%2Ftest6");
         List<ToolV1> responseList = response.readEntity(new GenericType<List<ToolV1>>() {
         });
         assertTool(SUPPORT.getObjectMapper().writeValueAsString(responseList), true);
     }
 
     private void toolsIdWorkflow() throws Exception {
-        Response response = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2FA%2Fl");
+        Response response = checkedResponse(baseURL + "tools/%23workflow%2Fgithub.com%2FA%2Fl");
         ToolV1 responseObject = response.readEntity(ToolV1.class);
         assertTool(SUPPORT.getObjectMapper().writeValueAsString(responseObject), false);
         // also try search by id
-        response = checkedResponse(basePath + "tools?id=%23workflow%2Fgithub.com%2FA%2Fl");
+        response = checkedResponse(baseURL + "tools?id=%23workflow%2Fgithub.com%2FA%2Fl");
         List<ToolV1> responseList = response.readEntity(new GenericType<List<ToolV1>>() {
         });
         assertTool(SUPPORT.getObjectMapper().writeValueAsString(responseList), false);
@@ -101,7 +101,7 @@ public class GA4GHV1IT extends GA4GHIT {
     @Test
     @Override
     public void testToolsIdVersions() throws Exception {
-        Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions");
+        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions");
         List<ToolVersionV1> responseObject = response.readEntity(new GenericType<List<ToolVersionV1>>() {
         });
         assertVersion(SUPPORT.getObjectMapper().writeValueAsString(responseObject));
@@ -110,7 +110,7 @@ public class GA4GHV1IT extends GA4GHIT {
     @Test
     @Override
     public void testToolClasses() throws Exception {
-        Response response = checkedResponse(basePath + "tool-classes");
+        Response response = checkedResponse(baseURL + "tool-classes");
         List<ToolClass> responseObject = response.readEntity(new GenericType<List<ToolClass>>() {
         });
         final String expected = SUPPORT.getObjectMapper()
@@ -122,14 +122,14 @@ public class GA4GHV1IT extends GA4GHIT {
     @Test
     @Override
     public void testToolsIdVersionsVersionId() throws Exception {
-        Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName");
+        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName");
         ToolVersionV1 responseObject = response.readEntity(ToolVersionV1.class);
         assertVersion(SUPPORT.getObjectMapper().writeValueAsString(responseObject));
     }
 
     @Override
     public void testToolsIdVersionsVersionIdTypeDescriptor() throws Exception {
-        Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor");
+        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor");
         ToolDescriptor responseObject = response.readEntity(ToolDescriptor.class);
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         assertDescriptor(SUPPORT.getObjectMapper().writeValueAsString(responseObject));
@@ -138,7 +138,7 @@ public class GA4GHV1IT extends GA4GHIT {
     @Override
     protected void toolsIdVersionsVersionIdTypeDescriptorRelativePathNormal() throws Exception {
         Response response = checkedResponse(
-            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/%2FDockstore.cwl");
+            baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/%2FDockstore.cwl");
         ToolDescriptor responseObject = response.readEntity(ToolDescriptor.class);
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         assertDescriptor(SUPPORT.getObjectMapper().writeValueAsString(responseObject));
@@ -146,7 +146,7 @@ public class GA4GHV1IT extends GA4GHIT {
 
     @Override
     protected void toolsIdVersionsVersionIdTypeDescriptorRelativePathMissingSlash() throws Exception {
-        Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/Dockstore.cwl");
+        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/Dockstore.cwl");
         ToolDescriptor responseObject = response.readEntity(ToolDescriptor.class);
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         assertDescriptor(SUPPORT.getObjectMapper().writeValueAsString(responseObject));
@@ -155,7 +155,7 @@ public class GA4GHV1IT extends GA4GHIT {
     @Override
     protected void toolsIdVersionsVersionIdTypeDescriptorRelativePathExtraDot() throws Exception {
         Response response = checkedResponse(
-            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/.%2FDockstore.cwl");
+            baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/.%2FDockstore.cwl");
         ToolDescriptor responseObject = response.readEntity(ToolDescriptor.class);
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         assertDescriptor(SUPPORT.getObjectMapper().writeValueAsString(responseObject));
@@ -165,12 +165,12 @@ public class GA4GHV1IT extends GA4GHIT {
     @Override
     public void testRelativePathEndpointToolTestParameterFileJSON() {
         Response response = checkedResponse(
-            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
+            baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
         ToolTestsV1 responseObject = response.readEntity(ToolTestsV1.class);
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         assertEquals("nestedPotato", responseObject.getTest());
         Response response2 = checkedResponse(
-            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/descriptor/%2Fnested%2Ftest.wdl.json");
+            baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/descriptor/%2Fnested%2Ftest.wdl.json");
         ToolTestsV1 responseObject2 = response2.readEntity(ToolTestsV1.class);
         assertEquals(HttpStatus.SC_OK, response2.getStatus());
         assertEquals("nestedPotato", responseObject2.getTest());
@@ -184,15 +184,15 @@ public class GA4GHV1IT extends GA4GHIT {
 
         // Check responses
         Response response = checkedResponse(
-            basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
         ToolTestsV1 responseObject = response.readEntity(ToolTestsV1.class);
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         assertEquals("nestedPotato", responseObject.getTest());
         Response response2 = client
-            .target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/descriptor/%2Ftest.potato.json").request().get();
+            .target(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/descriptor/%2Ftest.potato.json").request().get();
         assertEquals(HttpStatus.SC_NOT_FOUND, response2.getStatus());
         Response response3 = checkedResponse(
-            basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
         ToolTestsV1 responseObject3 = response3.readEntity(ToolTestsV1.class);
         assertEquals(HttpStatus.SC_OK, response3.getStatus());
         assertEquals("potato", responseObject3.getTest());
@@ -201,7 +201,7 @@ public class GA4GHV1IT extends GA4GHIT {
     @Test
     @Override
     public void testToolsIdVersionsVersionIdTypeTests() throws Exception {
-        Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/tests");
+        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/tests");
         List<ToolTestsV1> responseObject = response.readEntity(new GenericType<List<ToolTestsV1>>() {
         });
         assertThat(SUPPORT.getObjectMapper().writeValueAsString(responseObject).contains("test")).isTrue();
@@ -217,7 +217,7 @@ public class GA4GHV1IT extends GA4GHIT {
     @Test
     @Override
     public void testToolsIdVersionsVersionIdTypeDockerfile() {
-        Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/dockerfile");
+        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/dockerfile");
         // note: v1 really does expect only one item
         ToolDockerfile responseObject = response.readEntity(ToolDockerfile.class);
         assertTrue(!responseObject.getDockerfile().isEmpty() && !responseObject.getUrl().isEmpty());
@@ -253,22 +253,22 @@ public class GA4GHV1IT extends GA4GHIT {
     public void toolsIdGet4Workflows() throws Exception {
         // Insert the 4 workflows into the database using migrations
         CommonTestUtilities.setupSamePathsTest(SUPPORT);
-        Response response2 = checkedResponse(basePath + "tools");
-        checkedResponse(basePath + "tools");
+        Response response2 = checkedResponse(baseURL + "tools");
+        checkedResponse(baseURL + "tools");
         List<ToolV1> responseObject2 = response2.readEntity(new GenericType<List<ToolV1>>() {
         });
         assertNotNull(responseObject2);
         // Check responses
-        Response response = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2FfakeOrganization%2FfakeRepository");
+        Response response = checkedResponse(baseURL + "tools/%23workflow%2Fgithub.com%2FfakeOrganization%2FfakeRepository");
         ToolV1 responseObject = response.readEntity(ToolV1.class);
         assertThat(SUPPORT.getObjectMapper().writeValueAsString(responseObject)).contains("author1");
-        response = checkedResponse(basePath + "tools/%23workflow%2Fbitbucket.org%2FfakeOrganization%2FfakeRepository");
+        response = checkedResponse(baseURL + "tools/%23workflow%2Fbitbucket.org%2FfakeOrganization%2FfakeRepository");
         responseObject = response.readEntity(ToolV1.class);
         assertThat(SUPPORT.getObjectMapper().writeValueAsString(responseObject)).contains("author2");
-        response = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2FfakeOrganization%2FfakeRepository%2FPotato");
+        response = checkedResponse(baseURL + "tools/%23workflow%2Fgithub.com%2FfakeOrganization%2FfakeRepository%2FPotato");
         responseObject = response.readEntity(ToolV1.class);
         assertThat(SUPPORT.getObjectMapper().writeValueAsString(responseObject)).contains("author3");
-        response = checkedResponse(basePath + "tools/%23workflow%2Fbitbucket.org%2FfakeOrganization%2FfakeRepository%2FPotato");
+        response = checkedResponse(baseURL + "tools/%23workflow%2Fbitbucket.org%2FfakeOrganization%2FfakeRepository%2FPotato");
         responseObject = response.readEntity(ToolV1.class);
         assertThat(SUPPORT.getObjectMapper().writeValueAsString(responseObject)).contains("author4");
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2IT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2IT.java
@@ -22,6 +22,7 @@ import javax.ws.rs.core.Response;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.dockstore.common.CommonTestUtilities;
+import io.dockstore.common.TestUtility;
 import io.dockstore.common.Utilities;
 import io.dropwizard.testing.ResourceHelpers;
 import io.swagger.client.model.FileWrapper;
@@ -59,7 +60,7 @@ public class GA4GHV2IT extends GA4GHIT {
     @Test
     @Override
     public void testMetadata() throws Exception {
-        Response response = checkedResponse(basePath + "metadata");
+        Response response = checkedResponse(baseURL + "metadata");
         Metadata responseObject = response.readEntity(Metadata.class);
         assertThat(SUPPORT.getObjectMapper().writeValueAsString(responseObject)).contains("api_version");
         assertThat(SUPPORT.getObjectMapper().writeValueAsString(responseObject)).contains("friendly_name");
@@ -70,7 +71,7 @@ public class GA4GHV2IT extends GA4GHIT {
     @Test
     @Override
     public void testTools() throws Exception {
-        Response response = checkedResponse(basePath + "tools");
+        Response response = checkedResponse(baseURL + "tools");
         List<Tool> responseObject = response.readEntity(new GenericType<List<Tool>>() {
         });
         assertTool(SUPPORT.getObjectMapper().writeValueAsString(responseObject), true);
@@ -84,7 +85,7 @@ public class GA4GHV2IT extends GA4GHIT {
     }
 
     private void toolsIdTool() throws Exception {
-        Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6");
+        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6");
         Tool responseObject = response.readEntity(Tool.class);
         assertTool(SUPPORT.getObjectMapper().writeValueAsString(responseObject), true);
         // regression test for #1248
@@ -93,18 +94,18 @@ public class GA4GHV2IT extends GA4GHIT {
         assertTrue("imageName should never be null", responseObject.getVersions().size() > 0 && responseObject.getVersions().stream()
             .allMatch(version -> version.getImageName() != null));
         // search by id
-        response = checkedResponse(basePath + "tools?id=quay.io%2Ftest_org%2Ftest6");
+        response = checkedResponse(baseURL + "tools?id=quay.io%2Ftest_org%2Ftest6");
         List<Tool> responseList = response.readEntity(new GenericType<List<Tool>>() {
         });
         assertTool(SUPPORT.getObjectMapper().writeValueAsString(responseList), true);
     }
 
     private void toolsIdWorkflow() throws Exception {
-        Response response = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2FA%2Fl");
+        Response response = checkedResponse(baseURL + "tools/%23workflow%2Fgithub.com%2FA%2Fl");
         Tool responseObject = response.readEntity(Tool.class);
         assertTool(SUPPORT.getObjectMapper().writeValueAsString(responseObject), false);
         // search by id
-        response = checkedResponse(basePath + "tools?id=%23workflow%2Fgithub.com%2FA%2Fl");
+        response = checkedResponse(baseURL + "tools?id=%23workflow%2Fgithub.com%2FA%2Fl");
         List<Tool> responseList = response.readEntity(new GenericType<List<Tool>>() {
         });
         assertTool(SUPPORT.getObjectMapper().writeValueAsString(responseList), false);
@@ -113,7 +114,7 @@ public class GA4GHV2IT extends GA4GHIT {
     @Test
     @Override
     public void testToolsIdVersions() throws Exception {
-        Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions");
+        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions");
         List<ToolVersion> responseObject = response.readEntity(new GenericType<List<ToolVersion>>() {
         });
         assertVersion(SUPPORT.getObjectMapper().writeValueAsString(responseObject));
@@ -122,7 +123,7 @@ public class GA4GHV2IT extends GA4GHIT {
     @Test
     @Override
     public void testToolClasses() throws Exception {
-        Response response = checkedResponse(basePath + "toolClasses");
+        Response response = checkedResponse(baseURL + "toolClasses");
         List<ToolClass> responseObject = response.readEntity(new GenericType<List<ToolClass>>() {
         });
         final String expected = SUPPORT.getObjectMapper().writeValueAsString(
@@ -134,14 +135,14 @@ public class GA4GHV2IT extends GA4GHIT {
     @Test
     @Override
     public void testToolsIdVersionsVersionId() throws Exception {
-        Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName");
+        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName");
         ToolVersion responseObject = response.readEntity(ToolVersion.class);
         assertVersion(SUPPORT.getObjectMapper().writeValueAsString(responseObject));
     }
 
     @Override
     public void testToolsIdVersionsVersionIdTypeDescriptor() throws Exception {
-        Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor");
+        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor");
         FileWrapper responseObject = response.readEntity(FileWrapper.class);
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         assertDescriptor(SUPPORT.getObjectMapper().writeValueAsString(responseObject));
@@ -150,7 +151,7 @@ public class GA4GHV2IT extends GA4GHIT {
     @Override
     protected void toolsIdVersionsVersionIdTypeDescriptorRelativePathNormal() throws Exception {
         Response response = checkedResponse(
-            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/%2FDockstore.cwl");
+            baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/%2FDockstore.cwl");
         FileWrapper responseObject = response.readEntity(FileWrapper.class);
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         assertDescriptor(SUPPORT.getObjectMapper().writeValueAsString(responseObject));
@@ -158,7 +159,7 @@ public class GA4GHV2IT extends GA4GHIT {
 
     @Override
     protected void toolsIdVersionsVersionIdTypeDescriptorRelativePathMissingSlash() throws Exception {
-        Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/Dockstore.cwl");
+        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/Dockstore.cwl");
         FileWrapper responseObject = response.readEntity(FileWrapper.class);
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         assertDescriptor(SUPPORT.getObjectMapper().writeValueAsString(responseObject));
@@ -167,7 +168,7 @@ public class GA4GHV2IT extends GA4GHIT {
     @Override
     protected void toolsIdVersionsVersionIdTypeDescriptorRelativePathExtraDot() throws Exception {
         Response response = checkedResponse(
-            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/.%2FDockstore.cwl");
+            baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/.%2FDockstore.cwl");
         FileWrapper responseObject = response.readEntity(FileWrapper.class);
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         assertDescriptor(SUPPORT.getObjectMapper().writeValueAsString(responseObject));
@@ -177,12 +178,12 @@ public class GA4GHV2IT extends GA4GHIT {
     @Override
     public void testRelativePathEndpointToolTestParameterFileJSON() {
         Response response = checkedResponse(
-            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
+            baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
         FileWrapper responseObject = response.readEntity(FileWrapper.class);
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         assertEquals("nestedPotato", responseObject.getContent());
         Response response2 = checkedResponse(
-            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/descriptor/%2Fnested%2Ftest.wdl.json");
+            baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/descriptor/%2Fnested%2Ftest.wdl.json");
         FileWrapper responseObject2 = response2.readEntity(FileWrapper.class);
         assertEquals(HttpStatus.SC_OK, response2.getStatus());
         assertEquals("nestedPotato", responseObject2.getContent());
@@ -196,15 +197,15 @@ public class GA4GHV2IT extends GA4GHIT {
 
         // Check responses
         Response response = checkedResponse(
-            basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
         FileWrapper responseObject = response.readEntity(io.swagger.client.model.FileWrapper.class);
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         assertEquals("nestedPotato", responseObject.getContent());
         Response response2 = client
-            .target(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/descriptor/%2Ftest.potato.json").request().get();
+            .target(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/descriptor/%2Ftest.potato.json").request().get();
         assertEquals(HttpStatus.SC_NOT_FOUND, response2.getStatus());
         Response response3 = checkedResponse(
-            basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
         io.swagger.client.model.FileWrapper responseObject3 = response3.readEntity(io.swagger.client.model.FileWrapper.class);
         assertEquals(HttpStatus.SC_OK, response3.getStatus());
         assertEquals("potato", responseObject3.getContent());
@@ -213,7 +214,7 @@ public class GA4GHV2IT extends GA4GHIT {
     @Test
     @Override
     public void testToolsIdVersionsVersionIdTypeTests() throws Exception {
-        Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/tests");
+        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/tests");
         List<FileWrapper> responseObject = response.readEntity(new GenericType<List<FileWrapper>>() {
         });
         assertThat(SUPPORT.getObjectMapper().writeValueAsString(responseObject).contains("test")).isTrue();
@@ -223,7 +224,7 @@ public class GA4GHV2IT extends GA4GHIT {
     @Test
     @Override
     public void testToolsIdVersionsVersionIdTypeDockerfile() {
-        Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/containerfile");
+        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/containerfile");
         // note to tester, this seems to intentionally be a list in v2 as opposed to v1
         List<FileWrapper> responseObject = response.readEntity(new GenericType<List<FileWrapper>>() {
         });
@@ -243,7 +244,7 @@ public class GA4GHV2IT extends GA4GHIT {
 
     @Test
     public void toolsIdVersionsVersionIdTypeDescriptorRelativePathNoEncode() throws Exception {
-        Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor//Dockstore.cwl");
+        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor//Dockstore.cwl");
         FileWrapper responseObject = response.readEntity(FileWrapper.class);
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         assertDescriptor(SUPPORT.getObjectMapper().writeValueAsString(responseObject));
@@ -257,13 +258,13 @@ public class GA4GHV2IT extends GA4GHIT {
     @Test
     public void RelativePathEndpointToolTestParameterFileNoEncode() {
         Response response = checkedResponse(
-            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_CWL/descriptor//nested/test.cwl.json");
+            baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_CWL/descriptor//nested/test.cwl.json");
         String responseObject = response.readEntity(String.class);
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         assertEquals("nestedPotato", responseObject);
 
         Response response2 = checkedResponse(
-            basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_CWL/descriptor//test.cwl.json");
+            baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/PLAIN_CWL/descriptor//test.cwl.json");
         String responseObject2 = response2.readEntity(String.class);
         assertEquals(HttpStatus.SC_OK, response2.getStatus());
         assertEquals("potato", responseObject2);
@@ -280,20 +281,20 @@ public class GA4GHV2IT extends GA4GHIT {
         CommonTestUtilities.setupTestWorkflow(SUPPORT);
 
         // Check responses
-        Response response = checkedResponse(basePath
+        Response response = checkedResponse(baseURL
             + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//nested/test.cwl.json");
         String responseObject = response.readEntity(String.class);
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         assertEquals("nestedPotato", responseObject);
         Response response2 = checkedResponse(
-            basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//test.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//test.cwl.json");
         String responseObject2 = response2.readEntity(String.class);
         assertEquals(HttpStatus.SC_OK, response2.getStatus());
         assertEquals("potato", responseObject2);
     }
 
     private void toolsIdVersionsVersionIdTypeFileCWL() throws Exception {
-        Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/files");
+        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/files");
         List<ToolFile> responseObject = response.readEntity(new GenericType<List<ToolFile>>() {
         });
 
@@ -304,7 +305,7 @@ public class GA4GHV2IT extends GA4GHIT {
     }
 
     private void toolsIdVersionsVersionIdTypeFileWDL() throws Exception {
-        Response response = checkedResponse(basePath + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/files");
+        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/files");
         List<ToolFile> responseObject = response.readEntity(new GenericType<List<ToolFile>>() {
         });
         final String expected = SUPPORT.getObjectMapper()
@@ -342,16 +343,16 @@ public class GA4GHV2IT extends GA4GHIT {
         CommonTestUtilities.setupSamePathsTest(SUPPORT);
 
         // Check responses
-        Response response = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2FfakeOrganization%2FfakeRepository");
+        Response response = checkedResponse(baseURL + "tools/%23workflow%2Fgithub.com%2FfakeOrganization%2FfakeRepository");
         Tool responseObject = response.readEntity(Tool.class);
         assertThat(SUPPORT.getObjectMapper().writeValueAsString(responseObject)).contains("author1");
-        response = checkedResponse(basePath + "tools/%23workflow%2Fbitbucket.org%2FfakeOrganization%2FfakeRepository");
+        response = checkedResponse(baseURL + "tools/%23workflow%2Fbitbucket.org%2FfakeOrganization%2FfakeRepository");
         responseObject = response.readEntity(Tool.class);
         assertThat(SUPPORT.getObjectMapper().writeValueAsString(responseObject)).contains("author2");
-        response = checkedResponse(basePath + "tools/%23workflow%2Fgithub.com%2FfakeOrganization%2FfakeRepository%2FPotato");
+        response = checkedResponse(baseURL + "tools/%23workflow%2Fgithub.com%2FfakeOrganization%2FfakeRepository%2FPotato");
         responseObject = response.readEntity(Tool.class);
         assertThat(SUPPORT.getObjectMapper().writeValueAsString(responseObject)).contains("author3");
-        response = checkedResponse(basePath + "tools/%23workflow%2Fbitbucket.org%2FfakeOrganization%2FfakeRepository%2FPotato");
+        response = checkedResponse(baseURL + "tools/%23workflow%2Fbitbucket.org%2FfakeOrganization%2FfakeRepository%2FPotato");
         responseObject = response.readEntity(Tool.class);
         assertThat(SUPPORT.getObjectMapper().writeValueAsString(responseObject)).contains("author4");
     }
@@ -364,8 +365,8 @@ public class GA4GHV2IT extends GA4GHIT {
     public void cwlrunnerWorkflowRelativePathNotEncodedAdditionalFiles() throws Exception {
         CommonTestUtilities.setupTestWorkflow(SUPPORT);
         String command = "cwl-runner";
-        String descriptorPath =
-            basePath + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/plain-CWL/descriptor//Dockstore.cwl";
+        String originalUrl = baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/plain-CWL/descriptor//Dockstore.cwl";
+        String descriptorPath = TestUtility.mimicNginxRewrite(originalUrl, basePath);
         String testParameterFilePath = ResourceHelpers.resourceFilePath("testWorkflow.json");
         ImmutablePair<String, String> stringStringImmutablePair = Utilities
             .executeCommand(command + " " + descriptorPath + " " + testParameterFilePath, System.out, System.err);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -49,6 +49,7 @@ public final class CommonTestUtilities {
     public static final int WAIT_TIME = 60000;
 
 
+    public static final String PUBLIC_CONFIG_PATH_WITH_API = ResourceHelpers.resourceFilePath("dockstoreAPI.yml");
     public static final String PUBLIC_CONFIG_PATH = ResourceHelpers.resourceFilePath("dockstore.yml");
     /**
      * confidential testing config, includes keys

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/TestUtility.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/TestUtility.java
@@ -70,6 +70,21 @@ public final class TestUtility {
     }
 
     /**
+     * Currently in production, the basePath is "/api/" and Nginx removes first /api it finds and redirects it to "http://webservice:8080/$uri"
+     * This mimics the nginx functionality
+     * @param originalUrl   The original URL that the UI2 and the Swagger UI displays
+     * @param basePath      The basePath set in the Dropwizard configuration file
+     * @return              The URL modified by nginx
+     */
+    public static String mimicNginxRewrite(String originalUrl, String basePath) {
+        if (basePath.equals("/api/")) {
+            return originalUrl.replaceFirst("/api/", "/");
+        } else {
+            return originalUrl;
+        }
+    }
+
+    /**
      * Returns a path to a temporary configuration file with a valid notifications webhook URL
      * All slack webhook URLs are apparently valid.
      */

--- a/dockstore-integration-testing/src/test/resources/dockstoreAPI.yml
+++ b/dockstore-integration-testing/src/test/resources/dockstoreAPI.yml
@@ -1,0 +1,83 @@
+# These Client ID, Client Secrets, and redirect URIs are used by the webservice to setup a User's access tokens
+template: Hello, %s!
+quayClientID: <fill me in>
+quayRedirectURI: http://<fill me in>:8080/static/quay_callback.htm
+githubClientID: <fill me in>
+githubClientSecret: <fill me in>
+githubRedirectURI: http://<fill me in>:8080/auth/tokens/github.com
+gitlabClientID: <fill me in>
+gitlabClientSecret: <fill me in>
+gitlabRedirectURI: http://<fill me in>:8080/auth/tokens/gitlab.com
+bitbucketClientID: <fill me in>
+bitbucketClientSecret: <fill me in>
+
+googleClientID: <fill me in>
+googleClientSecret: <fill me in>
+# port should match the port where the UI is being hosted, 4200 by default
+googleRedirectURI: http://<fill me in>:8080/auth/tokens/google.com
+
+externalConfig:
+  basePath: /api/
+  hostname: localhost
+  scheme: http
+  port: 8080
+
+authenticationCachePolicy: maximumSize=10000, expireAfterAccess=10m
+
+server:
+  applicationConnectors:
+  - type: http
+    port: 8080
+  adminConnectors:
+  - type: http
+    port: 8001
+
+limitConfig:
+  workflowLimit: 10
+  workflowVersionLimit: 10
+
+database:
+  # the name of your JDBC driver
+  driverClass: org.postgresql.Driver
+
+  # the username
+  user: dockstore
+
+  # the password
+  password: dockstore
+
+  # the JDBC URL
+  url: jdbc:postgresql://localhost:5432/webservice_test
+
+  # any properties specific to your JDBC driver:
+  properties:
+    charSet: UTF-8
+    hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
+    # create database as needed, disable in production
+    hibernate.hbm2ddl.auto: validate
+    # suppress session log to reduce verbosity
+    hibernate.generate_statistics: false
+
+  # the maximum amount of time to wait on an empty pool before throwing an exception
+  maxWaitForConnection: 1s
+
+  # the SQL query to run when validating a connection's liveness
+  validationQuery: "/* MyApplication Health Check */ SELECT 1"
+
+  # the minimum number of connections to keep open
+  minSize: 8
+
+  # the maximum number of connections to keep open
+  maxSize: 32
+
+  # whether or not idle connections should be validated
+  checkConnectionWhileIdle: false
+
+logging:
+  level: ERROR
+  appenders:
+  - type: console
+    threshold: ERROR
+    timeZone: UTC
+    target: stdout
+    logFormat: # TODO

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
@@ -226,8 +227,11 @@ public final class ToolsImplCommon {
      */
     private static String baseURL(DockstoreWebserviceConfiguration config) throws URISyntaxException {
         int port = config.getExternalConfig().getPort() == null ? -1 : Integer.parseInt(config.getExternalConfig().getPort());
-        URI uri = new URI(config.getExternalConfig().getScheme(), null, config.getExternalConfig().getHostname(), port,
-            DockstoreWebserviceApplication.GA4GH_API_PATH + "/tools/", null, null);
+        // basePath should be "/" or "/api/"
+        String basePath = MoreObjects.firstNonNull(config.getExternalConfig().getBasePath(), "/");
+        // Example without the replace: "/api/" + "/api/ga4gh/v2" + "/tools/"
+        String baseURI = basePath + DockstoreWebserviceApplication.GA4GH_API_PATH.replaceFirst("/", "") + "/tools/";
+        URI uri = new URI(config.getExternalConfig().getScheme(), null, config.getExternalConfig().getHostname(), port, baseURI, null, null);
         return uri.toString();
     }
 


### PR DESCRIPTION
URLs returned by webservice are fine when used with a `/` basePath, but currently it's `/api/` in production and nginx strips away the first `/api` when found.

This PR:
- modifies the test to mimic what nginx does (if the basePath is `/api/`)
- fixes the URL presented in ga4gh return objects to account for a different basePath
- tests every single field that is called "URL" in all ga4gh objects and checks that it returns an OK response (with the exception of fake github URLs)