### PR TITLE
Fix unnecessary test output

### DIFF
--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -245,6 +245,19 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>findbugs</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -246,12 +246,12 @@
             <artifactId>findbugs</artifactId>
         </dependency>
 
+        <!-- https://github.com/dropwizard/dropwizard/issues/2318 -->
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchNoInternetTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchNoInternetTestIT.java
@@ -33,9 +33,9 @@ import static org.junit.Assert.assertTrue;
 public class LaunchNoInternetTestIT {
     private static String DOCKER_IMAGE_DIRECTORY;
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog();
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
     @Rule
     public final ExpectedSystemExit exit = ExpectedSystemExit.none();
     @Rule


### PR DESCRIPTION
The test uses Docker commands but causes long error output when used with Java 10 (even though the test passes).  The pom changes should fix those errors.  The mute in the actual test will ensure it.