### PR TITLE
Feature/1963/elastic search health check

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SearchResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SearchResourceIT.java
@@ -22,6 +22,7 @@ import io.dockstore.common.ConfidentialTest;
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
 import io.swagger.client.api.ExtendedGa4GhApi;
+import io.swagger.client.api.MetadataApi;
 import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.model.PublishRequest;
 import io.swagger.client.model.Workflow;
@@ -84,5 +85,51 @@ public class SearchResourceIT extends BaseIT {
         // after publication index should include workflow
         String s = extendedGa4GhApi.toolsIndexSearch(exampleESQuery);
         assertTrue(s.contains(WorkflowIT.DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW));
+    }
+
+    /**
+     * This tests that the elastic search health check will fail if the Docker container is down, the
+     * index is not made, or the index is made but there are no results.
+     */
+    @Test
+    public void testElasticSearchHealthCheck() {
+        final ApiClient webClient = getWebClient(USER_2_USERNAME);
+        ExtendedGa4GhApi extendedGa4GhApi = new ExtendedGa4GhApi(webClient);
+        MetadataApi metadataApi = new MetadataApi(webClient);
+
+        // Should fail with no index
+        try {
+            metadataApi.checkElasticSearch();
+        } catch (ApiException ex) {
+            assertTrue("Should fail", true);
+        }
+
+        // Update the search index
+        extendedGa4GhApi.toolsIndexGet();
+
+        // Should still fail even with index
+        try {
+            metadataApi.checkElasticSearch();
+        } catch (ApiException ex) {
+            assertTrue("Should fail", true);
+        }
+
+        // Register and publish workflow
+        WorkflowsApi workflowApi = new WorkflowsApi(webClient);
+        workflowApi.manualRegister("github", "DockstoreTestUser2/dockstore_workflow_cnv", "/workflow/cnv.cwl", "", "cwl", "/test.json");
+        final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(WorkflowIT.DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW);
+        // do targetted refresh, should promote workflow to fully-fleshed out workflow
+        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId());
+
+        workflowApi.publish(workflow.getId(), new PublishRequest() {
+            public Boolean isPublish() { return false;}
+        });
+
+        // Should not fail since a workflow exists in index
+        try {
+            metadataApi.checkElasticSearch();
+        } catch (ApiException ex) {
+            assertTrue("Should not fail", false);
+        }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -58,6 +58,7 @@ import io.dockstore.webservice.permissions.PermissionsInterface;
 import io.dockstore.webservice.resources.CollectionResource;
 import io.dockstore.webservice.resources.DockerRepoResource;
 import io.dockstore.webservice.resources.DockerRepoTagResource;
+import io.dockstore.webservice.resources.ElasticSearchHealthCheck;
 import io.dockstore.webservice.resources.EntryResource;
 import io.dockstore.webservice.resources.HostedToolResource;
 import io.dockstore.webservice.resources.HostedWorkflowResource;
@@ -218,6 +219,9 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
 
         final TemplateHealthCheck healthCheck = new TemplateHealthCheck(configuration.getTemplate());
         environment.healthChecks().register("template", healthCheck);
+
+        final ElasticSearchHealthCheck elasticSearchHealthCheck = new ElasticSearchHealthCheck(new ToolsExtendedApi());
+        environment.healthChecks().register("elasticSearch", elasticSearchHealthCheck);
 
         final UserDAO userDAO = new UserDAO(hibernate.getSessionFactory());
         final TokenDAO tokenDAO = new TokenDAO(hibernate.getSessionFactory());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticSearchHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticSearchHealthCheck.java
