### PR TITLE
Clear metadata if there is an error reading WDL

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -18,6 +18,7 @@ package io.dockstore.webservice.languages;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -69,7 +70,8 @@ public class WDLHandler implements LanguageHandlerInterface {
             WdlParser.Ast ast = (WdlParser.Ast)parser.parse(tokens).toAst();
 
             if (ast == null) {
-                LOG.info("Error with WDL file.");
+                LOG.error(MessageFormat.format("Unable to parse WDL file {0}", filepath));
+                clearMetadata(entry);
                 return entry;
             } else {
                 LOG.info("Repository has Dockstore.wdl");
@@ -112,10 +114,17 @@ public class WDLHandler implements LanguageHandlerInterface {
                 entry.setDescription(description[0]);
             }
         } catch (WdlParser.SyntaxError syntaxError) {
-            LOG.info("Invalid WDL file.");
+            LOG.error(MessageFormat.format("Unable to parse WDL file {0}", filepath), syntaxError);
+            clearMetadata(entry);
         }
 
         return entry;
+    }
+
+    private void clearMetadata(Entry entry) {
+        entry.setAuthor(null);
+        entry.setEmail(null);
+        entry.setDescription(null);
     }
 
     private String extractRuntimeAttributeFromAST(WdlParser.AstNode node, String key) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -54,7 +54,9 @@ import wdl4s.parser.WdlParser;
  */
 public class WDLHandler implements LanguageHandlerInterface {
     public static final Logger LOG = LoggerFactory.getLogger(WDLHandler.class);
+    public static final String WDL_SYNTAX_ERROR = "There is a syntax error, please check the WDL file.";
     private static final Pattern IMPORT_PATTERN = Pattern.compile("^import\\s+\"(\\S+)\"");
+
     @Override
     public Entry parseWorkflowContent(Entry entry, String filepath, String content, Set<SourceFile> sourceFiles) {
         // Use Broad WDL parser to grab data
@@ -124,7 +126,7 @@ public class WDLHandler implements LanguageHandlerInterface {
     private void clearMetadata(Entry entry) {
         entry.setAuthor(null);
         entry.setEmail(null);
-        entry.setDescription(null);
+        entry.setDescription(WDL_SYNTAX_ERROR);
     }
 
     private String extractRuntimeAttributeFromAST(WdlParser.AstNode node, String key) {

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ info:
     This describes the dockstore API, a webservice that manages pairs of Docker
     images and associated metadata such as CWL documents and Dockerfiles used to
     build those images
-  version: 1.5.2-SNAPSHOT
+  version: 1.5.4-SNAPSHOT
   title: Dockstore API
   termsOfService: TBD
   contact:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.5.2-SNAPSHOT"
+  version: "1.5.4-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
@@ -1,0 +1,69 @@
+package io.dockstore.webservice.languages;
+
+import java.util.Collections;
+
+import io.dockstore.webservice.core.Workflow;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class WDLHandlerTest {
+
+    private static final String GOOD_WDL =
+            "workflow myWorkflow {\n"
+                    + "    call myTask\n"
+                    + "  meta {\n"
+                    + "          author : \"Mr. Foo\"\n"
+                    + "          email : \"foo@foo.com\"\n"
+                    + "          description: \"Back to fixed!\"\n"
+                    + "      }\n"
+                    + "}\n"
+                    + "\n"
+                    + "task myTask {\n"
+                    + "    command {\n"
+                    + "        echo \"hello world\"\n"
+                    + "    }\n"
+                    + "    output {\n"
+                    + "        String out = read_string(stdout())\n"
+                    + "    }\n"
+                    + "}";
+
+    private static final String WDL_WITH_ILLEGAL_MULTILINE_DESCRIPTION =
+            "workflow myWorkflow {\n"
+                    + "    call myTask\n"
+                    + "  meta {\n"
+                    + "          author : \"Mr. Foo\"\n"
+                    + "          email : \"foo@foo.com\"\n"
+                    + "          description: \"This is a cool workflow trying another line \\n## This is a header\\n* First Bullet\\n* Second bullet\nIntentional problem\"\n"
+                    + "      }\n"
+                    + "}\n"
+                    + "\n"
+                    + "task myTask {\n"
+                    + "    command {\n"
+                    + "        echo \"hello world\"\n"
+                    + "    }\n"
+                    + "    output {\n"
+                    + "        String out = read_string(stdout())\n"
+                    + "    }\n"
+                    + "}";
+
+    @Test
+    public void getWorkflowContent() {
+        final WDLHandler wdlHandler = new WDLHandler();
+        final Workflow workflow = new Workflow();
+        workflow.setAuthor("Jane Doe");
+        workflow.setDescription("A good description");
+        workflow.setEmail("janedoe@example.org");
+
+        wdlHandler.parseWorkflowContent(workflow, "/foo.wdl", GOOD_WDL, Collections.emptySet());
+        Assert.assertEquals(workflow.getAuthor(), "Mr. Foo");
+        Assert.assertEquals(workflow.getEmail(), "foo@foo.com");
+        Assert.assertEquals(workflow.getDescription(), "Back to fixed!");
+
+        wdlHandler.parseWorkflowContent(workflow, "/foo.wdl", WDL_WITH_ILLEGAL_MULTILINE_DESCRIPTION, Collections.emptySet());
+        Assert.assertNull(workflow.getAuthor());
+        Assert.assertNull(workflow.getEmail());
+        Assert.assertNull(workflow.getDescription());
+
+
+    }
+}

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
@@ -1,69 +1,42 @@
 package io.dockstore.webservice.languages;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
 import io.dockstore.webservice.core.Workflow;
+import io.dropwizard.testing.ResourceHelpers;
+import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class WDLHandlerTest {
 
-    private static final String GOOD_WDL =
-            "workflow myWorkflow {\n"
-                    + "    call myTask\n"
-                    + "  meta {\n"
-                    + "          author : \"Mr. Foo\"\n"
-                    + "          email : \"foo@foo.com\"\n"
-                    + "          description: \"Back to fixed!\"\n"
-                    + "      }\n"
-                    + "}\n"
-                    + "\n"
-                    + "task myTask {\n"
-                    + "    command {\n"
-                    + "        echo \"hello world\"\n"
-                    + "    }\n"
-                    + "    output {\n"
-                    + "        String out = read_string(stdout())\n"
-                    + "    }\n"
-                    + "}";
-
-    private static final String WDL_WITH_ILLEGAL_MULTILINE_DESCRIPTION =
-            "workflow myWorkflow {\n"
-                    + "    call myTask\n"
-                    + "  meta {\n"
-                    + "          author : \"Mr. Foo\"\n"
-                    + "          email : \"foo@foo.com\"\n"
-                    + "          description: \"This is a cool workflow trying another line \\n## This is a header\\n* First Bullet\\n* Second bullet\nIntentional problem\"\n"
-                    + "      }\n"
-                    + "}\n"
-                    + "\n"
-                    + "task myTask {\n"
-                    + "    command {\n"
-                    + "        echo \"hello world\"\n"
-                    + "    }\n"
-                    + "    output {\n"
-                    + "        String out = read_string(stdout())\n"
-                    + "    }\n"
-                    + "}";
-
     @Test
-    public void getWorkflowContent() {
+    public void getWorkflowContent() throws IOException {
         final WDLHandler wdlHandler = new WDLHandler();
         final Workflow workflow = new Workflow();
         workflow.setAuthor("Jane Doe");
         workflow.setDescription("A good description");
         workflow.setEmail("janedoe@example.org");
 
-        wdlHandler.parseWorkflowContent(workflow, "/foo.wdl", GOOD_WDL, Collections.emptySet());
+        final String goodWdl = FileUtils
+                .readFileToString(new File(ResourceHelpers.resourceFilePath("valid_description_example.wdl")),
+                        StandardCharsets.UTF_8);
+        wdlHandler.parseWorkflowContent(workflow, "/foo.wdl", goodWdl, Collections.emptySet());
         Assert.assertEquals(workflow.getAuthor(), "Mr. Foo");
         Assert.assertEquals(workflow.getEmail(), "foo@foo.com");
-        Assert.assertEquals(workflow.getDescription(), "Back to fixed!");
+        Assert.assertEquals(workflow.getDescription(),
+                "This is a cool workflow trying another line \n## This is a header\n* First Bullet\n* Second bullet");
 
-        wdlHandler.parseWorkflowContent(workflow, "/foo.wdl", WDL_WITH_ILLEGAL_MULTILINE_DESCRIPTION, Collections.emptySet());
+        final String invalidDescriptionWdl = FileUtils
+                .readFileToString(new File(ResourceHelpers.resourceFilePath("invalid_description_example.wdl")),
+                        StandardCharsets.UTF_8);
+        wdlHandler.parseWorkflowContent(workflow, "/foo.wdl", invalidDescriptionWdl, Collections.emptySet());
         Assert.assertNull(workflow.getAuthor());
         Assert.assertNull(workflow.getEmail());
         Assert.assertNull(workflow.getDescription());
-
 
     }
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
@@ -36,7 +36,7 @@ public class WDLHandlerTest {
         wdlHandler.parseWorkflowContent(workflow, "/foo.wdl", invalidDescriptionWdl, Collections.emptySet());
         Assert.assertNull(workflow.getAuthor());
         Assert.assertNull(workflow.getEmail());
-        Assert.assertNull(workflow.getDescription());
+        Assert.assertEquals(WDLHandler.WDL_SYNTAX_ERROR, workflow.getDescription());
 
     }
 }

--- a/dockstore-webservice/src/test/resources/invalid_description_example.wdl
+++ b/dockstore-webservice/src/test/resources/invalid_description_example.wdl
@@ -1,0 +1,19 @@
+workflow myWorkflow {
+    call myTask
+  meta {
+          author : "Mr. Foo"
+          email : "foo@foo.com"
+          description: "This is a cool workflow trying another line \n## This is a header\n* First Bullet\n* Second bullet
+Intentional problem"
+      }
+}
+
+task myTask {
+    command {
+        echo "hello world"
+    }
+    output {
+        String out = read_string(stdout())
+    }
+}
+

--- a/dockstore-webservice/src/test/resources/valid_description_example.wdl
+++ b/dockstore-webservice/src/test/resources/valid_description_example.wdl
@@ -1,0 +1,17 @@
+workflow myWorkflow {
+    call myTask
+  meta {
+          author : "Mr. Foo"
+          email : "foo@foo.com"
+          description: "This is a cool workflow trying another line \n## This is a header\n* First Bullet\n* Second bullet"
+      }
+}
+
+task myTask {
+    command {
+        echo "hello world"
+    }
+    output {
+        String out = read_string(stdout())
+    }
+}


### PR DESCRIPTION
#1942

If there is an error reading the WDL, set author, email, and
description to null, otherwise the worklow's metadata will show
the previous version's metadata.
