### PR TITLE
Fix refresh issue with published workflows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,26 +56,26 @@ jobs:
       script: mvn --batch-mode clean install -P$TESTING_PROFILE -DskipClientITs=true
 
     # no point in running coverage if we don't pass integration tests
-    - stage: coverage 
-      if: branch IN (master, develop, /hotfix\/[\d]\.[\d]\.[\d]/)
+    - stage: coverage
+      if: type IN (pull_request) OR branch IN (master, develop)
       env:
         - TESTING_PROFILE=unit-tests
       script: mvn --batch-mode clean install jacoco:report jacoco:report-aggregate coveralls:report -P$TESTING_PROFILE,coverage
     - stage: coverage
-      if: branch IN (master, develop, /hotfix\/[\d]\.[\d]\.[\d]/)
+      if: type IN (pull_request) OR branch IN (master, develop)
       script: mvn --batch-mode clean install jacoco:report-integration jacoco:report-aggregate coveralls:report -P$TESTING_PROFILE,coverage -DskipITs=true
     - stage: coverage
-      if: branch IN (master, develop, /hotfix\/[\d]\.[\d]\.[\d]/)
+      if: type IN (pull_request) OR branch IN (master, develop)
       script: mvn --batch-mode clean install jacoco:report-integration jacoco:report-aggregate coveralls:report -P$TESTING_PROFILE,coverage -DskipClientITs=true
       env:
         - TESTING_PROFILE=tool-integration-tests
     - stage: coverage
-      if: branch IN (master, develop, /hotfix\/[\d]\.[\d]\.[\d]/)
+      if: type IN (pull_request) OR branch IN (master, develop)
       script: mvn --batch-mode clean install jacoco:report-integration jacoco:report-aggregate coveralls:report -P$TESTING_PROFILE,coverage -DskipClientITs=true
       env:
         - TESTING_PROFILE=workflow-integration-tests
     - stage: coverage
-      if: branch IN (master, develop, /hotfix\/[\d]\.[\d]\.[\d]/)
+      if: type IN (pull_request) OR branch IN (master, develop)
       script: mvn --batch-mode clean install jacoco:report-integration jacoco:report-aggregate coveralls:report -P$TESTING_PROFILE,coverage -DskipClientITs=true
       env:
         - TESTING_PROFILE=other-integration-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,25 +57,25 @@ jobs:
 
     # no point in running coverage if we don't pass integration tests
     - stage: coverage 
-      if: branch IN (master, develop)
+      if: branch IN (master, develop, /hotfix\/[\d]\.[\d]\.[\d]/)
       env:
         - TESTING_PROFILE=unit-tests
       script: mvn --batch-mode clean install jacoco:report jacoco:report-aggregate coveralls:report -P$TESTING_PROFILE,coverage
     - stage: coverage
-      if: branch IN (master, develop)
+      if: branch IN (master, develop, /hotfix\/[\d]\.[\d]\.[\d]/)
       script: mvn --batch-mode clean install jacoco:report-integration jacoco:report-aggregate coveralls:report -P$TESTING_PROFILE,coverage -DskipITs=true
     - stage: coverage
-      if: branch IN (master, develop)
+      if: branch IN (master, develop, /hotfix\/[\d]\.[\d]\.[\d]/)
       script: mvn --batch-mode clean install jacoco:report-integration jacoco:report-aggregate coveralls:report -P$TESTING_PROFILE,coverage -DskipClientITs=true
       env:
         - TESTING_PROFILE=tool-integration-tests
     - stage: coverage
-      if: branch IN (master, develop)
+      if: branch IN (master, develop, /hotfix\/[\d]\.[\d]\.[\d]/)
       script: mvn --batch-mode clean install jacoco:report-integration jacoco:report-aggregate coveralls:report -P$TESTING_PROFILE,coverage -DskipClientITs=true
       env:
         - TESTING_PROFILE=workflow-integration-tests
     - stage: coverage
-      if: branch IN (master, develop)
+      if: branch IN (master, develop, /hotfix\/[\d]\.[\d]\.[\d]/)
       script: mvn --batch-mode clean install jacoco:report-integration jacoco:report-aggregate coveralls:report -P$TESTING_PROFILE,coverage -DskipClientITs=true
       env:
         - TESTING_PROFILE=other-integration-tests

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -368,6 +368,7 @@ public class WorkflowResource
             }
         }
 
+        // new workflow is the workflow as found on github (source control)
         final Workflow newWorkflow = sourceCodeRepo
             .getWorkflow(workflow.getOrganization() + '/' + workflow.getRepository(), Optional.of(workflow));
         workflow.getUsers().add(user);
@@ -378,7 +379,8 @@ public class WorkflowResource
         if (!workflow.isIsChecker() && workflow.getCheckerWorkflow() != null) {
             refresh(user, workflow.getCheckerWorkflow().getId());
         }
-        elasticManager.handleIndexUpdate(newWorkflow, ElasticMode.UPDATE);
+        // workflow is the copy that is in our DB and merged with content from source control, so update index with that one
+        elasticManager.handleIndexUpdate(workflow, ElasticMode.UPDATE);
         return workflow;
     }
 


### PR DESCRIPTION
Working on #1941 
Looks like the refresh is improperly throwing the wrong copy of the refreshing workflow into the index (can diagnose it by looking for an id of 0, which may mean there is at max one "ghost" of this type at a time). 

Also fixes the issue with PRs to hotfix branches not running coverage on Travis-CI
