### PR TITLE
Feature/1973/remove checker workflows in search

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ElasticManager.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ElasticManager.java
@@ -180,11 +180,7 @@ public class ElasticManager {
      * @return          null if checker, entry otherwise
      */
     public static Entry filterCheckerWorkflows(Entry entry) {
-        if (entry instanceof Workflow && ((Workflow)entry).isIsChecker()) {
-            return null;
-        } else {
-            return entry;
-        }
+        return entry instanceof Workflow && ((Workflow)entry).isIsChecker() ? null : entry;
     }
 
     /**

--- a/dockstore-webservice/src/test/java/core/ElasticManagerIT.java
+++ b/dockstore-webservice/src/test/java/core/ElasticManagerIT.java
@@ -17,14 +17,18 @@ package core;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import com.google.api.client.util.Charsets;
 import com.google.common.io.Files;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
+import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Tag;
 import io.dockstore.webservice.core.Tool;
+import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.helpers.ElasticManager;
 import io.dockstore.webservice.helpers.ElasticMode;
 import io.dropwizard.testing.ResourceHelpers;
@@ -81,6 +85,16 @@ public class ElasticManagerIT {
 
         //TODO: should extend this by checking that elastic search holds the content we expect
         Assert.assertTrue("could not talk to elastic search", !systemOutRule.getLog().contains("Connection refused"));
+    }
+
+    @Test
+    public void filterCheckerWorkflows() {
+        Workflow workflow = new Workflow();
+        workflow.setIsChecker(true);
+        Tool tool = new Tool();
+        List<Entry> entries = manager.filterCheckerWorkflows(Arrays.asList(workflow, tool));
+        Assert.assertEquals("There should've been 1 entry without checker workflow", 1, entries.size());
+        entries.forEach(entry -> Assert.assertFalse("There should be no workflow", entry instanceof Workflow));
     }
 
 

--- a/dockstore-webservice/src/test/java/core/ElasticManagerIT.java
+++ b/dockstore-webservice/src/test/java/core/ElasticManagerIT.java
@@ -89,12 +89,14 @@ public class ElasticManagerIT {
 
     @Test
     public void filterCheckerWorkflows() {
+        Workflow checkerWorkflow = new Workflow();
+        checkerWorkflow.setIsChecker(true);
         Workflow workflow = new Workflow();
-        workflow.setIsChecker(true);
+        workflow.setIsChecker(false);
         Tool tool = new Tool();
-        List<Entry> entries = manager.filterCheckerWorkflows(Arrays.asList(workflow, tool));
-        Assert.assertEquals("There should've been 1 entry without checker workflow", 1, entries.size());
-        entries.forEach(entry -> Assert.assertFalse("There should be no workflow", entry instanceof Workflow));
+        List<Entry> entries = manager.filterCheckerWorkflows(Arrays.asList(workflow, tool, checkerWorkflow));
+        Assert.assertEquals("There should've been 2 entries without the checker workflow", 2, entries.size());
+        entries.forEach(entry -> Assert.assertFalse("There should be no checker workflows", entry instanceof Workflow && ((Workflow)entry).isIsChecker()));
     }
 
 


### PR DESCRIPTION
Quick fix to not put checker workflows in the elastic index.  Will require an index rebuild as this does not remove existing checker workflows.