### PR TITLE
Feature/fix migration

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -188,8 +188,9 @@ public class SourceFile implements Comparable<SourceFile> {
         @Column(columnDefinition = "text")
         public String metadata = "";
 
+        // By default set to null in database
         @Column(columnDefinition = "text")
-        public String platformVersion;
+        public String platformVersion = null;
 
         // database timestamps
         @Column(updatable = false)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -43,7 +43,6 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -189,9 +188,8 @@ public class SourceFile implements Comparable<SourceFile> {
         @Column(columnDefinition = "text")
         public String metadata = "";
 
-        @Column(columnDefinition = "text", nullable = false)
-        @ColumnDefault("'N/A'")
-        public String platformVersion = "N/A";
+        @Column(columnDefinition = "text")
+        public String platformVersion;
 
         // database timestamps
         @Column(updatable = false)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -43,6 +43,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -189,7 +190,8 @@ public class SourceFile implements Comparable<SourceFile> {
         public String metadata = "";
 
         @Column(columnDefinition = "text", nullable = false)
-        public String platformVersion = "";
+        @ColumnDefault("'N/A'")
+        public String platformVersion = "N/A";
 
         // database timestamps
         @Column(updatable = false)

--- a/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
@@ -18,12 +18,12 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd"
                    context="1.6.0">
-
     <changeSet author="gluu (generated)" id="addPlatformVersionToSourcefileVerified">
         <addColumn tableName="sourcefile_verified">
-            <column name="platformversion" type="text"/>
+            <column name="platformversion" type="text" defaultValue="">
+                <constraints nullable="false" />
+            </column>
         </addColumn>
-        <addNotNullConstraint columnDataType="clob" columnName="platformversion" tableName="sourcefile_verified"/>
     </changeSet>
 
     <changeSet author="aduncan (generated)" id="addOrganisationTable">

--- a/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
@@ -20,8 +20,8 @@
                    context="1.6.0">
     <changeSet author="gluu (generated)" id="addPlatformVersionToSourcefileVerified">
         <addColumn tableName="sourcefile_verified">
-            <column name="platformversion" type="text" defaultValue="">
-                <constraints nullable="false" />
+            <column defaultValue="N/A" name="platformversion" type="text">
+                <constraints nullable="false"/>
             </column>
         </addColumn>
     </changeSet>
@@ -113,5 +113,4 @@
     <changeSet author="aduncan (generated)" id="addWorkflowFKEvent">
         <addForeignKeyConstraint baseColumnNames="workflowid" baseTableName="event" constraintName="FKWorkflowId" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="workflow"/>
     </changeSet>
-
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
@@ -20,7 +20,7 @@
                    context="1.6.0">
     <changeSet author="gluu (generated)" id="addPlatformVersionToSourcefileVerified">
         <addColumn tableName="sourcefile_verified">
-            <column name="platformversion" type="text"/>
+            <column name="platformversion" type="text" remarks="By default set to null"/>
         </addColumn>
     </changeSet>
 

--- a/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
@@ -20,9 +20,7 @@
                    context="1.6.0">
     <changeSet author="gluu (generated)" id="addPlatformVersionToSourcefileVerified">
         <addColumn tableName="sourcefile_verified">
-            <column defaultValue="N/A" name="platformversion" type="text">
-                <constraints nullable="false"/>
-            </column>
+            <column name="platformversion" type="text"/>
         </addColumn>
     </changeSet>
 


### PR DESCRIPTION
Sets the default value in the DB as opposed to just Java code.
For some reason, having an empty string as the default value causes liquibase diff to completely ignore the change.  Setting the default to "N/A" instead, as that is what the UI2 was going to convert it to anyways.