### PR TITLE
Feature/organisation phase 1 collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ dockstore-client/target/
 swagger-java-client/target/
 swagger-java-quay-client/target/
 swagger-java-sam-client/target/
+swagger-java-bitbucket-client/target/
 dockstore-event-consumer/target/
 dockstore-webservice/nbactions.xml
 dockstore-common/target/

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
@@ -105,6 +105,8 @@ public class CRUDClientIT extends BaseIT {
         // clear lazy fields for now till merge
         hostedTool.setAliases(null);
         container.setAliases(null);
+        hostedTool.setCollections(null);
+        container.setCollections(null);
         assertEquals(container, hostedTool);
         assertEquals(1, container.getUsers().size());
         container.getUsers().forEach(user -> assertNull("getContainer() endpoint should not have user profiles", user.getUserProfiles()));
@@ -195,6 +197,8 @@ public class CRUDClientIT extends BaseIT {
         // clear lazy fields for now till merge
         hostedTool.setAliases(null);
         container.setAliases(null);
+        hostedTool.setCollections(null);
+        container.setCollections(null);
         assertEquals(1, container.getUsers().size());
         container.getUsers().forEach(user -> assertNull("getWorkflow() endpoint should not have user profiles", user.getUserProfiles()));
         assertEquals(container, hostedTool);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/LimitedCRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/LimitedCRUDClientIT.java
@@ -125,6 +125,8 @@ public class LimitedCRUDClientIT {
         // clear lazy fields for now till merge
         hostedTool.setAliases(null);
         container.setAliases(null);
+        hostedTool.setCollections(null);
+        container.setCollections(null);
         assertEquals(container, hostedTool);
         assertEquals(1, container.getUsers().size());
         container.getUsers().forEach(user -> assertNull("getContainer() endpoint should not have user profiles", user.getUserProfiles()));

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganisationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganisationIT.java
@@ -555,13 +555,23 @@ public class OrganisationIT extends BaseIT {
                 .runSelectStatement("select count(*) from collection_entry where collectionid = '1'", new ScalarHandler<>());
         assertEquals("There should be 2 entries associated with the collection, there are " + count2, 2, count2);
 
+        // There should be two ADD_TO_COLLECTION events
+        final long count3 = testingPostgres
+                .runSelectStatement("select count(*) from event where type = 'ADD_TO_COLLECTION'", new ScalarHandler<>());
+        assertEquals("There should be 2 events of type ADD_TO_COLLECTION, there are " + count3, 2, count3);
+
         // Remove a tool from the collection
         organisationsApi.deleteEntryFromCollection(organisation.getId(), collectionId, entryId);
 
+        // There should be one REMOVE_FROM_COLLECTION events
+        final long count4 = testingPostgres
+                .runSelectStatement("select count(*) from event where type = 'REMOVE_FROM_COLLECTION'", new ScalarHandler<>());
+        assertEquals("There should be 1 event of type REMOVE_FROM_COLLECTION, there are " + count4, 1, count4);
+
         // There should now be one entry for collection with ID 1
-        final long count3 = testingPostgres
+        final long count5 = testingPostgres
                 .runSelectStatement("select count(*) from collection_entry where collectionid = '1'", new ScalarHandler<>());
-        assertEquals("There should be 1 entry associated with the collection, there are " + count3, 1, count3);
+        assertEquals("There should be 1 entry associated with the collection, there are " + count5, 1, count5);
 
         // Try getting all collections
         List<Collection> collections = organisationsApi.getCollectionsFromOrganisation(organisation.getId());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
 import com.google.common.base.MoreObjects;
+import io.dockstore.webservice.core.Collection;
 import io.dockstore.webservice.core.Event;
 import io.dockstore.webservice.core.FileFormat;
 import io.dockstore.webservice.core.Label;
@@ -54,6 +55,7 @@ import io.dockstore.webservice.jdbi.UserDAO;
 import io.dockstore.webservice.jdbi.WorkflowDAO;
 import io.dockstore.webservice.permissions.PermissionsFactory;
 import io.dockstore.webservice.permissions.PermissionsInterface;
+import io.dockstore.webservice.resources.CollectionResource;
 import io.dockstore.webservice.resources.DockerRepoResource;
 import io.dockstore.webservice.resources.DockerRepoTagResource;
 import io.dockstore.webservice.resources.EntryResource;
@@ -122,7 +124,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
 
     private final HibernateBundle<DockstoreWebserviceConfiguration> hibernate = new HibernateBundle<DockstoreWebserviceConfiguration>(
             Token.class, Tool.class, User.class, Tag.class, Label.class, SourceFile.class, Workflow.class,
-            WorkflowVersion.class, FileFormat.class, Organisation.class, OrganisationUser.class, Event.class) {
+            WorkflowVersion.class, FileFormat.class, Organisation.class, OrganisationUser.class, Event.class, Collection.class) {
         @Override
         public DataSourceFactory getDataSourceFactory(DockstoreWebserviceConfiguration configuration) {
             return configuration.getDataSourceFactory();
@@ -254,6 +256,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         environment.jersey().register(new HostedWorkflowResource(getHibernate().getSessionFactory(), authorizer, configuration.getLimitConfig()));
         environment.jersey().register(new EntryResource(environment.getObjectMapper(), toolDAO));
         environment.jersey().register(new OrganisationResource(getHibernate().getSessionFactory()));
+        environment.jersey().register(new CollectionResource(getHibernate().getSessionFactory()));
 
 
         // attach the container dao statically to avoid too much modification of generated code

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
@@ -49,7 +49,7 @@ public class Collection implements Serializable {
     @Column(nullable = false, unique = true)
     @Pattern(regexp = "\\d*[a-zA-Z][a-zA-Z\\d]*")
     @Size(min = 3, max = 39)
-    @ApiModelProperty(value = "Name of the collection.", required = true, example = "OICR", position = 1)
+    @ApiModelProperty(value = "Name of the collection.", required = true, example = "Alignment", position = 1)
     private String name;
 
     @Column(columnDefinition = "TEXT")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
@@ -1,0 +1,142 @@
+package io.dockstore.webservice.core;
+
+import java.io.Serializable;
+import java.sql.Timestamp;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.ManyToOne;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/**
+ * This describes a Dockstore collection that can be associated with an organisation.
+ *
+ * @author aduncan
+ */
+@ApiModel("Collection")
+@Entity
+@Table(name = "collection")
+@NamedQueries({
+        @NamedQuery(name = "io.dockstore.webservice.core.Collection.findAllbyOrg", query = "SELECT col FROM Collection col WHERE organisationid = :organisationId"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Collection.findByNameAndOrg", query = "SELECT col FROM Collection col WHERE col.name = :name AND organisationid = :organisationId"),
+})
+@SuppressWarnings("checkstyle:magicnumber")
+public class Collection implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @ApiModelProperty(value = "Implementation specific ID for the collection in this web service", position = 0)
+    private long id;
+
+    @Column(nullable = false, unique = true)
+    @Pattern(regexp = "\\d*[a-zA-Z][a-zA-Z\\d]*")
+    @Size(min = 3, max = 39)
+    @ApiModelProperty(value = "Name of the collection (ex. OICR).", required = true, position = 1)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    @ApiModelProperty(value = "Description of the collection", position = 2)
+    private String description;
+
+    @JsonIgnore
+    @ManyToMany
+    @JoinTable(name = "collection_entry", joinColumns = @JoinColumn(name = "collectionid"), inverseJoinColumns = @JoinColumn(name = "entryid"))
+    private Set<Entry> entries = new HashSet<>();
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organisationid")
+    private Organisation organisation;
+
+    @Column(updatable = false)
+    @CreationTimestamp
+    private Timestamp dbCreateDate;
+
+    @Column()
+    @UpdateTimestamp
+    private Timestamp dbUpdateDate;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Set<Entry> getEntries() {
+        return entries;
+    }
+
+    public void setEntries(Set<Entry> entries) {
+        this.entries = entries;
+    }
+
+    public void addEntry(Entry entry) {
+        this.entries.add(entry);
+        entry.getCollections().add(this);
+    }
+
+    public void removeEntry(Entry entry) {
+        this.entries.remove(entry);
+        entry.getCollections().remove(this);
+    }
+
+    public Organisation getOrganisation() {
+        return organisation;
+    }
+
+    public void setOrganisation(Organisation organisation) {
+        this.organisation = organisation;
+    }
+
+    public Timestamp getDbCreateDate() {
+        return dbCreateDate;
+    }
+
+    public void setDbCreateDate(Timestamp dbCreateDate) {
+        this.dbCreateDate = dbCreateDate;
+    }
+
+    public Timestamp getDbUpdateDate() {
+        return dbUpdateDate;
+    }
+
+    public void setDbUpdateDate(Timestamp dbUpdateDate) {
+        this.dbUpdateDate = dbUpdateDate;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
@@ -36,7 +36,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 @Entity
 @Table(name = "collection")
 @NamedQueries({
-        @NamedQuery(name = "io.dockstore.webservice.core.Collection.findAllbyOrg", query = "SELECT col FROM Collection col WHERE organisationid = :organisationId"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Collection.findAllByOrg", query = "SELECT col FROM Collection col WHERE organisationid = :organisationId"),
         @NamedQuery(name = "io.dockstore.webservice.core.Collection.findByNameAndOrg", query = "SELECT col FROM Collection col WHERE col.name = :name AND organisationid = :organisationId"),
 })
 @SuppressWarnings("checkstyle:magicnumber")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
@@ -49,7 +49,7 @@ public class Collection implements Serializable {
     @Column(nullable = false, unique = true)
     @Pattern(regexp = "\\d*[a-zA-Z][a-zA-Z\\d]*")
     @Size(min = 3, max = 39)
-    @ApiModelProperty(value = "Name of the collection (ex. OICR).", required = true, position = 1)
+    @ApiModelProperty(value = "Name of the collection.", required = true, example = "OICR", position = 1)
     private String name;
 
     @Column(columnDefinition = "TEXT")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -19,6 +19,7 @@ package io.dockstore.webservice.core;
 import java.sql.Timestamp;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -147,6 +148,8 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     @ApiModelProperty(value = "This is a link to the associated repo with a descriptor, required GA4GH", required = true, position = 11)
     private String gitUrl;
 
+    @ManyToMany(mappedBy = "entries")
+    private Set<Collection> collections = new HashSet<>();
 
     @JsonIgnore
     @JoinColumn(name = "checkerid")
@@ -349,6 +352,15 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     public boolean removeStarredUser(User user) {
         return starredUsers.remove(user);
     }
+
+    public Set<Collection> getCollections() {
+        return collections;
+    }
+
+    public void setCollections(Set<Collection> collections) {
+        this.collections = collections;
+    }
+
     /**
      * Used during refresh to update containers
      *

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -80,9 +80,6 @@ import org.hibernate.annotations.UpdateTimestamp;
     @NamedNativeQuery(name = "Entry.getEntryByPath", query =
         "SELECT 'tool' as type, id from tool where registry = :one and namespace = :two and name = :three and toolname = :four union"
             + " select 'workflow' as type, id from workflow where sourcecontrol = :one and organization = :two and repository = :three and workflowname = :four"),
-        @NamedNativeQuery(name = "Entry.getEntryById", query =
-        "SELECT 'tool' as type, id from tool where id = :id union"
-            + " select 'workflow' as type, id from workflow where id = :id"),
     @NamedNativeQuery(name = "Entry.getEntryByPathNullName", query =
         "SELECT 'tool' as type, id from tool where registry = :one and namespace = :two and name = :three and toolname IS NULL union"
             + " select 'workflow' as type, id from workflow where sourcecontrol = :one and organization = :two and repository = :three and workflowname IS NULL"),

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -80,6 +80,9 @@ import org.hibernate.annotations.UpdateTimestamp;
     @NamedNativeQuery(name = "Entry.getEntryByPath", query =
         "SELECT 'tool' as type, id from tool where registry = :one and namespace = :two and name = :three and toolname = :four union"
             + " select 'workflow' as type, id from workflow where sourcecontrol = :one and organization = :two and repository = :three and workflowname = :four"),
+        @NamedNativeQuery(name = "Entry.getEntryById", query =
+        "SELECT 'tool' as type, id from tool where id = :id union"
+            + " select 'workflow' as type, id from workflow where id = :id"),
     @NamedNativeQuery(name = "Entry.getEntryByPathNullName", query =
         "SELECT 'tool' as type, id from tool where registry = :one and namespace = :two and name = :three and toolname IS NULL union"
             + " select 'workflow' as type, id from workflow where sourcecontrol = :one and organization = :two and repository = :three and workflowname IS NULL"),

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
@@ -27,7 +27,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 @ApiModel(value = "Event", description = "This describes events that occur on the Dockstore site.")
 @Entity
 @Table(name = "event")
-@SuppressWarnings("checkstyle:magicnumber")
+@SuppressWarnings({"checkstyle:magicnumber", "checkstyle:hiddenfield"})
 public class Event {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -78,6 +78,7 @@ public class Event {
     @UpdateTimestamp
     private Timestamp dbUpdateDate;
 
+    public Event() { }
     public Event(User user, Organisation organisation, Collection collection, Workflow workflow, Tool tool, User initiatorUser, EventType type) {
         this.user = user;
         this.organisation = organisation;
@@ -182,5 +183,65 @@ public class Event {
         MODIFY_COLLECTION,
         REMOVE_FROM_COLLECTION,
         ADD_TO_COLLECTION
+    }
+
+    public static class Builder {
+        private User user;
+        private Organisation organisation;
+        private Tool tool;
+        private Workflow workflow;
+        private Collection collection;
+        private User initiatorUser;
+        private EventType type;
+
+        public Builder() { }
+
+        public Builder withUser(User user) {
+            this.user = user;
+            return this;
+        }
+
+        public Builder withOrganisation(Organisation organisation) {
+            this.organisation = organisation;
+            return this;
+        }
+
+        public Builder withTool(Tool tool) {
+            this.tool = tool;
+            return this;
+        }
+
+        public Builder withWorkflow(Workflow workflow) {
+            this.workflow = workflow;
+            return this;
+        }
+
+        public Builder withCollection(Collection collection) {
+            this.collection = collection;
+            return this;
+        }
+
+        public Builder withInitiatorUser(User initiatorUser) {
+            this.initiatorUser = initiatorUser;
+            return this;
+        }
+
+        public Builder withType(EventType type) {
+            this.type = type;
+            return this;
+        }
+
+        public Event build() {
+            Event event = new Event();
+            event.user = this.user;
+            event.organisation = this.organisation;
+            event.tool = this.tool;
+            event.workflow = this.workflow;
+            event.collection = this.collection;
+            event.initiatorUser = this.initiatorUser;
+            event.type = this.type;
+
+            return event;
+        }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
@@ -128,6 +128,14 @@ public class Event {
         this.workflow = workflow;
     }
 
+    public Collection getCollection() {
+        return collection;
+    }
+
+    public void setCollection(Collection collection) {
+        this.collection = collection;
+    }
+
     public User getInitiatorUser() {
         return initiatorUser;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
@@ -55,13 +55,18 @@ public class Event {
     private Workflow workflow;
 
     @ManyToOne
+    @JoinColumn(name = "collectionId", referencedColumnName = "id")
+    @ApiModelProperty(value = "Collection that the event is acting on.", position = 5)
+    private Collection collection;
+
+    @ManyToOne
     @JoinColumn(name = "initiatorUserId", referencedColumnName = "id")
-    @ApiModelProperty(value = "User initiating the event.", position = 5)
+    @ApiModelProperty(value = "User initiating the event.", position = 6)
     private User initiatorUser;
 
     @Column
     @Enumerated(EnumType.STRING)
-    @ApiModelProperty(value = "The event type.", required = true, position = 6)
+    @ApiModelProperty(value = "The event type.", required = true, position = 7)
     private EventType type;
 
     // database timestamps
@@ -73,9 +78,10 @@ public class Event {
     @UpdateTimestamp
     private Timestamp dbUpdateDate;
 
-    public Event(User user, Organisation organisation, Workflow workflow, Tool tool, User initiatorUser, EventType type) {
+    public Event(User user, Organisation organisation, Collection collection, Workflow workflow, Tool tool, User initiatorUser, EventType type) {
         this.user = user;
         this.organisation = organisation;
+        this.collection = collection;
         this.workflow = workflow;
         this.tool = tool;
         this.initiatorUser = initiatorUser;
@@ -163,6 +169,8 @@ public class Event {
         REMOVE_USER_FROM_ORG,
         MODIFY_USER_ROLE_ORG,
         APPROVE_ORG_INVITE,
-        REJECT_ORG_INVITE
+        REJECT_ORG_INVITE,
+        CREATE_COLLECTION,
+        MODIFY_COLLECTION
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
@@ -171,6 +171,8 @@ public class Event {
         APPROVE_ORG_INVITE,
         REJECT_ORG_INVITE,
         CREATE_COLLECTION,
-        MODIFY_COLLECTION
+        MODIFY_COLLECTION,
+        REMOVE_FROM_COLLECTION,
+        ADD_TO_COLLECTION
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Organisation.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Organisation.java
@@ -49,7 +49,7 @@ public class Organisation implements Serializable {
     @Column(nullable = false, unique = true)
     @Pattern(regexp = "\\d*[a-zA-Z][a-zA-Z\\d]*")
     @Size(min = 3, max = 39)
-    @ApiModelProperty(value = "Name of the organisation (ex. OICR).", required = true, position = 1)
+    @ApiModelProperty(value = "Name of the organisation (ex. OICR).", required = true, example = "OICR", position = 1)
     private String name;
 
     @Column(columnDefinition = "TEXT")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Organisation.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Organisation.java
@@ -78,6 +78,10 @@ public class Organisation implements Serializable {
     @JsonIgnore
     private Set<OrganisationUser> users = new HashSet<>();
 
+    @JsonIgnore
+    @OneToMany(mappedBy = "organisation")
+    private Set<Collection> collections = new HashSet<>();
+
     @Column(updatable = false)
     @CreationTimestamp
     private Timestamp dbCreateDate;
@@ -164,5 +168,23 @@ public class Organisation implements Serializable {
 
     public void setUsers(Set<OrganisationUser> users) {
         this.users = users;
+    }
+
+    public Set<Collection> getCollections() {
+        return collections;
+    }
+
+    public void setCollections(Set<Collection> collections) {
+        this.collections = collections;
+    }
+
+    public void addCollection(Collection collection) {
+        collections.add(collection);
+        collection.setOrganisation(this);
+    }
+
+    public void removeCollection(Collection collection) {
+        collections.remove(collection);
+        collection.setOrganisation(null);
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/CollectionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/CollectionDAO.java
@@ -1,0 +1,45 @@
+package io.dockstore.webservice.jdbi;
+
+import io.dockstore.webservice.core.Collection;
+import io.dropwizard.hibernate.AbstractDAO;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.query.Query;
+
+public class CollectionDAO extends AbstractDAO<Collection> {
+    public CollectionDAO(SessionFactory factory) {
+        super(factory);
+    }
+
+    public Collection findById(Long id) {
+        return get(id);
+    }
+
+    public long create(Collection collection) {
+        return persist(collection).getId();
+    }
+
+    public long update(Collection collection) {
+        return persist(collection).getId();
+    }
+
+    public void delete(Collection collection) {
+        Session session = currentSession();
+        session.delete(collection);
+        session.flush();
+    }
+
+    public Collection findAllByOrg(String name, long organisationId) {
+        Query query = namedQuery("io.dockstore.webservice.core.Collection.findAllByOrg")
+                .setParameter("organisationId", organisationId);
+        return uniqueResult(query);
+    }
+
+    public Collection findByNameAndOrg(String name, long organisationId) {
+        Query query = namedQuery("io.dockstore.webservice.core.Collection.findByNameAndOrg")
+                .setParameter("name", name)
+                .setParameter("organisationId", organisationId);
+        return uniqueResult(query);
+    }
+
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/CollectionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/CollectionDAO.java
@@ -1,5 +1,7 @@
 package io.dockstore.webservice.jdbi;
 
+import java.util.List;
+
 import io.dockstore.webservice.core.Collection;
 import io.dropwizard.hibernate.AbstractDAO;
 import org.hibernate.Session;
@@ -29,10 +31,10 @@ public class CollectionDAO extends AbstractDAO<Collection> {
         session.flush();
     }
 
-    public Collection findAllByOrg(String name, long organisationId) {
+    public List<Collection> findAllByOrg(long organisationId) {
         Query query = namedQuery("io.dockstore.webservice.core.Collection.findAllByOrg")
                 .setParameter("organisationId", organisationId);
-        return uniqueResult(query);
+        return list(query);
     }
 
     public Collection findByNameAndOrg(String name, long organisationId) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -71,26 +71,6 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
         return get(id);
     }
 
-    public Entry findEntryById(Long id) {
-        String queryString = "Entry.getEntryById";
-        Query query = super.namedQuery(queryString);
-
-        query.setParameter("id", id);
-        List<Object[]> pair = list(query);
-        MutablePair<String, Entry> results = null;
-        if (pair.size() > 0) {
-            String type = (String)(pair.get(0))[0];
-            BigInteger entryId = (BigInteger)(pair.get(0))[1];
-            Long longId = entryId.longValue();
-            if ("workflow".equals(type)) {
-                results = new MutablePair<>("workflow", this.currentSession().get(Workflow.class, Objects.requireNonNull(longId)));
-            } else {
-                results = new MutablePair<>("tool", this.currentSession().get(Tool.class, Objects.requireNonNull(longId)));
-            }
-        }
-        return results.getRight();
-    }
-
     public MutablePair<String, Entry> findEntryByPath(String path, boolean isPublished) {
         String queryString = "Entry.";
         if (isPublished) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -71,6 +71,26 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
         return get(id);
     }
 
+    public Entry findEntryById(Long id) {
+        String queryString = "Entry.getEntryById";
+        Query query = super.namedQuery(queryString);
+
+        query.setParameter("id", id);
+        List<Object[]> pair = list(query);
+        MutablePair<String, Entry> results = null;
+        if (pair.size() > 0) {
+            String type = (String)(pair.get(0))[0];
+            BigInteger entryId = (BigInteger)(pair.get(0))[1];
+            Long longId = entryId.longValue();
+            if ("workflow".equals(type)) {
+                results = new MutablePair<>("workflow", this.currentSession().get(Workflow.class, Objects.requireNonNull(longId)));
+            } else {
+                results = new MutablePair<>("tool", this.currentSession().get(Tool.class, Objects.requireNonNull(longId)));
+            }
+        }
+        return results.getRight();
+    }
+
     public MutablePair<String, Entry> findEntryByPath(String path, boolean isPublished) {
         String queryString = "Entry.";
         if (isPublished) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
@@ -129,12 +129,20 @@ public class CollectionResource implements AuthenticatedResourceInterface {
 
         // Event for addition
         Organisation organisation = organisationDAO.findById(organisationId);
-        Event addToCollectionEvent;
+
+        Event.Builder eventBuild = new Event.Builder()
+                .withOrganisation(organisation)
+                .withCollection(entryAndCollection.getRight())
+                .withInitiatorUser(user)
+                .withType(Event.EventType.ADD_TO_COLLECTION);
+
         if (entryAndCollection.getLeft() instanceof Workflow) {
-            addToCollectionEvent = new Event(null, organisation, entryAndCollection.getRight(), (Workflow)entryAndCollection.getLeft(), null, user, Event.EventType.ADD_TO_COLLECTION);
+            eventBuild = eventBuild.withWorkflow((Workflow)entryAndCollection.getLeft());
         } else {
-            addToCollectionEvent = new Event(null, organisation, entryAndCollection.getRight(), null, (Tool)entryAndCollection.getLeft(), user, Event.EventType.ADD_TO_COLLECTION);
+            eventBuild = eventBuild.withTool((Tool)entryAndCollection.getLeft());
         }
+
+        Event addToCollectionEvent = eventBuild.build();
         eventDAO.create(addToCollectionEvent);
 
         return collectionDAO.findById(collectionId);
@@ -157,12 +165,20 @@ public class CollectionResource implements AuthenticatedResourceInterface {
 
         // Event for deletion
         Organisation organisation = organisationDAO.findById(organisationId);
-        Event removeFromCollectionEvent;
+
+        Event.Builder eventBuild = new Event.Builder()
+                .withOrganisation(organisation)
+                .withCollection(entryAndCollection.getRight())
+                .withInitiatorUser(user)
+                .withType(Event.EventType.REMOVE_FROM_COLLECTION);
+
         if (entryAndCollection.getLeft() instanceof Workflow) {
-            removeFromCollectionEvent = new Event(null, organisation, entryAndCollection.getRight(), (Workflow)entryAndCollection.getLeft(), null, user, Event.EventType.REMOVE_FROM_COLLECTION);
+            eventBuild = eventBuild.withWorkflow((Workflow)entryAndCollection.getLeft());
         } else {
-            removeFromCollectionEvent = new Event(null, organisation, entryAndCollection.getRight(), null, (Tool)entryAndCollection.getLeft(), user, Event.EventType.REMOVE_FROM_COLLECTION);
+            eventBuild = eventBuild.withTool((Tool)entryAndCollection.getLeft());
         }
+
+        Event removeFromCollectionEvent = eventBuild.build();
         eventDAO.create(removeFromCollectionEvent);
 
         return collectionDAO.findById(collectionId);
@@ -272,7 +288,12 @@ public class CollectionResource implements AuthenticatedResourceInterface {
 
         // Event for creation
         User foundUser = userDAO.findById(user.getId());
-        Event createCollectionEvent = new Event(null, organisation, collection, null, null, foundUser, Event.EventType.CREATE_COLLECTION);
+        Event createCollectionEvent = new Event.Builder()
+                .withOrganisation(organisation)
+                .withCollection(collection)
+                .withInitiatorUser(foundUser)
+                .withType(Event.EventType.CREATE_COLLECTION)
+                .build();
         eventDAO.create(createCollectionEvent);
 
         return collectionDAO.findById(id);
@@ -321,7 +342,12 @@ public class CollectionResource implements AuthenticatedResourceInterface {
         existingCollection.setDescription(collection.getDescription());
 
         // Event for update
-        Event updateCollectionEvent = new Event(null, organisation, collection, null, null, user, Event.EventType.MODIFY_COLLECTION);
+        Event updateCollectionEvent = new Event.Builder()
+                .withOrganisation(organisation)
+                .withCollection(collection)
+                .withInitiatorUser(user)
+                .withType(Event.EventType.MODIFY_COLLECTION)
+                .build();
         eventDAO.create(updateCollectionEvent);
 
         return collectionDAO.findById(collectionId);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
@@ -1,0 +1,196 @@
+package io.dockstore.webservice.resources;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.codahale.metrics.annotation.Timed;
+import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.Collection;
+import io.dockstore.webservice.core.Event;
+import io.dockstore.webservice.core.Organisation;
+import io.dockstore.webservice.core.OrganisationUser;
+import io.dockstore.webservice.core.User;
+import io.dockstore.webservice.jdbi.CollectionDAO;
+import io.dockstore.webservice.jdbi.EventDAO;
+import io.dockstore.webservice.jdbi.OrganisationDAO;
+import io.dockstore.webservice.jdbi.UserDAO;
+import io.dropwizard.auth.Auth;
+import io.dropwizard.hibernate.UnitOfWork;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.Authorization;
+import org.apache.http.HttpStatus;
+import org.hibernate.SessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
+
+/**
+ * Collection of collection endpoints
+ * @author aduncan
+ */
+@Path("/collections")
+@Api("/collections")
+@Produces(MediaType.APPLICATION_JSON)
+public class CollectionResource implements AuthenticatedResourceInterface {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OrganisationResource.class);
+
+    private static final String OPTIONAL_AUTH_MESSAGE = "Does not require authentication for approved organisations, authentication can be provided for unapproved organisations";
+
+    private final CollectionDAO collectionDAO;
+    private final OrganisationDAO organisationDAO;
+    private final UserDAO userDAO;
+    private final EventDAO eventDAO;
+    private final SessionFactory sessionFactory;
+
+    public CollectionResource(SessionFactory sessionFactory) {
+        this.collectionDAO = new CollectionDAO(sessionFactory);
+        this.organisationDAO = new OrganisationDAO(sessionFactory);
+        this.userDAO = new UserDAO(sessionFactory);
+        this.eventDAO = new EventDAO(sessionFactory);
+        this.sessionFactory = sessionFactory;
+    }
+
+    @GET
+    @Timed
+    @UnitOfWork
+    @Path("/{collectionId}")
+    @ApiOperation(value = "Retrieves a collection by ID.", notes = OPTIONAL_AUTH_MESSAGE, authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Collection.class)
+    public Collection getCollectionById(@ApiParam(hidden = true) @Auth Optional<User> user,
+            @ApiParam(value = "Collection ID.", required = true) @PathParam("collectionId") Long id) {
+
+        if (!user.isPresent()) {
+            // No user given, only show collections from approved organisations
+            Collection collection = collectionDAO.findById(id);
+            if (collection == null) {
+                String msg = "Collection not found.";
+                LOG.info(msg);
+                throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            }
+            Organisation organisation = organisationDAO.findApprovedById(collection.getOrganisation().getId());
+            if (organisation == null) {
+                String msg = "Collection not found.";
+                LOG.info(msg);
+                throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            }
+
+            return collection;
+        } else {
+            // User is given, check if the collections organisation is either approved or the user has access
+            // Admins and curators should be able to see collections from unapproved organisations
+            boolean doesCollectionExist = doesCollectionExistToUser(id, user.get().getId()) || user.get().getIsAdmin() || user.get().isCurator();
+            if (!doesCollectionExist) {
+                String msg = "Collection not found.";
+                LOG.info(msg);
+                throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            }
+
+            Collection collection = collectionDAO.findById(id);
+            return collection;
+        }
+    }
+
+    @PUT
+    @Timed
+    @UnitOfWork
+    @Path("/create/{organisationId}")
+    @ApiOperation(value = "Create a collection in the given organisation.", authorizations = {
+            @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Collection.class)
+    public Collection createCollection(@ApiParam(hidden = true) @Auth User user,
+            @ApiParam(value = "Organisation ID.", required = true) @PathParam("organisationId") Long organisationId,
+            @ApiParam(value = "Collection to register.", required = true) Collection collection) {
+
+        // First check if the organisation exists
+        boolean doesOrgExist = doesOrganisationExistToUser(organisationId, user.getId());
+        if (!doesOrgExist) {
+            String msg = "Organisation not found.";
+            LOG.info(msg);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+        }
+
+        // Check if any other collections in the organisation exist with that name
+        Collection matchingCollection = collectionDAO.findByNameAndOrg(collection.getName(), organisationId);
+        if (matchingCollection != null) {
+            String msg = "A collection already exists with the name '" + collection.getName() + "' in the specified organisation.";
+            LOG.info(msg);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+        }
+
+        // Get the organisation
+        Organisation organisation = organisationDAO.findById(organisationId);
+
+        // Save the collection
+        long id = collectionDAO.create(collection);
+        organisation.addCollection(collection);
+
+        // Event for creation
+        User foundUser = userDAO.findById(user.getId());
+        Event createCollectionEvent = new Event(null, organisation, collection, null, null, foundUser, Event.EventType.CREATE_COLLECTION);
+        eventDAO.create(createCollectionEvent);
+
+        return collectionDAO.findById(id);
+    }
+
+    /**
+     * For a collection to exist to a user, it must either be from an approved organisation
+     * or an organisation the user has access to.
+     * @param collectionId
+     * @param userId
+     * @return True if collection exists to user, false otherwise
+     */
+    private boolean doesCollectionExistToUser(Long collectionId, Long userId) {
+        // A collection is only visible to a user if the organisation it belongs to is approved or they are a member
+        Collection collection = collectionDAO.findById(collectionId);
+        if (collection == null) {
+            String msg = "Collection not found.";
+            LOG.info(msg);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+        }
+
+        return doesOrganisationExistToUser(collection.getOrganisation().getId(), userId);
+    }
+
+    /**
+     * Checks if the given user should know of the existence of the organisation
+     * For a user to see an organsation, either it must be approved or the user must have a role in the organisation
+     * @param organisationId
+     * @param userId
+     * @return True if organisation exists to user, false otherwise
+     */
+    private boolean doesOrganisationExistToUser(Long organisationId, Long userId) {
+        Organisation organisation = organisationDAO.findById(organisationId);
+        if (organisation == null) {
+            return false;
+        }
+        OrganisationUser organisationUser = getUserOrgRole(organisation, userId);
+        return organisation.isApproved() || (organisationUser != null);
+    }
+
+    /**
+     * Determine the role of a user in an organisation
+     * @param organisation
+     * @param userId
+     * @return OrganisationUser role
+     */
+    private OrganisationUser getUserOrgRole(Organisation organisation, Long userId) {
+        Set<OrganisationUser> organisationUserSet = organisation.getUsers();
+        Optional<OrganisationUser> matchingUser = organisationUserSet.stream().filter(organisationUser -> Objects
+                .equals(organisationUser.getUser().getId(), userId)).findFirst();
+        if (matchingUser.isPresent()) {
+            return matchingUser.get();
+        } else {
+            return null;
+        }
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
@@ -284,7 +284,7 @@ public class CollectionResource implements AuthenticatedResourceInterface {
     @Path("{organisationId}/collections/{collectionId}")
     @ApiOperation(value = "Update a collection.", notes = "Currently only name and description can be updated.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Collection.class)
     public Collection updateCollection(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Collection to register.", required = true) Collection collection,
+            @ApiParam(value = "Collection to update with.", required = true) Collection collection,
             @ApiParam(value = "Organisation ID.", required = true) @PathParam("organisationId") Long organisationId,
             @ApiParam(value = "Collection ID.", required = true) @PathParam("collectionId") Long collectionId) {
         // Ensure collection exists to the user

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
@@ -22,8 +22,10 @@ import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.Event;
 import io.dockstore.webservice.core.Organisation;
 import io.dockstore.webservice.core.OrganisationUser;
+import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Version;
+import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.jdbi.CollectionDAO;
 import io.dockstore.webservice.jdbi.EventDAO;
 import io.dockstore.webservice.jdbi.OrganisationDAO;
@@ -125,6 +127,16 @@ public class CollectionResource implements AuthenticatedResourceInterface {
         // Add the entry to the organisation
         entryAndCollection.getRight().addEntry(entryAndCollection.getLeft());
 
+        // Event for addition
+        Organisation organisation = organisationDAO.findById(organisationId);
+        Event addToCollectionEvent;
+        if (entryAndCollection.getLeft() instanceof Workflow) {
+            addToCollectionEvent = new Event(null, organisation, entryAndCollection.getRight(), (Workflow)entryAndCollection.getLeft(), null, user, Event.EventType.ADD_TO_COLLECTION);
+        } else {
+            addToCollectionEvent = new Event(null, organisation, entryAndCollection.getRight(), null, (Tool)entryAndCollection.getLeft(), user, Event.EventType.ADD_TO_COLLECTION);
+        }
+        eventDAO.create(addToCollectionEvent);
+
         return collectionDAO.findById(collectionId);
     }
 
@@ -142,6 +154,16 @@ public class CollectionResource implements AuthenticatedResourceInterface {
 
         // Remove the entry from the organisation
         entryAndCollection.getRight().removeEntry(entryAndCollection.getLeft());
+
+        // Event for deletion
+        Organisation organisation = organisationDAO.findById(organisationId);
+        Event removeFromCollectionEvent;
+        if (entryAndCollection.getLeft() instanceof Workflow) {
+            removeFromCollectionEvent = new Event(null, organisation, entryAndCollection.getRight(), (Workflow)entryAndCollection.getLeft(), null, user, Event.EventType.REMOVE_FROM_COLLECTION);
+        } else {
+            removeFromCollectionEvent = new Event(null, organisation, entryAndCollection.getRight(), null, (Tool)entryAndCollection.getLeft(), user, Event.EventType.REMOVE_FROM_COLLECTION);
+        }
+        eventDAO.create(removeFromCollectionEvent);
 
         return collectionDAO.findById(collectionId);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
@@ -87,13 +87,13 @@ public class CollectionResource implements AuthenticatedResourceInterface {
             if (collection == null) {
                 String msg = "Collection not found.";
                 LOG.info(msg);
-                throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+                throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
             }
             Organisation organisation = organisationDAO.findApprovedById(collection.getOrganisation().getId());
             if (organisation == null) {
                 String msg = "Collection not found.";
                 LOG.info(msg);
-                throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+                throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
             }
 
             return collection;
@@ -104,7 +104,7 @@ public class CollectionResource implements AuthenticatedResourceInterface {
             if (!doesCollectionExist) {
                 String msg = "Collection not found.";
                 LOG.info(msg);
-                throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+                throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
             }
 
             Collection collection = collectionDAO.findById(collectionId);
@@ -124,7 +124,7 @@ public class CollectionResource implements AuthenticatedResourceInterface {
         // Call common code to check if entry and collection exist and return them
         ImmutablePair<Entry, Collection> entryAndCollection = commonModifyCollection(entryId, collectionId, user);
 
-        // Add the entry to the organisation
+        // Add the entry to the collection
         entryAndCollection.getRight().addEntry(entryAndCollection.getLeft());
 
         // Event for addition
@@ -173,7 +173,7 @@ public class CollectionResource implements AuthenticatedResourceInterface {
      * visible to the user and that the user has the correct credentials to edit the collection.
      * @param entryId
      * @param collectionId
-     * @param user
+     * @param user User performing the action
      * @return Pair of found Entry and Collection
      */
     private ImmutablePair<Entry, Collection> commonModifyCollection(Long entryId, Long collectionId, User user) {
@@ -183,14 +183,14 @@ public class CollectionResource implements AuthenticatedResourceInterface {
         if (entry == null || !entry.getIsPublished()) {
             String msg = "Entry not found.";
             LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
         }
         // Check that collection exists to user
         boolean doesCollectionExist = doesCollectionExistToUser(collectionId, user.getId()) || user.getIsAdmin() || user.isCurator();
         if (!doesCollectionExist) {
             String msg = "Collection not found.";
             LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
         }
 
         Collection collection = collectionDAO.findById(collectionId);
@@ -202,7 +202,7 @@ public class CollectionResource implements AuthenticatedResourceInterface {
         if (organisationUser == null) {
             String msg = "User does not have rights to modify a collection from this organisation.";
             LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_UNAUTHORIZED);
         }
 
         return new ImmutablePair<>(entry, collection);
@@ -221,7 +221,7 @@ public class CollectionResource implements AuthenticatedResourceInterface {
             if (organisation == null) {
                 String msg = "Organisation not found";
                 LOG.info(msg);
-                throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+                throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
             }
 
             return collectionDAO.findAllByOrg(organisationId);
@@ -230,7 +230,7 @@ public class CollectionResource implements AuthenticatedResourceInterface {
             if (!doesOrgExist) {
                 String msg = "Organisation not found.";
                 LOG.info(msg);
-                throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+                throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
             }
 
             return collectionDAO.findAllByOrg(organisationId);
@@ -252,7 +252,7 @@ public class CollectionResource implements AuthenticatedResourceInterface {
         if (!doesOrgExist) {
             String msg = "Organisation not found.";
             LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
         }
 
         // Check if any other collections in the organisation exist with that name
@@ -292,7 +292,7 @@ public class CollectionResource implements AuthenticatedResourceInterface {
         if (!doesCollectionExist) {
             String msg = "Collection not found.";
             LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
         }
 
         Collection existingCollection = collectionDAO.findById(collectionId);
@@ -303,7 +303,7 @@ public class CollectionResource implements AuthenticatedResourceInterface {
         if (organisationUser == null) {
             String msg = "User does not have rights to modify a collection from this organisation.";
             LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_UNAUTHORIZED);
         }
 
         // Check if new name is valid
@@ -341,7 +341,7 @@ public class CollectionResource implements AuthenticatedResourceInterface {
         if (collection == null) {
             String msg = "Collection not found.";
             LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
         }
 
         return doesOrganisationExistToUser(collection.getOrganisation().getId(), userId);
@@ -373,10 +373,6 @@ public class CollectionResource implements AuthenticatedResourceInterface {
         Set<OrganisationUser> organisationUserSet = organisation.getUsers();
         Optional<OrganisationUser> matchingUser = organisationUserSet.stream().filter(organisationUser -> Objects
                 .equals(organisationUser.getUser().getId(), userId)).findFirst();
-        if (matchingUser.isPresent()) {
-            return matchingUser.get();
-        } else {
-            return null;
-        }
+        return matchingUser.orElse(null);
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganisationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganisationResource.java
@@ -89,8 +89,12 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
         }
         organisation.setApproved(true);
 
-        Event createOrganisationEvent = new Event(null, organisation, null, null, null, user, Event.EventType.APPROVE_ORG);
-        eventDAO.create(createOrganisationEvent);
+        Event approveOrgEvent = new Event.Builder()
+                .withOrganisation(organisation)
+                .withInitiatorUser(user)
+                .withType(Event.EventType.APPROVE_ORG)
+                .build();
+        eventDAO.create(approveOrgEvent);
 
         return organisationDAO.findById(id);
     }
@@ -171,7 +175,11 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
         Session currentSession = sessionFactory.getCurrentSession();
         currentSession.persist(organisationUser);
 
-        Event createOrganisationEvent = new Event(null, organisation, null, null, null, foundUser, Event.EventType.CREATE_ORG);
+        Event createOrganisationEvent = new Event.Builder()
+                .withOrganisation(organisation)
+                .withInitiatorUser(foundUser)
+                .withType(Event.EventType.CREATE_ORG)
+                .build();
         eventDAO.create(createOrganisationEvent);
 
         return organisationDAO.findById(id);
@@ -220,7 +228,11 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
         oldOrganisation.setLink(organisation.getLink());
         oldOrganisation.setLocation(organisation.getLocation());
 
-        Event updateOrganisationEvent = new Event(null, oldOrganisation, null, null, null, user, Event.EventType.MODIFY_ORG);
+        Event updateOrganisationEvent = new Event.Builder()
+                .withOrganisation(oldOrganisation)
+                .withInitiatorUser(user)
+                .withType(Event.EventType.MODIFY_ORG)
+                .build();
         eventDAO.create(updateOrganisationEvent);
 
         return organisationDAO.findById(id);
@@ -253,7 +265,12 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
             throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
         }
 
-        Event addUserOrganisationEvent = new Event(organisationAndUserToAdd.getRight(), organisationAndUserToAdd.getLeft(), null, null, null, user, Event.EventType.ADD_USER_TO_ORG);
+        Event addUserOrganisationEvent = new Event.Builder()
+                .withUser(organisationAndUserToAdd.getRight())
+                .withOrganisation(organisationAndUserToAdd.getLeft())
+                .withInitiatorUser(user)
+                .withType(Event.EventType.ADD_USER_TO_ORG)
+                .build();
         eventDAO.create(addUserOrganisationEvent);
 
         return organisationUser;
@@ -282,7 +299,13 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
             existingRole.setRole(OrganisationUser.Role.valueOf(role));
         }
 
-        Event updateUserOrganisationEvent = new Event(organisationAndUserToUpdate.getRight(), organisationAndUserToUpdate.getLeft(), null, null, null, user, Event.EventType.MODIFY_USER_ROLE_ORG);
+        Event updateUserOrganisationEvent = new Event.Builder()
+                .withUser(organisationAndUserToUpdate.getRight())
+                .withOrganisation(organisationAndUserToUpdate.getLeft())
+                .withInitiatorUser(user)
+                .withType(Event.EventType.MODIFY_USER_ROLE_ORG)
+                .build();
+
         eventDAO.create(updateUserOrganisationEvent);
 
         return existingRole;
@@ -311,7 +334,12 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
             currentSession.delete(existingRole);
         }
 
-        Event deleteUserOrganisationEvent = new Event(organisationAndUserToDelete.getRight(), organisationAndUserToDelete.getLeft(), null, null, null, user, Event.EventType.REMOVE_USER_FROM_ORG);
+        Event deleteUserOrganisationEvent = new Event.Builder()
+                .withUser(organisationAndUserToDelete.getRight())
+                .withOrganisation(organisationAndUserToDelete.getLeft())
+                .withInitiatorUser(user)
+                .withType(Event.EventType.REMOVE_USER_FROM_ORG)
+                .build();
         eventDAO.create(deleteUserOrganisationEvent);
     }
 
@@ -359,7 +387,11 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
         }
 
         Event.EventType eventType = accept ? Event.EventType.APPROVE_ORG_INVITE : Event.EventType.REJECT_ORG_INVITE;
-        Event addUserOrganisationEvent = new Event(null, organisation, null, null, null, user, eventType);
+        Event addUserOrganisationEvent = new Event.Builder()
+                .withOrganisation(organisation)
+                .withInitiatorUser(user)
+                .withType(eventType)
+                .build();
         eventDAO.create(addUserOrganisationEvent);
 
         return user;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganisationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganisationResource.java
@@ -87,14 +87,17 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
             LOG.info(msg);
             throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
         }
-        organisation.setApproved(true);
 
-        Event approveOrgEvent = new Event.Builder()
-                .withOrganisation(organisation)
-                .withInitiatorUser(user)
-                .withType(Event.EventType.APPROVE_ORG)
-                .build();
-        eventDAO.create(approveOrgEvent);
+        if (!organisation.isApproved()) {
+            organisation.setApproved(true);
+
+            Event approveOrgEvent = new Event.Builder()
+                    .withOrganisation(organisation)
+                    .withInitiatorUser(user)
+                    .withType(Event.EventType.APPROVE_ORG)
+                    .build();
+            eventDAO.create(approveOrgEvent);
+        }
 
         return organisationDAO.findById(id);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganisationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganisationResource.java
@@ -183,7 +183,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
     @Path("{organisationId}")
     @ApiOperation(value = "Update an organisation.", notes = "Currently only name, description, email, link and location can be updated.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Organisation.class)
     public Organisation updateOrganisation(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Organisation to register.", required = true) Organisation organisation,
+            @ApiParam(value = "Organisation to update with.", required = true) Organisation organisation,
             @ApiParam(value = "Organisation ID.", required = true) @PathParam("organisationId") Long id) {
 
         boolean doesOrgExist = doesOrganisationExistToUser(id, user.getId());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganisationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganisationResource.java
@@ -77,7 +77,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
     @Timed
     @UnitOfWork
     @RolesAllowed({ "curator", "admin" })
-    @Path("/approve/{organisationId}")
+    @Path("{organisationId}/approve/")
     @ApiOperation(value = "Approves an organisation.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Admin/curator only", response = Organisation.class)
     public Organisation approveOrganisation(@ApiParam(hidden = true) @Auth User user,
             @ApiParam(value = "Organisation ID.", required = true) @PathParam("organisationId") Long id) {
@@ -132,14 +132,20 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
     @Path("/all")
     @RolesAllowed({ "curator", "admin" })
     @ApiOperation(value = "List all organisations.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Admin/curator only", responseContainer = "List", response = Organisation.class)
-    public List<Organisation> getAllOrganisations() {
-        return organisationDAO.findAll();
+    public List<Organisation> getAllOrganisations(@ApiParam(value = "Filter to apply to organisations.", required = true, allowableValues = "all, unapproved, approved") @QueryParam("type") String type) {
+        switch (type) {
+        case "unapproved":
+            return organisationDAO.findAllUnapproved();
+        case "approved":
+            return organisationDAO.findAllApproved();
+        case "all": default:
+            return organisationDAO.findAll();
+        }
     }
 
     @PUT
     @Timed
     @UnitOfWork
-    @Path("/create")
     @ApiOperation(value = "Create an organisation.", notes = "Organisation requires approval by an admin before being made public.", authorizations = {
             @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Organisation.class)
     public Organisation createOrganisation(@ApiParam(hidden = true) @Auth User user,
@@ -174,7 +180,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
     @POST
     @Timed
     @UnitOfWork
-    @Path("/update/{organisationId}")
+    @Path("{organisationId}")
     @ApiOperation(value = "Update an organisation.", notes = "Currently only name, description, email, link and location can be updated.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Organisation.class)
     public Organisation updateOrganisation(@ApiParam(hidden = true) @Auth User user,
             @ApiParam(value = "Organisation to register.", required = true) Organisation organisation,
@@ -226,7 +232,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
     @Path("/{organisationId}/user")
     @ApiOperation(value = "Adds a user role to an organisation.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = OrganisationUser.class)
     public OrganisationUser addUserToOrg(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Role of user.", required = true, allowableValues = "ADMIN, MAINTAINER, MEMBER") @QueryParam("role") String role,
+            @ApiParam(value = "Role of user.", required = true, allowableValues = "MAINTAINER, MEMBER") @QueryParam("role") String role,
             @ApiParam(value = "User to add to org.", required = true) @QueryParam("userId") Long userId,
             @ApiParam(value = "Organisation ID.", required = true) @PathParam("organisationId") Long organisationId,
             @ApiParam(value = "This is here to appease Swagger. It requires PUT methods to have a body, even if it is empty. Please leave it empty.") String emptyBody) {
@@ -259,7 +265,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
     @Path("/{organisationId}/user")
     @ApiOperation(value = "Updates a user role in an organisation.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = OrganisationUser.class)
     public OrganisationUser updateUserRole(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Role of user.", required = true, allowableValues = "ADMIN, MAINTAINER, MEMBER") @QueryParam("role") String role,
+            @ApiParam(value = "Role of user.", required = true, allowableValues = "MAINTAINER, MEMBER") @QueryParam("role") String role,
             @ApiParam(value = "User to add to org.", required = true) @QueryParam("userId") Long userId,
             @ApiParam(value = "Organisation ID.", required = true) @PathParam("organisationId") Long organisationId) {
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganisationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganisationResource.java
@@ -85,7 +85,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
         if (organisation == null) {
             String msg = "Organisation not found";
             LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
         }
         organisation.setApproved(true);
 
@@ -108,7 +108,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
             if (organisation == null) {
                 String msg = "Organisation not found";
                 LOG.info(msg);
-                throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+                throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
             }
             return organisation;
         } else {
@@ -118,7 +118,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
             if (!doesOrgExist) {
                 String msg = "Organisation not found";
                 LOG.info(msg);
-                throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+                throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
             }
 
             Organisation organisation = organisationDAO.findById(id);
@@ -190,7 +190,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
         if (!doesOrgExist) {
             String msg = "Organisation not found";
             LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
         }
 
         Organisation oldOrganisation = organisationDAO.findById(id);
@@ -200,7 +200,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
         if (organisationUser == null) {
             String msg = "You do not have permissions to update the organisation.";
             LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_UNAUTHORIZED);
         }
 
         // Check if new name is valid
@@ -277,7 +277,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
         if (existingRole == null) {
             String msg = "The user with id '" + userId + "' does not have a role in the organisation with id '" + organisationId + "'.";
             LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_UNAUTHORIZED);
         } else {
             existingRole.setRole(OrganisationUser.Role.valueOf(role));
         }
@@ -305,7 +305,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
         if (existingRole == null) {
             String msg = "The user with id '" + userId + "' does not have a role in the organisation with id '" + organisationId + "'.";
             LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_UNAUTHORIZED);
         } else {
             Session currentSession = sessionFactory.getCurrentSession();
             currentSession.delete(existingRole);
@@ -329,7 +329,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
         if (!doesOrgExist) {
             String msg = "Organisation not found";
             LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
         }
 
         Organisation organisation = organisationDAO.findById(organisationId);
@@ -339,7 +339,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
         if (organisationUser == null) {
             String msg = "The user with id '" + user.getId() + "' does not have a role in the organisation with id '" + organisation.getId() + "'.";
             LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_UNAUTHORIZED);
         }
 
         // Check that the role is not already accepted
@@ -393,11 +393,11 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
         if (organisationUser == null) {
             String msg = "The user with id '" + userId + "' does not have a role in the organisation with id '" + organisation.getId() + "'.";
             LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_UNAUTHORIZED);
         } else if (!Objects.equals(organisationUser.getRole(), role)) {
             String msg = "The user with id '" + userId + "' does not have the required role in the organisation with id '" + organisation.getId() + "'.";
             LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_UNAUTHORIZED);
         } else {
             return organisationUser;
         }
@@ -432,7 +432,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
         if (!doesOrgExist) {
             String msg = "Organisation not found";
             LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
         }
 
         Organisation organisation = organisationDAO.findById(organisationId);
@@ -442,7 +442,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
         if (userToAdd == null) {
             String msg = "No user exists with the ID '" + userId + "'.";
             LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
         }
 
         // Check that you are not applying action on yourself

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganisationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganisationResource.java
@@ -89,7 +89,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
         }
         organisation.setApproved(true);
 
-        Event createOrganisationEvent = new Event(null, organisation, null, null, user, Event.EventType.APPROVE_ORG);
+        Event createOrganisationEvent = new Event(null, organisation, null, null, null, user, Event.EventType.APPROVE_ORG);
         eventDAO.create(createOrganisationEvent);
 
         return organisationDAO.findById(id);
@@ -165,7 +165,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
         Session currentSession = sessionFactory.getCurrentSession();
         currentSession.persist(organisationUser);
 
-        Event createOrganisationEvent = new Event(null, organisation, null, null, foundUser, Event.EventType.CREATE_ORG);
+        Event createOrganisationEvent = new Event(null, organisation, null, null, null, foundUser, Event.EventType.CREATE_ORG);
         eventDAO.create(createOrganisationEvent);
 
         return organisationDAO.findById(id);
@@ -214,7 +214,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
         oldOrganisation.setLink(organisation.getLink());
         oldOrganisation.setLocation(organisation.getLocation());
 
-        Event updateOrganisationEvent = new Event(null, oldOrganisation, null, null, user, Event.EventType.MODIFY_ORG);
+        Event updateOrganisationEvent = new Event(null, oldOrganisation, null, null, null, user, Event.EventType.MODIFY_ORG);
         eventDAO.create(updateOrganisationEvent);
 
         return organisationDAO.findById(id);
@@ -247,7 +247,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
             throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
         }
 
-        Event addUserOrganisationEvent = new Event(organisationAndUserToAdd.getRight(), organisationAndUserToAdd.getLeft(), null, null, user, Event.EventType.ADD_USER_TO_ORG);
+        Event addUserOrganisationEvent = new Event(organisationAndUserToAdd.getRight(), organisationAndUserToAdd.getLeft(), null, null, null, user, Event.EventType.ADD_USER_TO_ORG);
         eventDAO.create(addUserOrganisationEvent);
 
         return organisationUser;
@@ -276,7 +276,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
             existingRole.setRole(OrganisationUser.Role.valueOf(role));
         }
 
-        Event updateUserOrganisationEvent = new Event(organisationAndUserToUpdate.getRight(), organisationAndUserToUpdate.getLeft(), null, null, user, Event.EventType.MODIFY_USER_ROLE_ORG);
+        Event updateUserOrganisationEvent = new Event(organisationAndUserToUpdate.getRight(), organisationAndUserToUpdate.getLeft(), null, null, null, user, Event.EventType.MODIFY_USER_ROLE_ORG);
         eventDAO.create(updateUserOrganisationEvent);
 
         return existingRole;
@@ -305,7 +305,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
             currentSession.delete(existingRole);
         }
 
-        Event deleteUserOrganisationEvent = new Event(organisationAndUserToDelete.getRight(), organisationAndUserToDelete.getLeft(), null, null, user, Event.EventType.REMOVE_USER_FROM_ORG);
+        Event deleteUserOrganisationEvent = new Event(organisationAndUserToDelete.getRight(), organisationAndUserToDelete.getLeft(), null, null, null, user, Event.EventType.REMOVE_USER_FROM_ORG);
         eventDAO.create(deleteUserOrganisationEvent);
     }
 
@@ -353,7 +353,7 @@ public class OrganisationResource implements AuthenticatedResourceInterface {
         }
 
         Event.EventType eventType = accept ? Event.EventType.APPROVE_ORG_INVITE : Event.EventType.REJECT_ORG_INVITE;
-        Event addUserOrganisationEvent = new Event(null, organisation, null, null, user, eventType);
+        Event addUserOrganisationEvent = new Event(null, organisation, null, null, null, user, eventType);
         eventDAO.create(addUserOrganisationEvent);
 
         return user;

--- a/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
@@ -114,7 +114,7 @@
         <addForeignKeyConstraint baseColumnNames="workflowid" baseTableName="event" constraintName="FKWorkflowId" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="workflow"/>
     </changeSet>
 
-    <changeSet author="aduncan (generated)" id="1544737966182-3">
+    <changeSet author="aduncan (generated)" id="createCollectionTable">
         <createTable tableName="collection">
             <column autoIncrement="true" name="id" type="BIGSERIAL">
                 <constraints primaryKey="true" primaryKeyName="collection_pkey"/>
@@ -128,7 +128,7 @@
             <column name="organisationid" type="BIGINT"/>
         </createTable>
     </changeSet>
-    <changeSet author="aduncan (generated)" id="1544737966182-4">
+    <changeSet author="aduncan (generated)" id="createCollectionEntryTable">
         <createTable tableName="collection_entry">
             <column name="collectionid" type="BIGINT">
                 <constraints primaryKey="true" primaryKeyName="collection_entry_pkey"/>
@@ -138,14 +138,14 @@
             </column>
         </createTable>
     </changeSet>
-    <changeSet author="aduncan (generated)" id="1544737966182-5">
-        <addUniqueConstraint columnNames="name" constraintName="uk_y9tqsfhcsdnb3oqmc6dmb2i1" tableName="collection"/>
+    <changeSet author="aduncan (generated)" id="addCollectionNameConstraint">
+        <addUniqueConstraint columnNames="name" constraintName="uk_collectionName" tableName="collection"/>
     </changeSet>
-    <changeSet author="aduncan (generated)" id="1544737966182-7">
-        <addForeignKeyConstraint baseColumnNames="organisationid" baseTableName="collection" constraintName="fk7a33ojl6jbfa6n9os1xhof7xu" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="organisation"/>
+    <changeSet author="aduncan (generated)" id="addOrgIdFKConstraint">
+        <addForeignKeyConstraint baseColumnNames="organisationid" baseTableName="collection" constraintName="fk_orgIdInCollection" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="organisation"/>
     </changeSet>
-    <changeSet author="aduncan (generated)" id="1544737966182-8">
-        <addForeignKeyConstraint baseColumnNames="collectionid" baseTableName="collection_entry" constraintName="fkgeb6luwjr17p0q7w7qr01jheb" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="collection"/>
+    <changeSet author="aduncan (generated)" id="1addCollectionIdFKConstraint">
+        <addForeignKeyConstraint baseColumnNames="collectionid" baseTableName="collection_entry" constraintName="fk_collectionIdInCollectionEntry" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="collection"/>
     </changeSet>
 
     <changeSet author="aduncan (generated)" id="addCollectionColumnToEvent">
@@ -154,7 +154,7 @@
         </addColumn>
     </changeSet>
     <changeSet author="aduncan (generated)" id="addCollectionFKEvent">
-        <addForeignKeyConstraint baseColumnNames="collectionid" baseTableName="event" constraintName="fkom220e5fvyd8npyen20t581l6" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="collection"/>
+        <addForeignKeyConstraint baseColumnNames="collectionid" baseTableName="event" constraintName="fk_collectionIdInEvent" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="collection"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
@@ -114,4 +114,47 @@
         <addForeignKeyConstraint baseColumnNames="workflowid" baseTableName="event" constraintName="FKWorkflowId" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="workflow"/>
     </changeSet>
 
+    <changeSet author="aduncan (generated)" id="1544737966182-3">
+        <createTable tableName="collection">
+            <column autoIncrement="true" name="id" type="BIGSERIAL">
+                <constraints primaryKey="true" primaryKeyName="collection_pkey"/>
+            </column>
+            <column name="dbcreatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="dbupdatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="description" type="TEXT"/>
+            <column name="name" type="VARCHAR(39)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="organisationid" type="BIGINT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="aduncan (generated)" id="1544737966182-4">
+        <createTable tableName="collection_entry">
+            <column name="collectionid" type="BIGINT">
+                <constraints primaryKey="true" primaryKeyName="collection_entry_pkey"/>
+            </column>
+            <column name="entryid" type="BIGINT">
+                <constraints primaryKey="true" primaryKeyName="collection_entry_pkey"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="aduncan (generated)" id="1544737966182-5">
+        <addUniqueConstraint columnNames="name" constraintName="uk_y9tqsfhcsdnb3oqmc6dmb2i1" tableName="collection"/>
+    </changeSet>
+    <changeSet author="aduncan (generated)" id="1544737966182-7">
+        <addForeignKeyConstraint baseColumnNames="organisationid" baseTableName="collection" constraintName="fk7a33ojl6jbfa6n9os1xhof7xu" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="organisation"/>
+    </changeSet>
+    <changeSet author="aduncan (generated)" id="1544737966182-8">
+        <addForeignKeyConstraint baseColumnNames="collectionid" baseTableName="collection_entry" constraintName="fkgeb6luwjr17p0q7w7qr01jheb" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="collection"/>
+    </changeSet>
+
+    <changeSet author="aduncan (generated)" id="addCollectionColumnToEvent">
+        <addColumn tableName="event">
+            <column name="collectionid" type="int8"/>
+        </addColumn>
+    </changeSet>
+    <changeSet author="aduncan (generated)" id="addCollectionFKEvent">
+        <addForeignKeyConstraint baseColumnNames="collectionid" baseTableName="event" constraintName="fkom220e5fvyd8npyen20t581l6" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="collection"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -5614,7 +5614,8 @@ components:
           format: date-time
         name:
           type: string
-          description: Name of the collection (ex. OICR).
+          example: OICR
+          description: Name of the collection.
           minLength: 3
           maxLength: 39
           pattern: '\d*[a-zA-Z][a-zA-Z\d]*'

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -5614,7 +5614,7 @@ components:
           format: date-time
         name:
           type: string
-          example: OICR
+          example: Alignment
           description: Name of the collection.
           minLength: 3
           maxLength: 39
@@ -6067,6 +6067,7 @@ components:
           format: date-time
         name:
           type: string
+          example: OICR
           description: Name of the organisation (ex. OICR).
           minLength: 3
           maxLength: 39

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -29,6 +29,7 @@ tags:
       repositories. Implements TRS
       [1.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/1.0.0)
       and is considered final (not subject to change)
+  - name: collections
   - name: containers
     description: >-
       List and register entries in the dockstore (pairs of images + metadata
@@ -1472,6 +1473,63 @@ paths:
       responses:
         '400':
           description: Invalid token value
+      security:
+        - BEARER: []
+  '/collections/create/{organisationId}':
+    put:
+      tags:
+        - collections
+      summary: Create a collection in the given organisation.
+      description: ''
+      operationId: createCollection
+      parameters:
+        - name: organisationId
+          in: path
+          description: Organisation ID.
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+      security:
+        - BEARER: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Collection'
+        description: Collection to register.
+        required: true
+  '/collections/{collectionId}':
+    get:
+      tags:
+        - collections
+      summary: Retrieves a collection by ID.
+      description: >-
+        Does not require authentication for approved organisations,
+        authentication can be provided for unapproved organisations
+      operationId: getCollectionById
+      parameters:
+        - name: collectionId
+          in: path
+          description: Collection ID.
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
       security:
         - BEARER: []
   /containers/dockerRegistryList:
@@ -5384,6 +5442,30 @@ components:
       properties:
         content:
           type: string
+    Collection:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Implementation specific ID for the collection in this web service
+        dbCreateDate:
+          type: string
+          format: date-time
+        dbUpdateDate:
+          type: string
+          format: date-time
+        name:
+          type: string
+          description: Name of the collection (ex. OICR).
+          minLength: 3
+          maxLength: 39
+          pattern: '\d*[a-zA-Z][a-zA-Z\d]*'
+        description:
+          type: string
+          description: Description of the collection
     DescriptorLanguageBean:
       type: object
       properties:
@@ -5410,6 +5492,11 @@ components:
           type: integer
           format: int64
           description: Implementation specific ID for the container in this web service
+        collections:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/Collection'
         aliases:
           type: object
           description: aliases can be used as an alternate unique id for entries
@@ -5612,6 +5699,11 @@ components:
           type: integer
           format: int64
           description: Implementation specific ID for the container in this web service
+        collections:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/Collection'
         aliases:
           type: object
           description: aliases can be used as an alternate unique id for entries
@@ -6510,6 +6602,11 @@ components:
           type: integer
           format: int64
           description: Implementation specific ID for the container in this web service
+        collections:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/Collection'
         aliases:
           type: object
           description: aliases can be used as an alternate unique id for entries

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -1500,12 +1500,33 @@ paths:
       security:
         - BEARER: []
       requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Collection'
-        description: Collection to register.
-        required: true
+        $ref: '#/components/requestBodies/Collection'
+  '/collections/update/{collectionId}':
+    post:
+      tags:
+        - collections
+      summary: Update a collection.
+      description: Currently only name and description can be updated.
+      operationId: updateCollection
+      parameters:
+        - name: collectionId
+          in: path
+          description: Collection ID.
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+      security:
+        - BEARER: []
+      requestBody:
+        $ref: '#/components/requestBodies/Collection'
   '/collections/{collectionId}':
     get:
       tags:
@@ -5471,6 +5492,13 @@ components:
       description: >-
         Set of updated sourcefiles, add files by adding new files with unknown
         paths, delete files by including them with emptied content
+      required: true
+    Collection:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Collection'
+      description: Collection to register.
       required: true
     StarRequest:
       content:

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -2972,7 +2972,12 @@ paths:
       security:
         - BEARER: []
       requestBody:
-        $ref: '#/components/requestBodies/Organisation'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Organisation'
+        description: Organisation to register.
+        required: true
   /organisations/all:
     get:
       tags:
@@ -3054,7 +3059,12 @@ paths:
       security:
         - BEARER: []
       requestBody:
-        $ref: '#/components/requestBodies/Organisation'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Organisation'
+        description: Organisation to update with.
+        required: true
   '/organisations/{organisationId}/approve':
     post:
       tags:
@@ -5565,13 +5575,6 @@ components:
           schema:
             $ref: '#/components/schemas/VerifyRequest'
       description: Object containing verification information.
-      required: true
-    Organisation:
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Organisation'
-      description: Organisation to register.
       required: true
     Collection:
       content:

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -3141,7 +3141,12 @@ paths:
       security:
         - BEARER: []
       requestBody:
-        $ref: '#/components/requestBodies/Collection'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Collection'
+        description: Collection to register.
+        required: true
   '/organisations/{organisationId}/collections/{collectionId}':
     get:
       tags:
@@ -3206,7 +3211,12 @@ paths:
       security:
         - BEARER: []
       requestBody:
-        $ref: '#/components/requestBodies/Collection'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Collection'
+        description: Collection to update with.
+        required: true
   '/organisations/{organisationId}/collections/{collectionId}/entry':
     post:
       tags:
@@ -5575,13 +5585,6 @@ components:
           schema:
             $ref: '#/components/schemas/VerifyRequest'
       description: Object containing verification information.
-      required: true
-    Collection:
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Collection'
-      description: Collection to register.
       required: true
   securitySchemes:
     BEARER:

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -29,7 +29,6 @@ tags:
       repositories. Implements TRS
       [1.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/1.0.0)
       and is considered final (not subject to change)
-  - name: collections
   - name: containers
     description: >-
       List and register entries in the dockstore (pairs of images + metadata
@@ -1473,146 +1472,6 @@ paths:
       responses:
         '400':
           description: Invalid token value
-      security:
-        - BEARER: []
-  '/collections/create/{organisationId}':
-    put:
-      tags:
-        - collections
-      summary: Create a collection in the given organisation.
-      description: ''
-      operationId: createCollection
-      parameters:
-        - name: organisationId
-          in: path
-          description: Organisation ID.
-          required: true
-          schema:
-            type: integer
-            format: int64
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Collection'
-      security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/Collection'
-  '/collections/update/{collectionId}':
-    post:
-      tags:
-        - collections
-      summary: Update a collection.
-      description: Currently only name and description can be updated.
-      operationId: updateCollection
-      parameters:
-        - name: collectionId
-          in: path
-          description: Collection ID.
-          required: true
-          schema:
-            type: integer
-            format: int64
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Collection'
-      security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/Collection'
-  '/collections/{collectionId}':
-    get:
-      tags:
-        - collections
-      summary: Retrieves a collection by ID.
-      description: >-
-        Does not require authentication for approved organisations,
-        authentication can be provided for unapproved organisations
-      operationId: getCollectionById
-      parameters:
-        - name: collectionId
-          in: path
-          description: Collection ID.
-          required: true
-          schema:
-            type: integer
-            format: int64
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Collection'
-      security:
-        - BEARER: []
-  '/collections/{collectionId}/add':
-    post:
-      tags:
-        - collections
-      summary: Add an entry to a collection.
-      description: ''
-      operationId: addEntryToCollection
-      parameters:
-        - name: collectionId
-          in: path
-          description: Collection ID.
-          required: true
-          schema:
-            type: integer
-            format: int64
-        - name: entryId
-          in: query
-          description: Entry ID
-          required: true
-          schema:
-            type: integer
-            format: int64
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Collection'
-      security:
-        - BEARER: []
-  '/collections/{collectionId}/delete':
-    delete:
-      tags:
-        - collections
-      summary: Delete an entry from a collection.
-      description: ''
-      operationId: deleteEntryFromCollection
-      parameters:
-        - name: collectionId
-          in: path
-          description: Collection ID.
-          required: true
-          schema:
-            type: integer
-            format: int64
-        - name: entryId
-          in: query
-          description: Entry ID
-          required: true
-          schema:
-            type: integer
-            format: int64
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Collection'
       security:
         - BEARER: []
   /containers/dockerRegistryList:
@@ -3218,6 +3077,199 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Organisation'
+      security:
+        - BEARER: []
+  '/organisations/{organisationId}/collections':
+    get:
+      tags:
+        - organisations
+      summary: Retrieve all collections for an organisation.
+      description: >-
+        Does not require authentication for approved organisations,
+        authentication can be provided for unapproved organisations
+      operationId: getCollectionsFromOrganisation
+      parameters:
+        - name: organisationId
+          in: path
+          description: Organisation ID.
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Collection'
+      security:
+        - BEARER: []
+    put:
+      tags:
+        - organisations
+      summary: Create a collection in the given organisation.
+      description: ''
+      operationId: createCollection
+      parameters:
+        - name: organisationId
+          in: path
+          description: Organisation ID.
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+      security:
+        - BEARER: []
+      requestBody:
+        $ref: '#/components/requestBodies/Collection'
+  '/organisations/{organisationId}/collections/{collectionId}':
+    get:
+      tags:
+        - organisations
+      summary: Retrieves a collection by ID.
+      description: >-
+        Does not require authentication for approved organisations,
+        authentication can be provided for unapproved organisations
+      operationId: getCollectionById
+      parameters:
+        - name: organisationId
+          in: path
+          description: Organisation ID.
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: collectionId
+          in: path
+          description: Collection ID.
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+      security:
+        - BEARER: []
+    post:
+      tags:
+        - organisations
+      summary: Update a collection.
+      description: Currently only name and description can be updated.
+      operationId: updateCollection
+      parameters:
+        - name: organisationId
+          in: path
+          description: Organisation ID.
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: collectionId
+          in: path
+          description: Collection ID.
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+      security:
+        - BEARER: []
+      requestBody:
+        $ref: '#/components/requestBodies/Collection'
+  '/organisations/{organisationId}/collections/{collectionId}/entry':
+    post:
+      tags:
+        - organisations
+      summary: Add an entry to a collection.
+      description: ''
+      operationId: addEntryToCollection
+      parameters:
+        - name: organisationId
+          in: path
+          description: Organisation ID.
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: collectionId
+          in: path
+          description: Collection ID.
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: entryId
+          in: query
+          description: Entry ID
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+      security:
+        - BEARER: []
+    delete:
+      tags:
+        - organisations
+      summary: Delete an entry from a collection.
+      description: ''
+      operationId: deleteEntryFromCollection
+      parameters:
+        - name: organisationId
+          in: path
+          description: Organisation ID.
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: collectionId
+          in: path
+          description: Collection ID.
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: entryId
+          in: query
+          description: Entry ID
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
       security:
         - BEARER: []
   '/organisations/{organisationId}/invitation':
@@ -5500,13 +5552,6 @@ components:
         Set of updated sourcefiles, add files by adding new files with unknown
         paths, delete files by including them with emptied content
       required: true
-    Collection:
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Collection'
-      description: Collection to register.
-      required: true
     StarRequest:
       content:
         application/json:
@@ -5527,6 +5572,13 @@ components:
           schema:
             $ref: '#/components/schemas/Organisation'
       description: Organisation to register.
+      required: true
+    Collection:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Collection'
+      description: Collection to register.
       required: true
   securitySchemes:
     BEARER:

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -1532,6 +1532,68 @@ paths:
                 $ref: '#/components/schemas/Collection'
       security:
         - BEARER: []
+  '/collections/{collectionId}/add':
+    post:
+      tags:
+        - collections
+      summary: Add an entry to a collection.
+      description: ''
+      operationId: addEntryToCollection
+      parameters:
+        - name: collectionId
+          in: path
+          description: Collection ID.
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: entryId
+          in: query
+          description: Entry ID
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+      security:
+        - BEARER: []
+  '/collections/{collectionId}/delete':
+    delete:
+      tags:
+        - collections
+      summary: Delete an entry from a collection.
+      description: ''
+      operationId: deleteEntryFromCollection
+      parameters:
+        - name: collectionId
+          in: path
+          description: Collection ID.
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: entryId
+          in: query
+          description: Entry ID
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+      security:
+        - BEARER: []
   /containers/dockerRegistryList:
     get:
       tags:

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -3097,49 +3097,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Organisation'
-  /organisations/all:
-    get:
-      tags:
-        - organisations
-      summary: List all organisations.
-      description: Admin/curator only
-      operationId: getAllOrganisations
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Organisation'
-      security:
-        - BEARER: []
-  '/organisations/approve/{organisationId}':
-    post:
-      tags:
-        - organisations
-      summary: Approves an organisation.
-      description: Admin/curator only
-      operationId: approveOrganisation
-      parameters:
-        - name: organisationId
-          in: path
-          description: Organisation ID.
-          required: true
-          schema:
-            type: integer
-            format: int64
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Organisation'
-      security:
-        - BEARER: []
-  /organisations/create:
     put:
       tags:
         - organisations
@@ -3157,7 +3114,61 @@ paths:
         - BEARER: []
       requestBody:
         $ref: '#/components/requestBodies/Organisation'
-  '/organisations/update/{organisationId}':
+  /organisations/all:
+    get:
+      tags:
+        - organisations
+      summary: List all organisations.
+      description: Admin/curator only
+      operationId: getAllOrganisations
+      parameters:
+        - name: type
+          in: query
+          description: Filter to apply to organisations.
+          required: true
+          schema:
+            type: string
+            enum:
+              - all
+              - unapproved
+              - approved
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Organisation'
+      security:
+        - BEARER: []
+  '/organisations/{organisationId}':
+    get:
+      tags:
+        - organisations
+      summary: Retrieves an organisation by ID.
+      description: >-
+        Does not require authentication for approved organisations,
+        authentication can be provided for unapproved organisations
+      operationId: getOrganisationById
+      parameters:
+        - name: organisationId
+          in: path
+          description: Organisation ID.
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organisation'
+      security:
+        - BEARER: []
     post:
       tags:
         - organisations
@@ -3185,15 +3196,13 @@ paths:
         - BEARER: []
       requestBody:
         $ref: '#/components/requestBodies/Organisation'
-  '/organisations/{organisationId}':
-    get:
+  '/organisations/{organisationId}/approve':
+    post:
       tags:
         - organisations
-      summary: Retrieves an organisation by ID.
-      description: >-
-        Does not require authentication for approved organisations,
-        authentication can be provided for unapproved organisations
-      operationId: getOrganisationById
+      summary: Approves an organisation.
+      description: Admin/curator only
+      operationId: approveOrganisation
       parameters:
         - name: organisationId
           in: path
@@ -3256,7 +3265,6 @@ paths:
           schema:
             type: string
             enum:
-              - ADMIN
               - MAINTAINER
               - MEMBER
         - name: userId
@@ -3296,7 +3304,6 @@ paths:
           schema:
             type: string
             enum:
-              - ADMIN
               - MAINTAINER
               - MEMBER
         - name: userId

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5129,8 +5129,9 @@ definitions:
         format: "date-time"
       name:
         type: "string"
+        example: "OICR"
         position: 1
-        description: "Name of the collection (ex. OICR)."
+        description: "Name of the collection."
         minLength: 3
         maxLength: 39
         pattern: "\\d*[a-zA-Z][a-zA-Z\\d]*"

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5129,7 +5129,7 @@ definitions:
         format: "date-time"
       name:
         type: "string"
-        example: "OICR"
+        example: "Alignment"
         position: 1
         description: "Name of the collection."
         minLength: 3
@@ -5600,6 +5600,7 @@ definitions:
         format: "date-time"
       name:
         type: "string"
+        example: "OICR"
         position: 1
         description: "Name of the organisation (ex. OICR)."
         minLength: 3

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -25,7 +25,6 @@ tags:
   description: "A curated subset of resources proposed as a common standard for tool\
     \ repositories. Implements TRS [1.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/1.0.0)\
     \ and is considered final (not subject to change)"
-- name: "collections"
 - name: "containers"
   description: "List and register entries in the dockstore (pairs of images + metadata\
     \ (CWL and Dockerfile))"
@@ -1211,146 +1210,6 @@ paths:
       responses:
         400:
           description: "Invalid token value"
-      security:
-      - BEARER: []
-  /collections/create/{organisationId}:
-    put:
-      tags:
-      - "collections"
-      summary: "Create a collection in the given organisation."
-      description: ""
-      operationId: "createCollection"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "organisationId"
-        in: "path"
-        description: "Organisation ID."
-        required: true
-        type: "integer"
-        format: "int64"
-      - in: "body"
-        name: "body"
-        description: "Collection to register."
-        required: true
-        schema:
-          $ref: "#/definitions/Collection"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Collection"
-      security:
-      - BEARER: []
-  /collections/update/{collectionId}:
-    post:
-      tags:
-      - "collections"
-      summary: "Update a collection."
-      description: "Currently only name and description can be updated."
-      operationId: "updateCollection"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        description: "Collection to register."
-        required: true
-        schema:
-          $ref: "#/definitions/Collection"
-      - name: "collectionId"
-        in: "path"
-        description: "Collection ID."
-        required: true
-        type: "integer"
-        format: "int64"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Collection"
-      security:
-      - BEARER: []
-  /collections/{collectionId}:
-    get:
-      tags:
-      - "collections"
-      summary: "Retrieves a collection by ID."
-      description: "Does not require authentication for approved organisations, authentication\
-        \ can be provided for unapproved organisations"
-      operationId: "getCollectionById"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "collectionId"
-        in: "path"
-        description: "Collection ID."
-        required: true
-        type: "integer"
-        format: "int64"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Collection"
-      security:
-      - BEARER: []
-  /collections/{collectionId}/add:
-    post:
-      tags:
-      - "collections"
-      summary: "Add an entry to a collection."
-      description: ""
-      operationId: "addEntryToCollection"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "collectionId"
-        in: "path"
-        description: "Collection ID."
-        required: true
-        type: "integer"
-        format: "int64"
-      - name: "entryId"
-        in: "query"
-        description: "Entry ID"
-        required: true
-        type: "integer"
-        format: "int64"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Collection"
-      security:
-      - BEARER: []
-  /collections/{collectionId}/delete:
-    delete:
-      tags:
-      - "collections"
-      summary: "Delete an entry from a collection."
-      description: ""
-      operationId: "deleteEntryFromCollection"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "collectionId"
-        in: "path"
-        description: "Collection ID."
-        required: true
-        type: "integer"
-        format: "int64"
-      - name: "entryId"
-        in: "query"
-        description: "Entry ID"
-        required: true
-        type: "integer"
-        format: "int64"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Collection"
       security:
       - BEARER: []
   /containers/dockerRegistryList:
@@ -2919,6 +2778,193 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/Organisation"
+      security:
+      - BEARER: []
+  /organisations/{organisationId}/collections:
+    get:
+      tags:
+      - "organisations"
+      summary: "Retrieve all collections for an organisation."
+      description: "Does not require authentication for approved organisations, authentication\
+        \ can be provided for unapproved organisations"
+      operationId: "getCollectionsFromOrganisation"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "organisationId"
+        in: "path"
+        description: "Organisation ID."
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Collection"
+      security:
+      - BEARER: []
+    put:
+      tags:
+      - "organisations"
+      summary: "Create a collection in the given organisation."
+      description: ""
+      operationId: "createCollection"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "organisationId"
+        in: "path"
+        description: "Organisation ID."
+        required: true
+        type: "integer"
+        format: "int64"
+      - in: "body"
+        name: "body"
+        description: "Collection to register."
+        required: true
+        schema:
+          $ref: "#/definitions/Collection"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Collection"
+      security:
+      - BEARER: []
+  /organisations/{organisationId}/collections/{collectionId}:
+    get:
+      tags:
+      - "organisations"
+      summary: "Retrieves a collection by ID."
+      description: "Does not require authentication for approved organisations, authentication\
+        \ can be provided for unapproved organisations"
+      operationId: "getCollectionById"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "organisationId"
+        in: "path"
+        description: "Organisation ID."
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "collectionId"
+        in: "path"
+        description: "Collection ID."
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Collection"
+      security:
+      - BEARER: []
+    post:
+      tags:
+      - "organisations"
+      summary: "Update a collection."
+      description: "Currently only name and description can be updated."
+      operationId: "updateCollection"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Collection to register."
+        required: true
+        schema:
+          $ref: "#/definitions/Collection"
+      - name: "organisationId"
+        in: "path"
+        description: "Organisation ID."
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "collectionId"
+        in: "path"
+        description: "Collection ID."
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Collection"
+      security:
+      - BEARER: []
+  /organisations/{organisationId}/collections/{collectionId}/entry:
+    post:
+      tags:
+      - "organisations"
+      summary: "Add an entry to a collection."
+      description: ""
+      operationId: "addEntryToCollection"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "organisationId"
+        in: "path"
+        description: "Organisation ID."
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "collectionId"
+        in: "path"
+        description: "Collection ID."
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "entryId"
+        in: "query"
+        description: "Entry ID"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Collection"
+      security:
+      - BEARER: []
+    delete:
+      tags:
+      - "organisations"
+      summary: "Delete an entry from a collection."
+      description: ""
+      operationId: "deleteEntryFromCollection"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "organisationId"
+        in: "path"
+        description: "Organisation ID."
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "collectionId"
+        in: "path"
+        description: "Collection ID."
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "entryId"
+        in: "query"
+        description: "Entry ID"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Collection"
       security:
       - BEARER: []
   /organisations/{organisationId}/invitation:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -1266,6 +1266,64 @@ paths:
             $ref: "#/definitions/Collection"
       security:
       - BEARER: []
+  /collections/{collectionId}/add:
+    post:
+      tags:
+      - "collections"
+      summary: "Add an entry to a collection."
+      description: ""
+      operationId: "addEntryToCollection"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "collectionId"
+        in: "path"
+        description: "Collection ID."
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "entryId"
+        in: "query"
+        description: "Entry ID"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Collection"
+      security:
+      - BEARER: []
+  /collections/{collectionId}/delete:
+    delete:
+      tags:
+      - "collections"
+      summary: "Delete an entry from a collection."
+      description: ""
+      operationId: "deleteEntryFromCollection"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "collectionId"
+        in: "path"
+        description: "Collection ID."
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "entryId"
+        in: "query"
+        description: "Entry ID"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Collection"
+      security:
+      - BEARER: []
   /containers/dockerRegistryList:
     get:
       tags:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -2795,49 +2795,6 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/Organisation"
-  /organisations/all:
-    get:
-      tags:
-      - "organisations"
-      summary: "List all organisations."
-      description: "Admin/curator only"
-      operationId: "getAllOrganisations"
-      produces:
-      - "application/json"
-      parameters: []
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Organisation"
-      security:
-      - BEARER: []
-  /organisations/approve/{organisationId}:
-    post:
-      tags:
-      - "organisations"
-      summary: "Approves an organisation."
-      description: "Admin/curator only"
-      operationId: "approveOrganisation"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "organisationId"
-        in: "path"
-        description: "Organisation ID."
-        required: true
-        type: "integer"
-        format: "int64"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Organisation"
-      security:
-      - BEARER: []
-  /organisations/create:
     put:
       tags:
       - "organisations"
@@ -2860,7 +2817,58 @@ paths:
             $ref: "#/definitions/Organisation"
       security:
       - BEARER: []
-  /organisations/update/{organisationId}:
+  /organisations/all:
+    get:
+      tags:
+      - "organisations"
+      summary: "List all organisations."
+      description: "Admin/curator only"
+      operationId: "getAllOrganisations"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "type"
+        in: "query"
+        description: "Filter to apply to organisations."
+        required: true
+        type: "string"
+        enum:
+        - "all"
+        - "unapproved"
+        - "approved"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Organisation"
+      security:
+      - BEARER: []
+  /organisations/{organisationId}:
+    get:
+      tags:
+      - "organisations"
+      summary: "Retrieves an organisation by ID."
+      description: "Does not require authentication for approved organisations, authentication\
+        \ can be provided for unapproved organisations"
+      operationId: "getOrganisationById"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "organisationId"
+        in: "path"
+        description: "Organisation ID."
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Organisation"
+      security:
+      - BEARER: []
     post:
       tags:
       - "organisations"
@@ -2890,14 +2898,13 @@ paths:
             $ref: "#/definitions/Organisation"
       security:
       - BEARER: []
-  /organisations/{organisationId}:
-    get:
+  /organisations/{organisationId}/approve:
+    post:
       tags:
       - "organisations"
-      summary: "Retrieves an organisation by ID."
-      description: "Does not require authentication for approved organisations, authentication\
-        \ can be provided for unapproved organisations"
-      operationId: "getOrganisationById"
+      summary: "Approves an organisation."
+      description: "Admin/curator only"
+      operationId: "approveOrganisation"
       produces:
       - "application/json"
       parameters:
@@ -2958,7 +2965,6 @@ paths:
         required: true
         type: "string"
         enum:
-        - "ADMIN"
         - "MAINTAINER"
         - "MEMBER"
       - name: "userId"
@@ -2995,7 +3001,6 @@ paths:
         required: true
         type: "string"
         enum:
-        - "ADMIN"
         - "MAINTAINER"
         - "MEMBER"
       - name: "userId"

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -1242,6 +1242,35 @@ paths:
             $ref: "#/definitions/Collection"
       security:
       - BEARER: []
+  /collections/update/{collectionId}:
+    post:
+      tags:
+      - "collections"
+      summary: "Update a collection."
+      description: "Currently only name and description can be updated."
+      operationId: "updateCollection"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Collection to register."
+        required: true
+        schema:
+          $ref: "#/definitions/Collection"
+      - name: "collectionId"
+        in: "path"
+        description: "Collection ID."
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Collection"
+      security:
+      - BEARER: []
   /collections/{collectionId}:
     get:
       tags:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -2875,7 +2875,7 @@ paths:
       parameters:
       - in: "body"
         name: "body"
-        description: "Collection to register."
+        description: "Collection to update with."
         required: true
         schema:
           $ref: "#/definitions/Collection"

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -2740,7 +2740,7 @@ paths:
       parameters:
       - in: "body"
         name: "body"
-        description: "Organisation to register."
+        description: "Organisation to update with."
         required: true
         schema:
           $ref: "#/definitions/Organisation"

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -25,6 +25,7 @@ tags:
   description: "A curated subset of resources proposed as a common standard for tool\
     \ repositories. Implements TRS [1.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/1.0.0)\
     \ and is considered final (not subject to change)"
+- name: "collections"
 - name: "containers"
   description: "List and register entries in the dockstore (pairs of images + metadata\
     \ (CWL and Dockerfile))"
@@ -1210,6 +1211,59 @@ paths:
       responses:
         400:
           description: "Invalid token value"
+      security:
+      - BEARER: []
+  /collections/create/{organisationId}:
+    put:
+      tags:
+      - "collections"
+      summary: "Create a collection in the given organisation."
+      description: ""
+      operationId: "createCollection"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "organisationId"
+        in: "path"
+        description: "Organisation ID."
+        required: true
+        type: "integer"
+        format: "int64"
+      - in: "body"
+        name: "body"
+        description: "Collection to register."
+        required: true
+        schema:
+          $ref: "#/definitions/Collection"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Collection"
+      security:
+      - BEARER: []
+  /collections/{collectionId}:
+    get:
+      tags:
+      - "collections"
+      summary: "Retrieves a collection by ID."
+      description: "Does not require authentication for approved organisations, authentication\
+        \ can be provided for unapproved organisations"
+      operationId: "getCollectionById"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "collectionId"
+        in: "path"
+        description: "Collection ID."
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Collection"
       security:
       - BEARER: []
   /containers/dockerRegistryList:
@@ -4920,6 +4974,32 @@ definitions:
     properties:
       content:
         type: "string"
+  Collection:
+    type: "object"
+    required:
+    - "name"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+        description: "Implementation specific ID for the collection in this web service"
+      dbCreateDate:
+        type: "string"
+        format: "date-time"
+      dbUpdateDate:
+        type: "string"
+        format: "date-time"
+      name:
+        type: "string"
+        position: 1
+        description: "Name of the collection (ex. OICR)."
+        minLength: 3
+        maxLength: 39
+        pattern: "\\d*[a-zA-Z][a-zA-Z\\d]*"
+      description:
+        type: "string"
+        position: 2
+        description: "Description of the collection"
   DescriptorLanguageBean:
     type: "object"
     properties:
@@ -4946,6 +5026,11 @@ definitions:
         type: "integer"
         format: "int64"
         description: "Implementation specific ID for the container in this web service"
+      collections:
+        type: "array"
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/Collection"
       aliases:
         type: "object"
         description: "aliases can be used as an alternate unique id for entries"
@@ -5160,6 +5245,11 @@ definitions:
         type: "integer"
         format: "int64"
         description: "Implementation specific ID for the container in this web service"
+      collections:
+        type: "array"
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/Collection"
       aliases:
         type: "object"
         description: "aliases can be used as an alternate unique id for entries"
@@ -6069,6 +6159,11 @@ definitions:
         type: "integer"
         format: "int64"
         description: "Implementation specific ID for the container in this web service"
+      collections:
+        type: "array"
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/Collection"
       aliases:
         type: "object"
         description: "aliases can be used as an alternate unique id for entries"


### PR DESCRIPTION
Adds some basic collections functionality to Dockstore.
Can do the following operations on a collection:
* Create
* Read
* Update
* Add entry
* Delete entry

Events are also tracked for all operations that edit the database.

Note there is no versioning of the collections. We thought this was too complex. Also collections are not associated with a specific version. Collections simply reference a set of entries. If you want to refer to certain versions you can do so in the collection description. We thought having versioned collections and being able to reference specific versions of an entry didn't add enough value for the complexity it adds to development and usage by end users. We do keep track of when entries are added/removed from a collection automatically, which does provide some automatic history.