### PR TITLE
Feature/2007/Fixed json example in CWL tutorial 

### DIFF
--- a/_docs/getting-started-with-cwl.md
+++ b/_docs/getting-started-with-cwl.md
@@ -191,6 +191,7 @@ This downloads to my current directory and then moves to `/tmp`.  I could choose
 {
     "bam_input": {
         "class": "File",
+        "format": "http://edamontology.org/format_2572",
         "path": "/tmp/NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.bam"
     },
     "bamstats_report": {


### PR DESCRIPTION
#2007 
Added format line to json file so that running the dockstore tool in the next step of CWL tutorial no longer fails. 