@@ -22,22 +22,23 @@ public class ElasticSearchHealthCheck extends HealthCheck {
 
     @Override
     protected Result check() throws Exception {
+        String baseMessage = "Error contacting Elastic Search";
         // If elastic search is up with a valid index this should return healthy
         Response response;
         try {
             response = toolsExtendedApi.toolsIndexSearch(null, null, null);
         } catch (CustomWebApplicationException ex) {
-            LOG.info(ex.getStackTrace().toString());
-            return Result.unhealthy("Error contacting Elastic Search: " + ex.getResponse().getEntity());
+            LOG.info(baseMessage, ex);
+            return Result.unhealthy(baseMessage + ": " + ex.getResponse().getEntity());
         } catch (Exception ex) {
-            LOG.info(ex.getStackTrace().toString());
-            return Result.unhealthy("Error contacting Elastic Search: " + ex.getMessage());
+            LOG.info(baseMessage, ex);
+            return Result.unhealthy(baseMessage + ": " + ex.getMessage());
         }
 
         if (response.getStatus() >= Response.Status.OK.getStatusCode() && response.getStatus() < Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()) {
             return Result.healthy();
         } else {
-            return Result.unhealthy("Error contacting Elastic Search, got status code '" + response.getStatus() + "'.");
+            return Result.unhealthy(baseMessage + ", got status code '" + response.getStatus() + "'.");
         }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticSearchHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticSearchHealthCheck.java
@@ -5,13 +5,15 @@ import javax.ws.rs.core.Response;
 import com.codahale.metrics.health.HealthCheck;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.resources.proposedGA4GH.ToolsExtendedApi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Checks that elastic search is healthy
  */
 public class ElasticSearchHealthCheck extends HealthCheck {
-    private static final int LOWER_BOUND_SUCCESS_STATUS = 200;
-    private static final int UPPER_BOUND_SUCCESS_STATUS = 300;
+    private static final Logger LOG = LoggerFactory.getLogger(ElasticSearchHealthCheck.class);
+
     private final ToolsExtendedApi toolsExtendedApi;
 
     public ElasticSearchHealthCheck(ToolsExtendedApi toolsExtendedApi) {
@@ -25,14 +27,14 @@ public class ElasticSearchHealthCheck extends HealthCheck {
         try {
             response = toolsExtendedApi.toolsIndexSearch(null, null, null);
         } catch (CustomWebApplicationException ex) {
-            ex.printStackTrace();
+            LOG.info(ex.getStackTrace().toString());
             return Result.unhealthy("Error contacting Elastic Search: " + ex.getResponse().getEntity());
         } catch (Exception ex) {
-            ex.printStackTrace();
+            LOG.info(ex.getStackTrace().toString());
             return Result.unhealthy("Error contacting Elastic Search: " + ex.getMessage());
         }
 
-        if (response.getStatus() >= LOWER_BOUND_SUCCESS_STATUS && response.getStatus() < UPPER_BOUND_SUCCESS_STATUS) {
+        if (response.getStatus() >= Response.Status.OK.getStatusCode() && response.getStatus() < Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()) {
             return Result.healthy();
         } else {
             return Result.unhealthy("Error contacting Elastic Search, got status code '" + response.getStatus() + "'.");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticSearchHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticSearchHealthCheck.java
@@ -1,0 +1,41 @@
+package io.dockstore.webservice.resources;
+
+import javax.ws.rs.core.Response;
+
+import com.codahale.metrics.health.HealthCheck;
+import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.resources.proposedGA4GH.ToolsExtendedApi;
+
+/**
+ * Checks that elastic search is healthy
+ */
+public class ElasticSearchHealthCheck extends HealthCheck {
+    private static final int LOWER_BOUND_SUCCESS_STATUS = 200;
+    private static final int UPPER_BOUND_SUCCESS_STATUS = 300;
+    private final ToolsExtendedApi toolsExtendedApi;
+
+    public ElasticSearchHealthCheck(ToolsExtendedApi toolsExtendedApi) {
+        this.toolsExtendedApi = toolsExtendedApi;
+    }
+
+    @Override
+    protected Result check() throws Exception {
+        // If elastic search is up with a valid index this should return healthy
+        Response response;
+        try {
+            response = toolsExtendedApi.toolsIndexSearch(null, null, null);
+        } catch (CustomWebApplicationException ex) {
+            ex.printStackTrace();
+            return Result.unhealthy("Error contacting Elastic Search: " + ex.getResponse().getEntity());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            return Result.unhealthy("Error contacting Elastic Search: " + ex.getMessage());
+        }
+
+        if (response.getStatus() >= LOWER_BOUND_SUCCESS_STATUS && response.getStatus() < UPPER_BOUND_SUCCESS_STATUS) {
+            return Result.healthy();
+        } else {
+            return Result.unhealthy("Error contacting Elastic Search, got status code '" + response.getStatus() + "'.");
+        }
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -18,6 +18,7 @@ package io.dockstore.webservice.resources;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,9 +67,12 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import okhttp3.Cache;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.hibernate.SessionFactory;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -292,6 +296,13 @@ public class MetadataResource {
         Response elasticSearchResponse;
         try {
             elasticSearchResponse = delegate.toolsIndexSearch(null, null, null);
+            String result = IOUtils.toString((InputStream)(elasticSearchResponse.getEntity()), StandardCharsets.UTF_8);
+            JSONObject jsonObj = new JSONObject(result);
+            JSONObject hitsHolder = jsonObj.getJSONObject("hits");
+            JSONArray hitsArray = hitsHolder.getJSONArray("hits");
+            if (hitsArray.length() == 0) {
+                return Response.status(ERROR_STATUS_CODE).build();
+            }
         } catch (Exception ex) {
             return Response.status(ERROR_STATUS_CODE).build();
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -85,7 +85,6 @@ import org.slf4j.LoggerFactory;
 public class MetadataResource {
 
     private static final Logger LOG = LoggerFactory.getLogger(MetadataResource.class);
-    private static final int ERROR_STATUS_CODE = 500;
     private final ToolsExtendedApiService delegate = ToolsApiExtendedServiceFactory.getToolsExtendedApi();
 
     private final ToolDAO toolDAO;
@@ -300,11 +299,11 @@ public class MetadataResource {
             JSONObject jsonObj = new JSONObject(result);
             JSONObject hitsHolder = jsonObj.getJSONObject("hits");
             JSONArray hitsArray = hitsHolder.getJSONArray("hits");
-            if (hitsArray.length() == 0) {
-                return Response.status(ERROR_STATUS_CODE).build();
+            if (hitsArray.toList().isEmpty()) {
+                return Response.status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()).build();
             }
         } catch (Exception ex) {
-            return Response.status(ERROR_STATUS_CODE).build();
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()).build();
         }
         return Response.ok().build();
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -289,9 +289,8 @@ public class MetadataResource {
     @Path("/elasticSearch")
     @ApiOperation(value = "Successful response if elastic search is up and running.", notes = "NO authentication")
     public Response checkElasticSearch() {
-        Response elasticSearchResponse;
         try {
-            elasticSearchResponse = delegate.toolsIndexSearch(null, null, null);
+            delegate.toolsIndexSearch(null, null, null);
         } catch (Exception ex) {
             return Response.status(ERROR_STATUS_CODE).build();
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -289,8 +289,9 @@ public class MetadataResource {
     @Path("/elasticSearch")
     @ApiOperation(value = "Successful response if elastic search is up and running.", notes = "NO authentication")
     public Response checkElasticSearch() {
+        Response elasticSearchResponse;
         try {
-            delegate.toolsIndexSearch(null, null, null);
+            elasticSearchResponse = delegate.toolsIndexSearch(null, null, null);
         } catch (Exception ex) {
             return Response.status(ERROR_STATUS_CODE).build();
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -55,6 +55,8 @@ import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowVersion;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import io.dockstore.webservice.jdbi.WorkflowDAO;
+import io.dockstore.webservice.resources.proposedGA4GH.ToolsApiExtendedServiceFactory;
+import io.dockstore.webservice.resources.proposedGA4GH.ToolsExtendedApiService;
 import io.dockstore.webservice.resources.rss.RSSEntry;
 import io.dockstore.webservice.resources.rss.RSSFeed;
 import io.dockstore.webservice.resources.rss.RSSHeader;
@@ -79,6 +81,8 @@ import org.slf4j.LoggerFactory;
 public class MetadataResource {
 
     private static final Logger LOG = LoggerFactory.getLogger(MetadataResource.class);
+    private static final int ERROR_STATUS_CODE = 500;
+    private final ToolsExtendedApiService delegate = ToolsApiExtendedServiceFactory.getToolsExtendedApi();
 
     private final ToolDAO toolDAO;
     private final WorkflowDAO workflowDAO;
@@ -277,6 +281,21 @@ public class MetadataResource {
             LOG.warn("unable to determine cache size, may not have initialized yet");
         }
         return results;
+    }
+
+    @GET
+    @Timed
+    @UnitOfWork
+    @Path("/elasticSearch")
+    @ApiOperation(value = "Successful response if elastic search is up and running.", notes = "NO authentication")
+    public Response checkElasticSearch() {
+        Response elasticSearchResponse;
+        try {
+            elasticSearchResponse = delegate.toolsIndexSearch(null, null, null);
+        } catch (Exception ex) {
+            return Response.status(ERROR_STATUS_CODE).build();
+        }
+        return Response.ok().build();
     }
 
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -193,7 +193,9 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
                 Map<String, String> parameters = new HashMap<>();
                 // TODO: note that this is lossy if there are repeated parameters
                 // but it looks like the elastic search http client classes don't handle it
-                queryParameters.forEach((key, value) -> parameters.put(key, value.get(0)));
+                if (queryParameters != null) {
+                    queryParameters.forEach((key, value) -> parameters.put(key, value.get(0)));
+                }
                 org.elasticsearch.client.Response get = restClient.performRequest("GET", "/entry/_search", parameters, entity);
                 if (get.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
                     throw new CustomWebApplicationException("Could not submit index to elastic search",

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsExtendedApi.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsExtendedApi.java
@@ -77,7 +77,7 @@ public class ToolsExtendedApi {
     @ApiResponses(value = { @ApiResponse(code = HttpStatus.SC_OK, message = "An elastic search result.", response = String.class) })
     public Response toolsIndexSearch(@ApiParam(value = "elastic search query", required = true) String query, @Context UriInfo uriInfo,
         @Context SecurityContext securityContext) {
-        return delegate.toolsIndexSearch(query, uriInfo.getQueryParameters(), securityContext);
+        return delegate.toolsIndexSearch(query, uriInfo != null ? uriInfo.getQueryParameters() : null, securityContext);
     }
 
     @POST

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -2825,6 +2825,16 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/RegistryBean'
+  /metadata/elasticSearch:
+    get:
+      tags:
+        - metadata
+      summary: Successful response if elastic search is up and running.
+      description: NO authentication
+      operationId: checkElasticSearch
+      responses:
+        default:
+          description: successful operation
   /metadata/okHttpCachePerformance:
     get:
       tags:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -2526,6 +2526,20 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/RegistryBean"
+  /metadata/elasticSearch:
+    get:
+      tags:
+      - "metadata"
+      summary: "Successful response if elastic search is up and running."
+      description: "NO authentication"
+      operationId: "checkElasticSearch"
+      produces:
+      - "text/html"
+      - "text/xml"
+      parameters: []
+      responses:
+        default:
+          description: "successful operation"
   /metadata/okHttpCachePerformance:
     get:
       tags:


### PR DESCRIPTION
Two ways to check health.
1) Use Dropwizard health check - <url>:8081/healthcheck
1) Use metadata elasticSearch endpoint - To be used by uptime robot (200 on success, 500 on error)

https://github.com/ga4gh/dockstore/issues/1963