### PR TITLE
Don't log error when saving a non-published workflow

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ElasticManager.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ElasticManager.java
@@ -102,7 +102,7 @@ public class ElasticManager {
             return;
         }
         if (!checkValid(entry, command)) {
-            LOGGER.error("Could not perform the elastic search index update.");
+            LOGGER.info("Could not perform the elastic search index update.");
             return;
         }
         String json = getDocumentValueFromEntry(entry);
@@ -125,7 +125,7 @@ public class ElasticManager {
             if (statusCode == HttpStatus.SC_OK || statusCode == HttpStatus.SC_CREATED) {
                 LOGGER.info("Successful " + command + ".");
             } else {
-                LOGGER.info("Could not submit index to elastic search. " + post.getStatusLine().getReasonPhrase());
+                LOGGER.error("Could not submit index to elastic search. " + post.getStatusLine().getReasonPhrase());
             }
         } catch (IOException e) {
             LOGGER.error("Could not submit index to elastic search. " + e.getMessage());

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -1,55 +1,50 @@
 openapi: 3.0.0
 info:
-  description: >-
-    This describes the dockstore API, a webservice that manages pairs of Docker
+  description: This describes the dockstore API, a webservice that manages pairs of Docker
     images and associated metadata such as CWL documents and Dockerfiles used to
     build those images
-  version: 1.6.0-alpha.3-SNAPSHOT
+  version: 1.6.0-alpha.4-SNAPSHOT
   title: Dockstore API
   termsOfService: TBD
   contact:
     name: Dockstore@ga4gh
-    url: 'https://github.com/ga4gh/dockstore'
+    url: https://github.com/ga4gh/dockstore
     email: theglobalalliance@genomicsandhealth.org
   license:
     name: Apache License Version 2.0
-    url: 'https://github.com/ga4gh/dockstore/blob/develop/LICENSE'
+    url: https://github.com/ga4gh/dockstore/blob/develop/LICENSE
 tags:
   - name: GA4GH
-    description: >-
-      A curated subset of resources proposed as a common standard for tool
+    description: A curated subset of resources proposed as a common standard for tool
       repositories. Implements TRS
       [2.0.0-beta.2](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0-beta.2)
       . Integrators are welcome to use these endpoints but they are subject to
       change based on community input.
   - name: NIHdatacommons
   - name: GA4GHV1
-    description: >-
-      A curated subset of resources proposed as a common standard for tool
+    description: A curated subset of resources proposed as a common standard for tool
       repositories. Implements TRS
       [1.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/1.0.0)
       and is considered final (not subject to change)
   - name: containers
-    description: >-
-      List and register entries in the dockstore (pairs of images + metadata
+    description: List and register entries in the dockstore (pairs of images + metadata
       (CWL and Dockerfile))
   - name: containertags
     description: List and modify tags for containers
   - name: entries
-    description: >-
-      Interact with entries in Dockstore regardless of whether they are
+    description: Interact with entries in Dockstore regardless of whether they are
       containers or workflows
   - name: extendedGA4GH
     description: Optional experimental extensions of the GA4GH API
   - name: hosted
     description: Created and modify hosted entries in the dockstore
   - name: metadata
-    description: 'Information about Dockstore like RSS, sitemap, lists of dependencies, etc.'
+    description: Information about Dockstore like RSS, sitemap, lists of dependencies, etc.
   - name: organisations
   - name: tokens
-    description: 'List, modify, refresh, and delete tokens for external services'
+    description: List, modify, refresh, and delete tokens for external services
   - name: users
-    description: 'List, modify, and manage end users of the dockstore'
+    description: List, modify, and manage end users of the dockstore
   - name: workflows
     description: List and register workflows in the dockstore (CWL or WDL)
 paths:
@@ -61,50 +56,48 @@ paths:
       description: Return some metadata that is useful for describing this registry
       operationId: metadataGet
       responses:
-        '200':
+        "200":
           description: A Metadata object describing this service.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MetadataV1'
+                $ref: "#/components/schemas/MetadataV1"
             text/plain:
               schema:
-                $ref: '#/components/schemas/MetadataV1'
+                $ref: "#/components/schemas/MetadataV1"
   /api/ga4gh/v1/tool-classes:
     get:
       tags:
         - GA4GHV1
       summary: List all tool types
-      description: 'This endpoint returns all tool-classes available '
+      description: "This endpoint returns all tool-classes available "
       operationId: toolClassesGet
       responses:
-        '200':
+        "200":
           description: An array of methods that match the filter.
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolClass'
+                  $ref: "#/components/schemas/ToolClass"
             text/plain:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolClass'
+                  $ref: "#/components/schemas/ToolClass"
   /api/ga4gh/v1/tools:
     get:
       tags:
         - GA4GHV1
       summary: List all tools
-      description: >-
-        This endpoint returns all tools available or a filtered subset using
-        metadata query parameters. 
+      description: "This endpoint returns all tools available or a filtered subset using
+        metadata query parameters. "
       operationId: toolsGet
       parameters:
         - name: id
           in: query
-          description: >-
-            A unique identifier of the tool, scoped to this registry, for
+          description: A unique identifier of the tool, scoped to this registry, for
             example `123456`
           required: false
           schema:
@@ -141,16 +134,14 @@ paths:
             type: string
         - name: author
           in: query
-          description: >-
-            The author of the tool (TODO a thought occurs, are we assuming that
+          description: The author of the tool (TODO a thought occurs, are we assuming that
             the author of the CWL and the image are the same?).
           required: false
           schema:
             type: string
         - name: offset
           in: query
-          description: >-
-            Start index of paging. Pagination results can be based on numbers or
+          description: Start index of paging. Pagination results can be based on numbers or
             other values chosen by the registry implementor (for example, SHA
             values). If this exceeds the current result set return an empty
             set.  If not specified in the request this will start at the
@@ -166,48 +157,46 @@ paths:
             type: integer
             format: int32
       responses:
-        '200':
+        "200":
           description: An array of Tools that match the filter.
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolV1'
+                  $ref: "#/components/schemas/ToolV1"
             text/plain:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolV1'
-  '/api/ga4gh/v1/tools/{id}':
+                  $ref: "#/components/schemas/ToolV1"
+  "/api/ga4gh/v1/tools/{id}":
     get:
       tags:
         - GA4GHV1
-      summary: 'List one specific tool, acts as an anchor for self references'
-      description: >-
-        This endpoint returns one specific tool (which has ToolVersions nested
+      summary: List one specific tool, acts as an anchor for self references
+      description: This endpoint returns one specific tool (which has ToolVersions nested
         inside it)
       operationId: toolsIdGet
       parameters:
         - name: id
           in: path
-          description: >-
-            A unique identifier of the tool, scoped to this registry, for
+          description: A unique identifier of the tool, scoped to this registry, for
             example `123456`
           required: true
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: A tool.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ToolV1'
+                $ref: "#/components/schemas/ToolV1"
             text/plain:
               schema:
-                $ref: '#/components/schemas/ToolV1'
-  '/api/ga4gh/v1/tools/{id}/versions':
+                $ref: "#/components/schemas/ToolV1"
+  "/api/ga4gh/v1/tools/{id}/versions":
     get:
       tags:
         - GA4GHV1
@@ -217,61 +206,58 @@ paths:
       parameters:
         - name: id
           in: path
-          description: >-
-            A unique identifier of the tool, scoped to this registry, for
+          description: A unique identifier of the tool, scoped to this registry, for
             example `123456`
           required: true
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: An array of tool versions
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolVersionV1'
+                  $ref: "#/components/schemas/ToolVersionV1"
             text/plain:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolVersionV1'
-  '/api/ga4gh/v1/tools/{id}/versions/{version_id}':
+                  $ref: "#/components/schemas/ToolVersionV1"
+  "/api/ga4gh/v1/tools/{id}/versions/{version_id}":
     get:
       tags:
         - GA4GHV1
-      summary: 'List one specific tool version, acts as an anchor for self references'
+      summary: List one specific tool version, acts as an anchor for self references
       description: This endpoint returns one specific tool version
       operationId: toolsIdVersionsVersionIdGet
       parameters:
         - name: id
           in: path
-          description: >-
-            A unique identifier of the tool, scoped to this registry, for
+          description: A unique identifier of the tool, scoped to this registry, for
             example `123456`
           required: true
           schema:
             type: string
         - name: version_id
           in: path
-          description: >-
-            An identifier of the tool version, scoped to this registry, for
+          description: An identifier of the tool version, scoped to this registry, for
             example `v1`
           required: true
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: A tool version.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ToolVersionV1'
+                $ref: "#/components/schemas/ToolVersionV1"
             text/plain:
               schema:
-                $ref: '#/components/schemas/ToolVersionV1'
-  '/api/ga4gh/v1/tools/{id}/versions/{version_id}/dockerfile':
+                $ref: "#/components/schemas/ToolVersionV1"
+  "/api/ga4gh/v1/tools/{id}/versions/{version_id}/dockerfile":
     get:
       tags:
         - GA4GHV1
@@ -281,40 +267,38 @@ paths:
       parameters:
         - name: id
           in: path
-          description: >-
-            A unique identifier of the tool, scoped to this registry, for
+          description: A unique identifier of the tool, scoped to this registry, for
             example `123456`
           required: true
           schema:
             type: string
         - name: version_id
           in: path
-          description: >-
-            An identifier of the tool version for this particular tool registry,
+          description: An identifier of the tool version for this particular tool registry,
             for example `v1`
           required: true
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: The tool payload.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ToolDockerfile'
+                $ref: "#/components/schemas/ToolDockerfile"
             text/plain:
               schema:
-                $ref: '#/components/schemas/ToolDockerfile'
-        '404':
+                $ref: "#/components/schemas/ToolDockerfile"
+        "404":
           description: The tool payload is not present in the service.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ToolDockerfile'
+                $ref: "#/components/schemas/ToolDockerfile"
             text/plain:
               schema:
-                $ref: '#/components/schemas/ToolDockerfile'
-  '/api/ga4gh/v1/tools/{id}/versions/{version_id}/{type}/descriptor':
+                $ref: "#/components/schemas/ToolDockerfile"
+  "/api/ga4gh/v1/tools/{id}/versions/{version_id}/{type}/descriptor":
     get:
       tags:
         - GA4GHV1
@@ -324,8 +308,7 @@ paths:
       parameters:
         - name: type
           in: path
-          description: >-
-            The output type of the descriptor. If not specified it is up to the
+          description: The output type of the descriptor. If not specified it is up to the
             underlying implementation to determine which output type to return.
             Plain types return the bare descriptor while the "non-plain" types
             return a descriptor wrapped with metadata
@@ -339,56 +322,52 @@ paths:
               - PLAIN_WDL
         - name: id
           in: path
-          description: >-
-            A unique identifier of the tool, scoped to this registry, for
+          description: A unique identifier of the tool, scoped to this registry, for
             example `123456`
           required: true
           schema:
             type: string
         - name: version_id
           in: path
-          description: >-
-            An identifier of the tool version for this particular tool registry,
+          description: An identifier of the tool version for this particular tool registry,
             for example `v1`
           required: true
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: The tool descriptor.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ToolDescriptor'
+                $ref: "#/components/schemas/ToolDescriptor"
             text/plain:
               schema:
-                $ref: '#/components/schemas/ToolDescriptor'
-        '404':
+                $ref: "#/components/schemas/ToolDescriptor"
+        "404":
           description: The tool can not be output in the specified type.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ToolDescriptor'
+                $ref: "#/components/schemas/ToolDescriptor"
             text/plain:
               schema:
-                $ref: '#/components/schemas/ToolDescriptor'
-  '/api/ga4gh/v1/tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}':
+                $ref: "#/components/schemas/ToolDescriptor"
+  "/api/ga4gh/v1/tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}":
     get:
       tags:
         - GA4GHV1
       summary: Get additional tool descriptor files (CWL/WDL) relative to the main file
-      description: >-
-        Returns additional CWL or WDL descriptors for the specified tool in the
+      description: Returns additional CWL or WDL descriptors for the specified tool in the
         same or subdirectories
       operationId: toolsIdVersionsVersionIdTypeDescriptorRelativePathGet
       parameters:
         - name: type
           in: path
-          description: >-
-            The output type of the descriptor. If not specified it is up to the
-            underlying implementation to determine which output type to return. 
-            Plain types return the bare descriptor while the "non-plain" types
-            return a descriptor wrapped with metadata
+          description: The output type of the descriptor. If not specified it is up to the
+            underlying implementation to determine which output type to
+            return.  Plain types return the bare descriptor while the
+            "non-plain" types return a descriptor wrapped with metadata
           required: true
           schema:
             type: string
@@ -399,60 +378,56 @@ paths:
               - PLAIN_WDL
         - name: id
           in: path
-          description: >-
-            A unique identifier of the tool, scoped to this registry, for
+          description: A unique identifier of the tool, scoped to this registry, for
             example `123456`
           required: true
           schema:
             type: string
         - name: version_id
           in: path
-          description: >-
-            An identifier of the tool version for this particular tool registry,
+          description: An identifier of the tool version for this particular tool registry,
             for example `v1`
           required: true
           schema:
             type: string
         - name: relative_path
           in: path
-          description: >-
-            A relative path to the additional file (same directory or
+          description: A relative path to the additional file (same directory or
             subdirectories), for example 'foo.cwl' would return a 'foo.cwl' from
             the same directory as the main descriptor
           required: true
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: The tool descriptor.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ToolDescriptor'
+                $ref: "#/components/schemas/ToolDescriptor"
             text/plain:
               schema:
-                $ref: '#/components/schemas/ToolDescriptor'
-        '404':
+                $ref: "#/components/schemas/ToolDescriptor"
+        "404":
           description: The tool can not be output in the specified type.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ToolDescriptor'
+                $ref: "#/components/schemas/ToolDescriptor"
             text/plain:
               schema:
-                $ref: '#/components/schemas/ToolDescriptor'
-  '/api/ga4gh/v1/tools/{id}/versions/{version_id}/{type}/tests':
+                $ref: "#/components/schemas/ToolDescriptor"
+  "/api/ga4gh/v1/tools/{id}/versions/{version_id}/{type}/tests":
     get:
       tags:
         - GA4GHV1
       summary: Get an array of test JSONs suitable for use with this descriptor type.
-      description: ''
+      description: ""
       operationId: toolsIdVersionsVersionIdTypeTestsGet
       parameters:
         - name: type
           in: path
-          description: >-
-            The output type of the descriptor. If not specified it is up to the
+          description: The output type of the descriptor. If not specified it is up to the
             underlying implementation to determine which output type to return.
             Plain types return the bare descriptor while the "non-plain" types
             return a descriptor wrapped with metadata
@@ -466,84 +441,82 @@ paths:
               - PLAIN_WDL
         - name: id
           in: path
-          description: >-
-            A unique identifier of the tool, scoped to this registry, for
+          description: A unique identifier of the tool, scoped to this registry, for
             example `123456`
           required: true
           schema:
             type: string
         - name: version_id
           in: path
-          description: >-
-            An identifier of the tool version for this particular tool registry,
+          description: An identifier of the tool version for this particular tool registry,
             for example `v1`
           required: true
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: The tool test JSON response.
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolTestsV1'
+                  $ref: "#/components/schemas/ToolTestsV1"
             text/plain:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolTestsV1'
-        '404':
+                  $ref: "#/components/schemas/ToolTestsV1"
+        "404":
           description: The tool can not be output in the specified type.
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolTestsV1'
+                  $ref: "#/components/schemas/ToolTestsV1"
             text/plain:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolTestsV1'
-  '/api/ga4gh/v2/extended/containers/{organization}':
+                  $ref: "#/components/schemas/ToolTestsV1"
+  "/api/ga4gh/v2/extended/containers/{organization}":
     get:
       tags:
         - extendedGA4GH
       summary: List entries of an organization
-      description: 'This endpoint returns entries of an organization. '
+      description: "This endpoint returns entries of an organization. "
       operationId: entriesOrgGet
       parameters:
         - name: organization
           in: path
-          description: 'An organization, for example `cancercollaboratory`'
+          description: An organization, for example `cancercollaboratory`
           required: true
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: An array of Tools of the input organization.
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolV1'
+                  $ref: "#/components/schemas/ToolV1"
             text/plain:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolV1'
+                  $ref: "#/components/schemas/ToolV1"
   /api/ga4gh/v2/extended/organizations:
     get:
       tags:
         - extendedGA4GH
       summary: List all organizations
-      description: 'This endpoint returns list of all organizations. '
+      description: "This endpoint returns list of all organizations. "
       operationId: entriesOrgGet
       responses:
-        '200':
+        "200":
           description: An array of organizations' names.
           content:
             application/json:
@@ -561,17 +534,9 @@ paths:
       tags:
         - extendedGA4GH
       summary: Search the index of tools
-      description: >-
-        This endpoint searches the index for all published tools and workflows.
+      description: This endpoint searches the index for all published tools and workflows.
         Used by utilities that expect to talk to an elastic search endpoint
       operationId: toolsIndexSearch
-      responses:
-        '200':
-          description: An elastic search result.
-          content:
-            application/json:
-              schema:
-                type: string
       requestBody:
         content:
           application/json:
@@ -579,114 +544,116 @@ paths:
               type: string
         description: elastic search query
         required: true
+      responses:
+        "200":
+          description: An elastic search result.
+          content:
+            application/json:
+              schema:
+                type: string
   /api/ga4gh/v2/extended/tools/index:
     post:
       tags:
         - extendedGA4GH
       summary: Update the index of tools
-      description: 'This endpoint updates the index for all published tools and workflows. '
+      description: "This endpoint updates the index for all published tools and workflows. "
       operationId: toolsIndexGet
       responses:
-        '200':
+        "200":
           description: An array of Tools of the input organization.
       security:
-        - BEARER: []
-  '/api/ga4gh/v2/extended/tools/{organization}':
+        - BEARER:
+            []
+  "/api/ga4gh/v2/extended/tools/{organization}":
     get:
       tags:
         - extendedGA4GH
       summary: List tools of an organization
-      description: 'This endpoint returns tools of an organization. '
+      description: "This endpoint returns tools of an organization. "
       operationId: toolsOrgGet
       parameters:
         - name: organization
           in: path
-          description: 'An organization, for example `cancercollaboratory`'
+          description: An organization, for example `cancercollaboratory`
           required: true
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: An array of Tools of the input organization.
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolV1'
+                  $ref: "#/components/schemas/ToolV1"
             text/plain:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolV1'
-  '/api/ga4gh/v2/extended/workflows/{organization}':
+                  $ref: "#/components/schemas/ToolV1"
+  "/api/ga4gh/v2/extended/workflows/{organization}":
     get:
       tags:
         - extendedGA4GH
       summary: List workflows of an organization
-      description: 'This endpoint returns workflows of an organization. '
+      description: "This endpoint returns workflows of an organization. "
       operationId: workflowsOrgGet
       parameters:
         - name: organization
           in: path
-          description: 'An organization, for example `cancercollaboratory`'
+          description: An organization, for example `cancercollaboratory`
           required: true
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: An array of Tools of the input organization.
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolV1'
+                  $ref: "#/components/schemas/ToolV1"
             text/plain:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolV1'
-  '/api/ga4gh/v2/extended/{id}/versions/{version_id}/{type}/tests/{relative_path}':
+                  $ref: "#/components/schemas/ToolV1"
+  "/api/ga4gh/v2/extended/{id}/versions/{version_id}/{type}/tests/{relative_path}":
     post:
       tags:
         - extendedGA4GH
-      summary: >-
-        Annotate test JSON with information on whether it ran successfully on
+      summary: Annotate test JSON with information on whether it ran successfully on
         particular platforms plus metadata
-      description: >-
-        Test JSON can be annotated with whether they ran correctly keyed by
-        platform and associated with some metadata 
+      description: "Test JSON can be annotated with whether they ran correctly keyed by
+        platform and associated with some metadata "
       operationId: toolsIdVersionsVersionIdTypeTestsPost
       parameters:
         - name: type
           in: path
-          description: >-
-            The type of the underlying descriptor. Allowable values include
+          description: The type of the underlying descriptor. Allowable values include
             "CWL", "WDL", "NFL".
           required: true
           schema:
             type: string
         - name: id
           in: path
-          description: >-
-            A unique identifier of the tool, scoped to this registry, for
+          description: A unique identifier of the tool, scoped to this registry, for
             example `123456`
           required: true
           schema:
             type: string
         - name: version_id
           in: path
-          description: >-
-            An identifier of the tool version for this particular tool registry,
+          description: An identifier of the tool version for this particular tool registry,
             for example `v1`
           required: true
           schema:
             type: string
         - name: relative_path
           in: path
-          description: >-
-            A relative path to the test json as retrieved from the files
+          description: A relative path to the test json as retrieved from the files
             endpoint or the tests endpoint
           required: true
           schema:
@@ -706,18 +673,18 @@ paths:
             type: string
         - name: verified
           in: query
-          description: 'Verification status, omit to delete key'
+          description: Verification status, omit to delete key
           required: false
           schema:
             type: boolean
         - name: metadata
           in: query
-          description: 'Additional information on the verification (notes, explanation)'
+          description: Additional information on the verification (notes, explanation)
           required: true
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: The tool test JSON response.
           content:
             application/json:
@@ -725,20 +692,21 @@ paths:
                 type: object
                 additionalProperties:
                   type: object
-        '401':
+        "401":
           description: Credentials not provided or incorrect
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-        '404':
+                $ref: "#/components/schemas/Error"
+        "404":
           description: The tool test cannot be found to annotate.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
       security:
-        - BEARER: []
+        - BEARER:
+            []
   /api/ga4gh/v2/metadata:
     get:
       tags:
@@ -747,58 +715,55 @@ paths:
       description: Return some metadata that is useful for describing this registry
       operationId: metadataGet
       responses:
-        '200':
+        "200":
           description: A Metadata object describing this service.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Metadata'
+                $ref: "#/components/schemas/Metadata"
             text/plain:
               schema:
-                $ref: '#/components/schemas/Metadata'
+                $ref: "#/components/schemas/Metadata"
   /api/ga4gh/v2/toolClasses:
     get:
       tags:
         - GA4GH
       summary: List all tool types
-      description: 'This endpoint returns all tool-classes available '
+      description: "This endpoint returns all tool-classes available "
       operationId: toolClassesGet
       responses:
-        '200':
+        "200":
           description: A list of potential tool classes.
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolClass'
+                  $ref: "#/components/schemas/ToolClass"
             text/plain:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolClass'
+                  $ref: "#/components/schemas/ToolClass"
   /api/ga4gh/v2/tools:
     get:
       tags:
         - GA4GH
       summary: List all tools
-      description: >-
-        This endpoint returns all tools available or a filtered subset using
-        metadata query parameters. 
+      description: "This endpoint returns all tools available or a filtered subset using
+        metadata query parameters. "
       operationId: toolsGet
       parameters:
         - name: id
           in: query
-          description: >-
-            A unique identifier of the tool, scoped to this registry, for
+          description: A unique identifier of the tool, scoped to this registry, for
             example `123456`
           required: false
           schema:
             type: string
         - name: alias
           in: query
-          description: >-
-            OPTIONAL for tool registries that support aliases. If provided will
+          description: OPTIONAL for tool registries that support aliases. If provided will
             only return entries with the given alias.
           required: false
           schema:
@@ -835,8 +800,7 @@ paths:
             type: string
         - name: author
           in: query
-          description: >-
-            The author of the tool (TODO a thought occurs, are we assuming that
+          description: The author of the tool (TODO a thought occurs, are we assuming that
             the author of the CWL and the image are the same?).
           required: false
           schema:
@@ -849,8 +813,7 @@ paths:
             type: boolean
         - name: offset
           in: query
-          description: >-
-            Start index of paging. Pagination results can be based on numbers or
+          description: Start index of paging. Pagination results can be based on numbers or
             other values chosen by the registry implementor (for example, SHA
             values). If this exceeds the current result set return an empty
             set.  If not specified in the request, this will start at the
@@ -867,57 +830,55 @@ paths:
             format: int32
             default: 1000
       responses:
-        '200':
+        "200":
           description: An array of Tools that match the filter.
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Tool'
+                  $ref: "#/components/schemas/Tool"
             text/plain:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Tool'
-  '/api/ga4gh/v2/tools/{id}':
+                  $ref: "#/components/schemas/Tool"
+  "/api/ga4gh/v2/tools/{id}":
     get:
       tags:
         - GA4GH
-      summary: 'List one specific tool, acts as an anchor for self references'
-      description: >-
-        This endpoint returns one specific tool (which has ToolVersions nested
+      summary: List one specific tool, acts as an anchor for self references
+      description: This endpoint returns one specific tool (which has ToolVersions nested
         inside it)
       operationId: toolsIdGet
       parameters:
         - name: id
           in: path
-          description: >-
-            A unique identifier of the tool, scoped to this registry, for
+          description: A unique identifier of the tool, scoped to this registry, for
             example `123456`
           required: true
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: A tool.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Tool'
+                $ref: "#/components/schemas/Tool"
             text/plain:
               schema:
-                $ref: '#/components/schemas/Tool'
-        '404':
+                $ref: "#/components/schemas/Tool"
+        "404":
           description: The tool can not be found.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
             text/plain:
               schema:
-                $ref: '#/components/schemas/Error'
-  '/api/ga4gh/v2/tools/{id}/versions':
+                $ref: "#/components/schemas/Error"
+  "/api/ga4gh/v2/tools/{id}/versions":
     get:
       tags:
         - GA4GH
@@ -927,76 +888,72 @@ paths:
       parameters:
         - name: id
           in: path
-          description: >-
-            A unique identifier of the tool, scoped to this registry, for
+          description: A unique identifier of the tool, scoped to this registry, for
             example `123456`
           required: true
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: An array of tool versions
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolVersion'
+                  $ref: "#/components/schemas/ToolVersion"
             text/plain:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolVersion'
-  '/api/ga4gh/v2/tools/{id}/versions/{version_id}':
+                  $ref: "#/components/schemas/ToolVersion"
+  "/api/ga4gh/v2/tools/{id}/versions/{version_id}":
     get:
       tags:
         - GA4GH
-      summary: 'List one specific tool version, acts as an anchor for self references'
+      summary: List one specific tool version, acts as an anchor for self references
       description: This endpoint returns one specific tool version
       operationId: toolsIdVersionsVersionIdGet
       parameters:
         - name: id
           in: path
-          description: >-
-            A unique identifier of the tool, scoped to this registry, for
+          description: A unique identifier of the tool, scoped to this registry, for
             example `123456`
           required: true
           schema:
             type: string
         - name: version_id
           in: path
-          description: >-
-            An identifier of the tool version, scoped to this registry, for
+          description: An identifier of the tool version, scoped to this registry, for
             example `v1`
           required: true
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: A tool version.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ToolVersion'
+                $ref: "#/components/schemas/ToolVersion"
             text/plain:
               schema:
-                $ref: '#/components/schemas/ToolVersion'
-        '404':
+                $ref: "#/components/schemas/ToolVersion"
+        "404":
           description: The tool can not be found.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
             text/plain:
               schema:
-                $ref: '#/components/schemas/Error'
-  '/api/ga4gh/v2/tools/{id}/versions/{version_id}/containerfile':
+                $ref: "#/components/schemas/Error"
+  "/api/ga4gh/v2/tools/{id}/versions/{version_id}/containerfile":
     get:
       tags:
         - GA4GH
       summary: Get the container specification(s) for the specified image.
-      description: >-
-        Returns the container specifications(s) for the specified image. For
+      description: Returns the container specifications(s) for the specified image. For
         example, a CWL CommandlineTool can be associated with one specification
         for a container, a CWL Workflow can be associated with multiple
         specifications for containers
@@ -1004,57 +961,53 @@ paths:
       parameters:
         - name: id
           in: path
-          description: >-
-            A unique identifier of the tool, scoped to this registry, for
+          description: A unique identifier of the tool, scoped to this registry, for
             example `123456`
           required: true
           schema:
             type: string
         - name: version_id
           in: path
-          description: >-
-            An identifier of the tool version for this particular tool registry,
+          description: An identifier of the tool version for this particular tool registry,
             for example `v1`
           required: true
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: The tool payload.
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/FileWrapper'
+                  $ref: "#/components/schemas/FileWrapper"
             text/plain:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/FileWrapper'
-        '404':
+                  $ref: "#/components/schemas/FileWrapper"
+        "404":
           description: There are no container specifications for this tool
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
             text/plain:
               schema:
-                $ref: '#/components/schemas/Error'
-  '/api/ga4gh/v2/tools/{id}/versions/{version_id}/{type}/descriptor':
+                $ref: "#/components/schemas/Error"
+  "/api/ga4gh/v2/tools/{id}/versions/{version_id}/{type}/descriptor":
     get:
       tags:
         - GA4GH
       summary: Get the tool descriptor for the specified tool
-      description: >-
-        Returns the descriptor for the specified tool (examples include CWL,
+      description: Returns the descriptor for the specified tool (examples include CWL,
         WDL, or Nextflow documents).
       operationId: toolsIdVersionsVersionIdTypeDescriptorGet
       parameters:
         - name: type
           in: path
-          description: >-
-            The output type of the descriptor. If not specified, it is up to the
+          description: The output type of the descriptor. If not specified, it is up to the
             underlying implementation to determine which output type to return.
             Plain types return the bare descriptor while the "non-plain" types
             return a descriptor wrapped with metadata. Allowable values include
@@ -1064,58 +1017,54 @@ paths:
             type: string
         - name: id
           in: path
-          description: >-
-            A unique identifier of the tool, scoped to this registry, for
+          description: A unique identifier of the tool, scoped to this registry, for
             example `123456`
           required: true
           schema:
             type: string
         - name: version_id
           in: path
-          description: >-
-            An identifier of the tool version, scoped to this registry, for
+          description: An identifier of the tool version, scoped to this registry, for
             example `v1`
           required: true
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: The tool descriptor.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/FileWrapper'
+                $ref: "#/components/schemas/FileWrapper"
             text/plain:
               schema:
-                $ref: '#/components/schemas/FileWrapper'
-        '404':
+                $ref: "#/components/schemas/FileWrapper"
+        "404":
           description: The tool descriptor can not be found.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
             text/plain:
               schema:
-                $ref: '#/components/schemas/Error'
-  '/api/ga4gh/v2/tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}':
+                $ref: "#/components/schemas/Error"
+  "/api/ga4gh/v2/tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}":
     get:
       tags:
         - GA4GH
       summary: Get additional tool descriptor files relative to the main file
-      description: >-
-        Descriptors can often include imports that refer to additional
+      description: "Descriptors can often include imports that refer to additional
         descriptors. This returns additional descriptors for the specified tool
         in the same or other directories that can be reached as a relative path.
         This endpoint can be useful for workflow engine implementations like
         cwltool to programmatically download all the descriptors for a tool and
         run it. This can optionally include other files described with
-        FileWrappers such as test parameters and containerfiles. 
+        FileWrappers such as test parameters and containerfiles. "
       operationId: toolsIdVersionsVersionIdTypeDescriptorRelativePathGet
       parameters:
         - name: type
           in: path
-          description: >-
-            The output type of the descriptor. If not specified, it is up to the
+          description: The output type of the descriptor. If not specified, it is up to the
             underlying implementation to determine which output type to return.
             Plain types return the bare descriptor while the "non-plain" types
             return a descriptor wrapped with metadata. Allowable values are
@@ -1125,24 +1074,21 @@ paths:
             type: string
         - name: id
           in: path
-          description: >-
-            A unique identifier of the tool, scoped to this registry, for
+          description: A unique identifier of the tool, scoped to this registry, for
             example `123456`
           required: true
           schema:
             type: string
         - name: version_id
           in: path
-          description: >-
-            An identifier of the tool version for this particular tool registry,
+          description: An identifier of the tool version for this particular tool registry,
             for example `v1`
           required: true
           schema:
             type: string
         - name: relative_path
           in: path
-          description: >-
-            A relative path to the additional file (same directory or
+          description: A relative path to the additional file (same directory or
             subdirectories), for example 'foo.cwl' would return a 'foo.cwl' from
             the same directory as the main descriptor. 'nestedDirectory/foo.cwl'
             would return the file  from a nested subdirectory.  Unencoded paths
@@ -1152,150 +1098,141 @@ paths:
             type: string
             pattern: .+
       responses:
-        '200':
+        "200":
           description: The tool descriptor.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/FileWrapper'
+                $ref: "#/components/schemas/FileWrapper"
             text/plain:
               schema:
-                $ref: '#/components/schemas/FileWrapper'
-        '404':
+                $ref: "#/components/schemas/FileWrapper"
+        "404":
           description: The tool can not be output in the specified type.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
             text/plain:
               schema:
-                $ref: '#/components/schemas/Error'
-  '/api/ga4gh/v2/tools/{id}/versions/{version_id}/{type}/files':
+                $ref: "#/components/schemas/Error"
+  "/api/ga4gh/v2/tools/{id}/versions/{version_id}/{type}/files":
     get:
       tags:
         - GA4GH
       summary: Get a list of objects that contain the relative path and file type
-      description: >-
-        Get a list of objects that contain the relative path and file type. The
+      description: "Get a list of objects that contain the relative path and file type. The
         descriptors are intended for use with the
         /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path : .+}
-        endpoint.
+        endpoint."
       operationId: toolsIdVersionsVersionIdTypeFilesGet
       parameters:
         - name: type
           in: path
-          description: >-
-            The output type of the descriptor. Examples of allowable values are
+          description: The output type of the descriptor. Examples of allowable values are
             "CWL", "WDL", and "NextFlow."
           required: true
           schema:
             type: string
         - name: id
           in: path
-          description: >-
-            A unique identifier of the tool, scoped to this registry, for
+          description: A unique identifier of the tool, scoped to this registry, for
             example `123456`
           required: true
           schema:
             type: string
         - name: version_id
           in: path
-          description: >-
-            An identifier of the tool version for this particular tool registry,
+          description: An identifier of the tool version for this particular tool registry,
             for example `v1`
           required: true
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: The array of File JSON responses.
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolFile'
+                  $ref: "#/components/schemas/ToolFile"
             text/plain:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ToolFile'
-        '404':
+                  $ref: "#/components/schemas/ToolFile"
+        "404":
           description: The tool can not be output in the specified type.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
             text/plain:
               schema:
-                $ref: '#/components/schemas/Error'
-  '/api/ga4gh/v2/tools/{id}/versions/{version_id}/{type}/tests':
+                $ref: "#/components/schemas/Error"
+  "/api/ga4gh/v2/tools/{id}/versions/{version_id}/{type}/tests":
     get:
       tags:
         - GA4GH
       summary: Get a list of test JSONs
-      description: >-
-        Get a list of test JSONs (these allow you to execute the tool
+      description: Get a list of test JSONs (these allow you to execute the tool
         successfully) suitable for use with this descriptor type.
       operationId: toolsIdVersionsVersionIdTypeTestsGet
       parameters:
         - name: type
           in: path
-          description: >-
-            The type of the underlying descriptor. Allowable values include
+          description: 'The type of the underlying descriptor. Allowable values include
             "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL". For
             example, "CWL" would return an list of ToolTests objects while
             "PLAIN_CWL" would return a bare JSON list with the content of the
-            tests. 
+            tests. '
           required: true
           schema:
             type: string
         - name: id
           in: path
-          description: >-
-            A unique identifier of the tool, scoped to this registry, for
+          description: A unique identifier of the tool, scoped to this registry, for
             example `123456`
           required: true
           schema:
             type: string
         - name: version_id
           in: path
-          description: >-
-            An identifier of the tool version for this particular tool registry,
+          description: An identifier of the tool version for this particular tool registry,
             for example `v1`
           required: true
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: The tool test JSON response.
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/FileWrapper'
+                  $ref: "#/components/schemas/FileWrapper"
             text/plain:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/FileWrapper'
-        '404':
+                  $ref: "#/components/schemas/FileWrapper"
+        "404":
           description: The tool can not be output in the specified type.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
             text/plain:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
   /auth/tokens/bitbucket.org:
     get:
       tags:
         - tokens
-      summary: 'Add a new bitbucket.org token, used by quay.io redirect.'
-      description: >-
-        This is used as part of the OAuth 2 web flow. Once a user has approved
+      summary: Add a new bitbucket.org token, used by quay.io redirect.
+      description: This is used as part of the OAuth 2 web flow. Once a user has approved
         permissions for CollaboratoryTheir browser will load the redirect URI
         which should resolve here
       operationId: addBitbucketToken
@@ -1306,41 +1243,41 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token'
+                $ref: "#/components/schemas/Token"
       security:
-        - BEARER: []
+        - BEARER:
+            []
   /auth/tokens/github:
     post:
       tags:
         - tokens
-      summary: >-
-        Allow satellizer to post a new GitHub token to dockstore, used by login,
+      summary: Allow satellizer to post a new GitHub token to dockstore, used by login,
         can create new users.
       description: A post method is required by saetillizer to send the GitHub token
       operationId: addToken
+      requestBody:
+        $ref: "#/components/requestBodies/addTokenBody"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token'
+                $ref: "#/components/schemas/Token"
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/addTokenBody'
+        - BEARER:
+            []
   /auth/tokens/github.com:
     get:
       tags:
         - tokens
-      summary: 'Add a new github.com token, used by accounts page.'
-      description: >-
-        This is used as part of the OAuth 2 web flow. Once a user has approved
+      summary: Add a new github.com token, used by accounts page.
+      description: This is used as part of the OAuth 2 web flow. Once a user has approved
         permissions for CollaboratoryTheir browser will load the redirect URI
         which should resolve here
       operationId: addGithubToken
@@ -1351,21 +1288,21 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token'
+                $ref: "#/components/schemas/Token"
       security:
-        - BEARER: []
+        - BEARER:
+            []
   /auth/tokens/gitlab.com:
     get:
       tags:
         - tokens
       summary: Add a new gitlab.com token.
-      description: >-
-        This is used as part of the OAuth 2 web flow. Once a user has approved
+      description: This is used as part of the OAuth 2 web flow. Once a user has approved
         permissions for CollaboratoryTheir browser will load the redirect URI
         which should resolve here
       operationId: addGitlabToken
@@ -1376,14 +1313,15 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token'
+                $ref: "#/components/schemas/Token"
       security:
-        - BEARER: []
+        - BEARER:
+            []
   /auth/tokens/google:
     post:
       tags:
@@ -1391,24 +1329,24 @@ paths:
       summary: Allow satellizer to post a new Google token to Dockstore.
       description: A post method is required by satellizer to send the Google token
       operationId: addGoogleToken
+      requestBody:
+        $ref: "#/components/requestBodies/addTokenBody"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token'
+                $ref: "#/components/schemas/Token"
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/addTokenBody'
+        - BEARER:
+            []
   /auth/tokens/quay.io:
     get:
       tags:
         - tokens
       summary: Add a new quay IO token.
-      description: >-
-        This is used as part of the OAuth 2 web flow. Once a user has approved
+      description: This is used as part of the OAuth 2 web flow. Once a user has approved
         permissions for CollaboratoryTheir browser will load the redirect URI
         which should resolve here
       operationId: addQuayToken
@@ -1419,20 +1357,21 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token'
+                $ref: "#/components/schemas/Token"
       security:
-        - BEARER: []
-  '/auth/tokens/{tokenId}':
+        - BEARER:
+            []
+  "/auth/tokens/{tokenId}":
     get:
       tags:
         - tokens
       summary: Get a specific token by id.
-      description: ''
+      description: ""
       operationId: listToken
       parameters:
         - name: tokenId
@@ -1443,23 +1382,24 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token'
-        '400':
+                $ref: "#/components/schemas/Token"
+        "400":
           description: Invalid ID supplied
-        '404':
+        "404":
           description: Token not found
       security:
-        - BEARER: []
+        - BEARER:
+            []
     delete:
       tags:
         - tokens
       summary: Delete a token.
-      description: ''
+      description: ""
       operationId: deleteToken
       parameters:
         - name: tokenId
@@ -1470,10 +1410,11 @@ paths:
             type: integer
             format: int64
       responses:
-        '400':
+        "400":
           description: Invalid token value
       security:
-        - BEARER: []
+        - BEARER:
+            []
   /containers/dockerRegistryList:
     get:
       tags:
@@ -1482,20 +1423,20 @@ paths:
       description: Does not need authentication
       operationId: getDockerRegistries
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/RegistryBean'
+                  $ref: "#/components/schemas/RegistryBean"
   /containers/hostedEntry:
     post:
       tags:
         - hosted
       summary: Create a hosted tool.
-      description: ''
+      description: ""
       operationId: createHostedTool
       parameters:
         - name: registry
@@ -1529,20 +1470,21 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockstoreTool'
+                $ref: "#/components/schemas/DockstoreTool"
       security:
-        - BEARER: []
-  '/containers/hostedEntry/{entryId}':
+        - BEARER:
+            []
+  "/containers/hostedEntry/{entryId}":
     delete:
       tags:
         - hosted
       summary: Delete a revision of a hosted tool.
-      description: ''
+      description: ""
       operationId: deleteHostedToolVersion
       parameters:
         - name: entryId
@@ -1559,19 +1501,20 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockstoreTool'
+                $ref: "#/components/schemas/DockstoreTool"
       security:
-        - BEARER: []
+        - BEARER:
+            []
     patch:
       tags:
         - hosted
       summary: Non-idempotent operation for creating new revisions of hosted tools.
-      description: ''
+      description: ""
       operationId: editHostedTool
       parameters:
         - name: entryId
@@ -1581,18 +1524,19 @@ paths:
           schema:
             type: integer
             format: int64
+      requestBody:
+        $ref: "#/components/requestBodies/SourceFileArray"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockstoreTool'
+                $ref: "#/components/schemas/DockstoreTool"
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/SourceFileArray'
-  '/containers/namespace/{namespace}/published':
+        - BEARER:
+            []
+  "/containers/namespace/{namespace}/published":
     get:
       tags:
         - containers
@@ -1607,15 +1551,15 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DockstoreTool'
-  '/containers/path/tool/{repository}':
+                  $ref: "#/components/schemas/DockstoreTool"
+  "/containers/path/tool/{repository}":
     get:
       tags:
         - containers
@@ -1631,20 +1575,21 @@ paths:
             type: string
         - name: include
           in: query
-          description: 'Comma-delimited list of fields to include: validations'
+          description: "Comma-delimited list of fields to include: validations"
           required: false
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockstoreTool'
+                $ref: "#/components/schemas/DockstoreTool"
       security:
-        - BEARER: []
-  '/containers/path/tool/{repository}/published':
+        - BEARER:
+            []
+  "/containers/path/tool/{repository}/published":
     get:
       tags:
         - containers
@@ -1660,23 +1605,23 @@ paths:
             type: string
         - name: include
           in: query
-          description: 'Comma-delimited list of fields to include: validations'
+          description: "Comma-delimited list of fields to include: validations"
           required: false
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockstoreTool'
-  '/containers/path/{containerId}/tags':
+                $ref: "#/components/schemas/DockstoreTool"
+  "/containers/path/{containerId}/tags":
     get:
       tags:
         - containertags
       summary: Get tags for a tool by id.
-      description: ''
+      description: ""
       operationId: getTagsByPath
       parameters:
         - name: containerId
@@ -1687,7 +1632,7 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
@@ -1695,10 +1640,11 @@ paths:
                 type: array
                 uniqueItems: true
                 items:
-                  $ref: '#/components/schemas/Tag'
+                  $ref: "#/components/schemas/Tag"
       security:
-        - BEARER: []
-  '/containers/path/{repository}':
+        - BEARER:
+            []
+  "/containers/path/{repository}":
     get:
       tags:
         - containers
@@ -1713,17 +1659,18 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DockstoreTool'
+                  $ref: "#/components/schemas/DockstoreTool"
       security:
-        - BEARER: []
-  '/containers/path/{repository}/published':
+        - BEARER:
+            []
+  "/containers/path/{repository}/published":
     get:
       tags:
         - containers
@@ -1738,12 +1685,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockstoreTool'
+                $ref: "#/components/schemas/DockstoreTool"
   /containers/published:
     get:
       tags:
@@ -1754,8 +1701,7 @@ paths:
       parameters:
         - name: offset
           in: query
-          description: >-
-            Start index of paging. Pagination results can be based on numbers or
+          description: Start index of paging. Pagination results can be based on numbers or
             other values chosen by the registry implementor (for example, SHA
             values). If this exceeds the current result set return an empty
             set.  If not specified in the request, this will start at the
@@ -1765,7 +1711,7 @@ paths:
             type: string
         - name: limit
           in: query
-          description: 'Amount of records to return in a given page, limited to 100'
+          description: Amount of records to return in a given page, limited to 100
           required: false
           schema:
             type: integer
@@ -1775,7 +1721,7 @@ paths:
             default: 100
         - name: filter
           in: query
-          description: 'Filter, this is a search string that filters the results.'
+          description: Filter, this is a search string that filters the results.
           required: false
           schema:
             type: string
@@ -1797,15 +1743,15 @@ paths:
               - desc
             default: desc
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DockstoreTool'
-  '/containers/published/{containerId}':
+                  $ref: "#/components/schemas/DockstoreTool"
+  "/containers/published/{containerId}":
     get:
       tags:
         - containers
@@ -1822,41 +1768,42 @@ paths:
             format: int64
         - name: include
           in: query
-          description: 'Comma-delimited list of fields to include: validations'
+          description: "Comma-delimited list of fields to include: validations"
           required: false
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockstoreTool'
+                $ref: "#/components/schemas/DockstoreTool"
   /containers/registerManual:
     post:
       tags:
         - containers
-      summary: 'Register a tool manually, along with tags.'
-      description: ''
+      summary: Register a tool manually, along with tags.
+      description: ""
       operationId: registerManual
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DockstoreTool'
-      security:
-        - BEARER: []
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DockstoreTool'
+              $ref: "#/components/schemas/DockstoreTool"
         description: Tool to be registered
         required: true
-  '/containers/schema/{containerId}/published':
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DockstoreTool"
+      security:
+        - BEARER:
+            []
+  "/containers/schema/{containerId}/published":
     get:
       tags:
         - containers
@@ -1872,7 +1819,7 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
@@ -1882,13 +1829,12 @@ paths:
                   type: array
                   items:
                     type: object
-  '/containers/{containerId}':
+  "/containers/{containerId}":
     get:
       tags:
         - containers
       summary: Retrieve a tool.
-      description: >-
-        This is one of the few endpoints that returns the user object with
+      description: This is one of the few endpoints that returns the user object with
         populated properties (minus the userProfiles property)
       operationId: getContainer
       parameters:
@@ -1901,25 +1847,25 @@ paths:
             format: int64
         - name: include
           in: query
-          description: 'Comma-delimited list of fields to include: validations'
+          description: "Comma-delimited list of fields to include: validations"
           required: false
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockstoreTool'
+                $ref: "#/components/schemas/DockstoreTool"
       security:
-        - BEARER: []
+        - BEARER:
+            []
     put:
       tags:
         - containers
       summary: Update the tool with the given tool.
-      description: >-
-        Updates default descriptor paths, default Docker paths, default test
+      description: Updates default descriptor paths, default Docker paths, default test
         parameter paths, git url, and default version. Also updates tool
         maintainer email, and private access for manual tools.
       operationId: updateContainer
@@ -1931,22 +1877,23 @@ paths:
           schema:
             type: integer
             format: int64
+      requestBody:
+        $ref: "#/components/requestBodies/DockstoreTool"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockstoreTool'
+                $ref: "#/components/schemas/DockstoreTool"
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/DockstoreTool'
+        - BEARER:
+            []
     delete:
       tags:
         - containers
       summary: Delete a tool.
-      description: ''
+      description: ""
       operationId: deleteContainer
       parameters:
         - name: containerId
@@ -1957,17 +1904,17 @@ paths:
             type: integer
             format: int64
       responses:
-        '400':
-          description: 'Invalid '
+        "400":
+          description: "Invalid "
       security:
-        - BEARER: []
-  '/containers/{containerId}/cwl':
+        - BEARER:
+            []
+  "/containers/{containerId}/cwl":
     get:
       tags:
         - containers
       summary: Get the primary CWL descriptor file on Github.
-      description: >-
-        Does not require authentication for published tools, authentication can
+      description: Does not require authentication for published tools, authentication can
         be provided for restricted tools
       operationId: cwl
       parameters:
@@ -1984,21 +1931,21 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SourceFile'
+                $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-  '/containers/{containerId}/cwl/{relative-path}':
+        - BEARER:
+            []
+  "/containers/{containerId}/cwl/{relative-path}":
     get:
       tags:
         - containers
       summary: Get the corresponding CWL descriptor file on Github.
-      description: >-
-        Does not require authentication for published tools, authentication can
+      description: Does not require authentication for published tools, authentication can
         be provided for restricted tools
       operationId: secondaryCwlPath
       parameters:
@@ -2020,21 +1967,21 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SourceFile'
+                $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-  '/containers/{containerId}/dockerfile':
+        - BEARER:
+            []
+  "/containers/{containerId}/dockerfile":
     get:
       tags:
         - containers
       summary: Get the corresponding Dockerfile on Github.
-      description: >-
-        Does not require authentication for published tools, authentication can
+      description: Does not require authentication for published tools, authentication can
         be provided for restricted tools
       operationId: dockerfile
       parameters:
@@ -2051,21 +1998,21 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SourceFile'
+                $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-  '/containers/{containerId}/labels':
+        - BEARER:
+            []
+  "/containers/{containerId}/labels":
     put:
       tags:
         - containers
       summary: Update the labels linked to a tool.
-      description: >-
-        Labels are alphanumerical (case-insensitive and may contain internal
+      description: Labels are alphanumerical (case-insensitive and may contain internal
         hyphens), given in a comma-delimited list.
       operationId: updateLabels
       parameters:
@@ -2082,23 +2029,24 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        $ref: "#/components/requestBodies/updateLabelsBody"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockstoreTool'
+                $ref: "#/components/schemas/DockstoreTool"
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/updateLabelsBody'
-  '/containers/{containerId}/publish':
+        - BEARER:
+            []
+  "/containers/{containerId}/publish":
     post:
       tags:
         - containers
       summary: Publish or unpublish a tool.
-      description: ''
+      description: ""
       operationId: publish
       parameters:
         - name: containerId
@@ -2108,23 +2056,24 @@ paths:
           schema:
             type: integer
             format: int64
+      requestBody:
+        $ref: "#/components/requestBodies/PublishRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockstoreTool'
+                $ref: "#/components/schemas/DockstoreTool"
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/PublishRequest'
-  '/containers/{containerId}/refresh':
+        - BEARER:
+            []
+  "/containers/{containerId}/refresh":
     get:
       tags:
         - containers
       summary: Refresh one particular tool.
-      description: ''
+      description: ""
       operationId: refresh
       parameters:
         - name: containerId
@@ -2135,20 +2084,21 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockstoreTool'
+                $ref: "#/components/schemas/DockstoreTool"
       security:
-        - BEARER: []
-  '/containers/{containerId}/requestDOI/{tagId}':
+        - BEARER:
+            []
+  "/containers/{containerId}/requestDOI/{tagId}":
     post:
       tags:
         - containertags
       summary: Request a DOI for this version of a tool.
-      description: ''
+      description: ""
       operationId: requestDOIForToolTag
       parameters:
         - name: containerId
@@ -2166,23 +2116,23 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Tag'
+                  $ref: "#/components/schemas/Tag"
       security:
-        - BEARER: []
-  '/containers/{containerId}/secondaryCwl':
+        - BEARER:
+            []
+  "/containers/{containerId}/secondaryCwl":
     get:
       tags:
         - containers
       summary: Get a list of secondary CWL files from Git.
-      description: >-
-        Does not require authentication for published tools, authentication can
+      description: Does not require authentication for published tools, authentication can
         be provided for restricted tools
       operationId: secondaryCwl
       parameters:
@@ -2199,23 +2149,23 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SourceFile'
+                  $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-  '/containers/{containerId}/secondaryWdl':
+        - BEARER:
+            []
+  "/containers/{containerId}/secondaryWdl":
     get:
       tags:
         - containers
       summary: Get a list of secondary WDL files from Git.
-      description: >-
-        Does not require authentication for published tools, authentication can
+      description: Does not require authentication for published tools, authentication can
         be provided for restricted tools
       operationId: secondaryWdl
       parameters:
@@ -2232,22 +2182,23 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SourceFile'
+                  $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-  '/containers/{containerId}/star':
+        - BEARER:
+            []
+  "/containers/{containerId}/star":
     put:
       tags:
         - containers
       summary: Star a tool.
-      description: ''
+      description: ""
       operationId: starEntry
       parameters:
         - name: containerId
@@ -2257,19 +2208,20 @@ paths:
           schema:
             type: integer
             format: int64
+      requestBody:
+        $ref: "#/components/requestBodies/StarRequest"
       responses:
         default:
           description: successful operation
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/StarRequest'
-  '/containers/{containerId}/starredUsers':
+        - BEARER:
+            []
+  "/containers/{containerId}/starredUsers":
     get:
       tags:
         - containers
       summary: Returns list of users who starred a tool.
-      description: ''
+      description: ""
       operationId: getStarredUsers
       parameters:
         - name: containerId
@@ -2280,20 +2232,20 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/User'
-  '/containers/{containerId}/tags':
+                  $ref: "#/components/schemas/User"
+  "/containers/{containerId}/tags":
     post:
       tags:
         - containertags
       summary: Add new tags linked to a tool.
-      description: ''
+      description: ""
       operationId: addTags
       parameters:
         - name: containerId
@@ -2303,31 +2255,32 @@ paths:
           schema:
             type: integer
             format: int64
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Tag'
-      security:
-        - BEARER: []
       requestBody:
         content:
           application/json:
             schema:
               type: array
               items:
-                $ref: '#/components/schemas/Tag'
+                $ref: "#/components/schemas/Tag"
         description: List of new tags
         required: true
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Tag"
+      security:
+        - BEARER:
+            []
     put:
       tags:
         - containertags
       summary: Update the tags linked to a tool.
-      description: ''
+      description: ""
       operationId: updateTags
       parameters:
         - name: containerId
@@ -2337,32 +2290,33 @@ paths:
           schema:
             type: integer
             format: int64
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Tag'
-      security:
-        - BEARER: []
       requestBody:
         content:
           application/json:
             schema:
               type: array
               items:
-                $ref: '#/components/schemas/Tag'
+                $ref: "#/components/schemas/Tag"
         description: List of modified tags
         required: true
-  '/containers/{containerId}/tags/{tagId}':
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Tag"
+      security:
+        - BEARER:
+            []
+  "/containers/{containerId}/tags/{tagId}":
     delete:
       tags:
         - containertags
       summary: Delete tag linked to a tool.
-      description: ''
+      description: ""
       operationId: deleteTags
       parameters:
         - name: containerId
@@ -2383,14 +2337,14 @@ paths:
         default:
           description: successful operation
       security:
-        - BEARER: []
-  '/containers/{containerId}/testParameterFiles':
+        - BEARER:
+            []
+  "/containers/{containerId}/testParameterFiles":
     get:
       tags:
         - containers
       summary: Get the corresponding wdl test parameter files.
-      description: >-
-        Does not require authentication for published tools, authentication can
+      description: Does not require authentication for published tools, authentication can
         be provided for restricted tools
       operationId: getTestParameterFiles
       parameters:
@@ -2417,21 +2371,22 @@ paths:
               - WDL
               - NFL
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SourceFile'
+                  $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
+        - BEARER:
+            []
     put:
       tags:
         - containers
       summary: Add test parameter files to a tag.
-      description: ''
+      description: ""
       operationId: addTestParameterFiles
       parameters:
         - name: containerId
@@ -2464,8 +2419,10 @@ paths:
             enum:
               - CWL
               - WDL
+      requestBody:
+        $ref: "#/components/requestBodies/updateLabelsBody"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
@@ -2473,16 +2430,15 @@ paths:
                 type: array
                 uniqueItems: true
                 items:
-                  $ref: '#/components/schemas/SourceFile'
+                  $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/updateLabelsBody'
+        - BEARER:
+            []
     delete:
       tags:
         - containers
       summary: Delete test parameter files to a tag.
-      description: ''
+      description: ""
       operationId: deleteTestParameterFiles
       parameters:
         - name: containerId
@@ -2516,7 +2472,7 @@ paths:
               - CWL
               - WDL
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
@@ -2524,15 +2480,16 @@ paths:
                 type: array
                 uniqueItems: true
                 items:
-                  $ref: '#/components/schemas/SourceFile'
+                  $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-  '/containers/{containerId}/unstar':
+        - BEARER:
+            []
+  "/containers/{containerId}/unstar":
     delete:
       tags:
         - containers
       summary: Unstar a tool.
-      description: ''
+      description: ""
       operationId: unstarEntry
       parameters:
         - name: containerId
@@ -2546,14 +2503,14 @@ paths:
         default:
           description: successful operation
       security:
-        - BEARER: []
-  '/containers/{containerId}/updateTagPaths':
+        - BEARER:
+            []
+  "/containers/{containerId}/updateTagPaths":
     put:
       tags:
         - containers
       summary: Change the tool paths.
-      description: >-
-        Resets the descriptor paths and dockerfile path of all versions to match
+      description: Resets the descriptor paths and dockerfile path of all versions to match
         the default paths from the tool object passed.
       operationId: updateTagContainerPath
       parameters:
@@ -2564,23 +2521,24 @@ paths:
           schema:
             type: integer
             format: int64
+      requestBody:
+        $ref: "#/components/requestBodies/DockstoreTool"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockstoreTool'
+                $ref: "#/components/schemas/DockstoreTool"
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/DockstoreTool'
-  '/containers/{containerId}/users':
+        - BEARER:
+            []
+  "/containers/{containerId}/users":
     get:
       tags:
         - containers
       summary: Get users of a tool.
-      description: ''
+      description: ""
       operationId: getUsers
       parameters:
         - name: containerId
@@ -2591,17 +2549,18 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/User'
+                  $ref: "#/components/schemas/User"
       security:
-        - BEARER: []
-  '/containers/{containerId}/verifiedSources':
+        - BEARER:
+            []
+  "/containers/{containerId}/verifiedSources":
     get:
       tags:
         - containers
@@ -2617,18 +2576,18 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: string
-  '/containers/{containerId}/verify/{tagId}':
+  "/containers/{containerId}/verify/{tagId}":
     put:
       tags:
         - containertags
       summary: Verify or unverify a version . ADMIN ONLY
-      description: ''
+      description: ""
       operationId: verifyToolTag
       parameters:
         - name: containerId
@@ -2645,26 +2604,26 @@ paths:
           schema:
             type: integer
             format: int64
+      requestBody:
+        $ref: "#/components/requestBodies/VerifyRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Tag'
+                  $ref: "#/components/schemas/Tag"
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/VerifyRequest'
-  '/containers/{containerId}/wdl':
+        - BEARER:
+            []
+  "/containers/{containerId}/wdl":
     get:
       tags:
         - containers
       summary: Get the primary WDL descriptor file on Github.
-      description: >-
-        Does not require authentication for published tools, authentication can
+      description: Does not require authentication for published tools, authentication can
         be provided for restricted tools
       operationId: wdl
       parameters:
@@ -2681,21 +2640,21 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SourceFile'
+                $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-  '/containers/{containerId}/wdl/{relative-path}':
+        - BEARER:
+            []
+  "/containers/{containerId}/wdl/{relative-path}":
     get:
       tags:
         - containers
       summary: Get the corresponding WDL descriptor file on Github.
-      description: >-
-        Does not require authentication for published tools, authentication can
+      description: Does not require authentication for published tools, authentication can
         be provided for restricted tools
       operationId: secondaryWdlPath
       parameters:
@@ -2717,20 +2676,21 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SourceFile'
+                $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-  '/containers/{toolId}/defaultVersion':
+        - BEARER:
+            []
+  "/containers/{toolId}/defaultVersion":
     put:
       tags:
         - containers
       summary: Update the default version of the given tool.
-      description: ''
+      description: ""
       operationId: updateToolDefaultVersion
       parameters:
         - name: toolId
@@ -2740,15 +2700,6 @@ paths:
           schema:
             type: integer
             format: int64
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DockstoreTool'
-      security:
-        - BEARER: []
       requestBody:
         content:
           application/json:
@@ -2756,12 +2707,22 @@ paths:
               type: string
         description: Tag name to set as default.
         required: true
-  '/containers/{toolId}/zip/{tagId}':
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DockstoreTool"
+      security:
+        - BEARER:
+            []
+  "/containers/{toolId}/zip/{tagId}":
     get:
       tags:
         - containers
       summary: Download a ZIP file of a tool and all associated files.
-      description: ''
+      description: ""
       operationId: getToolZip
       parameters:
         - name: toolId
@@ -2782,14 +2743,14 @@ paths:
         default:
           description: successful operation
       security:
-        - BEARER: []
-  '/entries/{id}/aliases':
+        - BEARER:
+            []
+  "/entries/{id}/aliases":
     put:
       tags:
         - entries
       summary: Update the aliases linked to an entry.
-      description: >-
-        Aliases are alphanumerical (case-insensitive and may contain internal
+      description: Aliases are alphanumerical (case-insensitive and may contain internal
         hyphens), given in a comma-delimited list.
       operationId: updateAliases
       parameters:
@@ -2806,17 +2767,18 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        $ref: "#/components/requestBodies/updateLabelsBody"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: "#/components/schemas/Entry"
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/updateLabelsBody'
+        - BEARER:
+            []
   /metadata/descriptorLanguageList:
     get:
       tags:
@@ -2825,14 +2787,14 @@ paths:
       description: NO authentication
       operationId: getDescriptorLanguages
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DescriptorLanguageBean'
+                  $ref: "#/components/schemas/DescriptorLanguageBean"
   /metadata/dockerRegistryList:
     get:
       tags:
@@ -2841,14 +2803,14 @@ paths:
       description: NO authentication
       operationId: getDockerRegistries
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/RegistryBean'
+                  $ref: "#/components/schemas/RegistryBean"
   /metadata/elasticSearch:
     get:
       tags:
@@ -2867,7 +2829,7 @@ paths:
       description: NO authentication
       operationId: getCachePerformance
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
@@ -2885,7 +2847,7 @@ paths:
       description: NO authentication
       operationId: rssFeed
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             text/xml:
@@ -2896,7 +2858,7 @@ paths:
       tags:
         - metadata
       summary: Returns the file containing runner dependencies.
-      description: ''
+      description: ""
       operationId: getRunnerDependencies
       parameters:
         - name: client_version
@@ -2907,11 +2869,11 @@ paths:
             type: string
         - name: python_version
           in: query
-          description: 'Python version, only relevant for the cwltool runner'
+          description: Python version, only relevant for the cwltool runner
           required: false
           schema:
             type: string
-            default: '2'
+            default: "2"
         - name: runner
           in: query
           description: The tool runner
@@ -2932,7 +2894,7 @@ paths:
               - text
             default: text
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             text/plain:
@@ -2949,7 +2911,7 @@ paths:
       description: NO authentication
       operationId: sitemap
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             text/html:
@@ -2966,14 +2928,14 @@ paths:
       description: NO authentication
       operationId: getSourceControlList
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SourceControlBean'
+                  $ref: "#/components/schemas/SourceControlBean"
   /organisations:
     get:
       tags:
@@ -2982,36 +2944,37 @@ paths:
       description: NO Authentication
       operationId: getApprovedOrganisations
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Organisation'
+                  $ref: "#/components/schemas/Organisation"
     put:
       tags:
         - organisations
       summary: Create an organisation.
       description: Organisation requires approval by an admin before being made public.
       operationId: createOrganisation
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Organisation'
-      security:
-        - BEARER: []
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Organisation'
+              $ref: "#/components/schemas/Organisation"
         description: Organisation to register.
         required: true
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Organisation"
+      security:
+        - BEARER:
+            []
   /organisations/all:
     get:
       tags:
@@ -3031,23 +2994,23 @@ paths:
               - unapproved
               - approved
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Organisation'
+                  $ref: "#/components/schemas/Organisation"
       security:
-        - BEARER: []
-  '/organisations/name/{name}':
+        - BEARER:
+            []
+  "/organisations/name/{name}":
     get:
       tags:
         - organisations
       summary: Retrieves an organisation by name.
-      description: >-
-        Does not require authentication for approved organisations,
+      description: Does not require authentication for approved organisations,
         authentication can be provided for unapproved organisations
       operationId: getOrganisationByName
       parameters:
@@ -3058,21 +3021,21 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organisation'
+                $ref: "#/components/schemas/Organisation"
       security:
-        - BEARER: []
-  '/organisations/{organisationId}':
+        - BEARER:
+            []
+  "/organisations/{organisationId}":
     get:
       tags:
         - organisations
       summary: Retrieves an organisation by ID.
-      description: >-
-        Does not require authentication for approved organisations,
+      description: Does not require authentication for approved organisations,
         authentication can be provided for unapproved organisations
       operationId: getOrganisationById
       parameters:
@@ -3084,20 +3047,20 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organisation'
+                $ref: "#/components/schemas/Organisation"
       security:
-        - BEARER: []
+        - BEARER:
+            []
     post:
       tags:
         - organisations
       summary: Update an organisation.
-      description: >-
-        Currently only name, description, email, link and location can be
+      description: Currently only name, description, email, link and location can be
         updated.
       operationId: updateOrganisation
       parameters:
@@ -3108,23 +3071,24 @@ paths:
           schema:
             type: integer
             format: int64
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Organisation'
-      security:
-        - BEARER: []
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Organisation'
+              $ref: "#/components/schemas/Organisation"
         description: Organisation to update with.
         required: true
-  '/organisations/{organisationId}/approve':
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Organisation"
+      security:
+        - BEARER:
+            []
+  "/organisations/{organisationId}/approve":
     post:
       tags:
         - organisations
@@ -3140,21 +3104,21 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organisation'
+                $ref: "#/components/schemas/Organisation"
       security:
-        - BEARER: []
-  '/organisations/{organisationId}/collections':
+        - BEARER:
+            []
+  "/organisations/{organisationId}/collections":
     get:
       tags:
         - organisations
       summary: Retrieve all collections for an organisation.
-      description: >-
-        Does not require authentication for approved organisations,
+      description: Does not require authentication for approved organisations,
         authentication can be provided for unapproved organisations
       operationId: getCollectionsFromOrganisation
       parameters:
@@ -3171,21 +3135,22 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Collection'
+                  $ref: "#/components/schemas/Collection"
       security:
-        - BEARER: []
+        - BEARER:
+            []
     put:
       tags:
         - organisations
       summary: Create a collection in the given organisation.
-      description: ''
+      description: ""
       operationId: createCollection
       parameters:
         - name: organisationId
@@ -3195,29 +3160,29 @@ paths:
           schema:
             type: integer
             format: int64
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Collection'
-      security:
-        - BEARER: []
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Collection'
+              $ref: "#/components/schemas/Collection"
         description: Collection to register.
         required: true
-  '/organisations/{organisationId}/collections/{collectionId}':
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Collection"
+      security:
+        - BEARER:
+            []
+  "/organisations/{organisationId}/collections/{collectionId}":
     get:
       tags:
         - organisations
       summary: Retrieves a collection by ID.
-      description: >-
-        Does not require authentication for approved organisations,
+      description: Does not require authentication for approved organisations,
         authentication can be provided for unapproved organisations
       operationId: getCollectionById
       parameters:
@@ -3236,14 +3201,15 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Collection'
+                $ref: "#/components/schemas/Collection"
       security:
-        - BEARER: []
+        - BEARER:
+            []
     post:
       tags:
         - organisations
@@ -3265,28 +3231,29 @@ paths:
           schema:
             type: integer
             format: int64
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Collection'
-      security:
-        - BEARER: []
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Collection'
+              $ref: "#/components/schemas/Collection"
         description: Collection to update with.
         required: true
-  '/organisations/{organisationId}/collections/{collectionId}/entry':
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Collection"
+      security:
+        - BEARER:
+            []
+  "/organisations/{organisationId}/collections/{collectionId}/entry":
     post:
       tags:
         - organisations
       summary: Add an entry to a collection.
-      description: ''
+      description: ""
       operationId: addEntryToCollection
       parameters:
         - name: organisationId
@@ -3311,19 +3278,20 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Collection'
+                $ref: "#/components/schemas/Collection"
       security:
-        - BEARER: []
+        - BEARER:
+            []
     delete:
       tags:
         - organisations
       summary: Delete an entry from a collection.
-      description: ''
+      description: ""
       operationId: deleteEntryFromCollection
       parameters:
         - name: organisationId
@@ -3348,21 +3316,21 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Collection'
+                $ref: "#/components/schemas/Collection"
       security:
-        - BEARER: []
-  '/organisations/{organisationId}/events':
+        - BEARER:
+            []
+  "/organisations/{organisationId}/events":
     get:
       tags:
         - organisations
       summary: Retrieves all events for an organisation.
-      description: >-
-        Does not require authentication for approved organisations,
+      description: Does not require authentication for approved organisations,
         authentication can be provided for unapproved organisations
       operationId: getOrganisationEvents
       parameters:
@@ -3374,22 +3342,23 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Event'
+                  $ref: "#/components/schemas/Event"
       security:
-        - BEARER: []
-  '/organisations/{organisationId}/invitation':
+        - BEARER:
+            []
+  "/organisations/{organisationId}/invitation":
     post:
       tags:
         - organisations
       summary: Accept or reject an organisation invitation.
-      description: 'True accepts the invitation, false rejects the invitation.'
+      description: True accepts the invitation, false rejects the invitation.
       operationId: acceptOrRejectInvitation
       parameters:
         - name: organisationId
@@ -3406,21 +3375,21 @@ paths:
           schema:
             type: boolean
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: "#/components/schemas/User"
       security:
-        - BEARER: []
-  '/organisations/{organisationId}/members':
+        - BEARER:
+            []
+  "/organisations/{organisationId}/members":
     get:
       tags:
         - organisations
       summary: Retrieves all members for an organisation.
-      description: >-
-        Does not require authentication for approved organisations,
+      description: Does not require authentication for approved organisations,
         authentication can be provided for unapproved organisations
       operationId: getOrganisationMembers
       parameters:
@@ -3432,7 +3401,7 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
@@ -3440,15 +3409,16 @@ paths:
                 type: array
                 uniqueItems: true
                 items:
-                  $ref: '#/components/schemas/OrganisationUser'
+                  $ref: "#/components/schemas/OrganisationUser"
       security:
-        - BEARER: []
-  '/organisations/{organisationId}/user':
+        - BEARER:
+            []
+  "/organisations/{organisationId}/user":
     post:
       tags:
         - organisations
       summary: Updates a user role in an organisation.
-      description: ''
+      description: ""
       operationId: updateUserRole
       parameters:
         - name: role
@@ -3475,19 +3445,20 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganisationUser'
+                $ref: "#/components/schemas/OrganisationUser"
       security:
-        - BEARER: []
+        - BEARER:
+            []
     put:
       tags:
         - organisations
       summary: Adds a user role to an organisation.
-      description: ''
+      description: ""
       operationId: addUserToOrg
       parameters:
         - name: role
@@ -3513,22 +3484,23 @@ paths:
           schema:
             type: integer
             format: int64
+      requestBody:
+        $ref: "#/components/requestBodies/updateLabelsBody"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganisationUser'
+                $ref: "#/components/schemas/OrganisationUser"
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/updateLabelsBody'
+        - BEARER:
+            []
     delete:
       tags:
         - organisations
       summary: Remove a user from an organisation.
-      description: ''
+      description: ""
       operationId: deleteUserRole
       parameters:
         - name: userId
@@ -3549,13 +3521,14 @@ paths:
         default:
           description: successful operation
       security:
-        - BEARER: []
-  '/users/checkUser/{username}':
+        - BEARER:
+            []
+  "/users/checkUser/{username}":
     get:
       tags:
         - users
       summary: Check if user with some username exists.
-      description: ''
+      description: ""
       operationId: checkUserExists
       parameters:
         - name: username
@@ -3565,50 +3538,53 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: boolean
       security:
-        - BEARER: []
+        - BEARER:
+            []
   /users/starredTools:
     get:
       tags:
         - users
       summary: Get the logged-in user's starred tools.
-      description: ''
+      description: ""
       operationId: getStarredTools
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Entry'
+                  $ref: "#/components/schemas/Entry"
       security:
-        - BEARER: []
+        - BEARER:
+            []
   /users/starredWorkflows:
     get:
       tags:
         - users
       summary: Get the logged-in user's starred workflows.
-      description: ''
+      description: ""
       operationId: getStarredWorkflows
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Entry'
+                  $ref: "#/components/schemas/Entry"
       security:
-        - BEARER: []
+        - BEARER:
+            []
   /users/updateUserMetadata:
     get:
       tags:
@@ -3617,53 +3593,56 @@ paths:
       description: Admin only.
       operationId: updateUserMetadata
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/User'
+                  $ref: "#/components/schemas/User"
       security:
-        - BEARER: []
+        - BEARER:
+            []
   /users/user:
     get:
       tags:
         - users
       summary: Get the logged-in user.
-      description: ''
+      description: ""
       operationId: getUser
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: "#/components/schemas/User"
       security:
-        - BEARER: []
+        - BEARER:
+            []
     delete:
       tags:
         - users
       summary: Delete user if possible.
-      description: ''
+      description: ""
       operationId: selfDestruct
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: boolean
       security:
-        - BEARER: []
+        - BEARER:
+            []
   /users/user/changeUsername:
     post:
       tags:
         - users
       summary: Change username if possible.
-      description: ''
+      description: ""
       operationId: changeUsername
       parameters:
         - name: username
@@ -3673,36 +3652,38 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: "#/components/schemas/User"
       security:
-        - BEARER: []
+        - BEARER:
+            []
   /users/user/extended:
     get:
       tags:
         - users
       summary: Get additional information about the logged-in user.
-      description: ''
+      description: ""
       operationId: getExtendedUserData
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ExtendedUserData'
+                $ref: "#/components/schemas/ExtendedUserData"
       security:
-        - BEARER: []
+        - BEARER:
+            []
   /users/user/updateUserMetadata:
     get:
       tags:
         - users
       summary: Update metadata for logged in user.
-      description: ''
+      description: ""
       operationId: updateLoggedInUserMetadata
       parameters:
         - name: source
@@ -3715,20 +3696,21 @@ paths:
               - google.com
               - github.com
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: "#/components/schemas/User"
       security:
-        - BEARER: []
-  '/users/username/{username}':
+        - BEARER:
+            []
+  "/users/username/{username}":
     get:
       tags:
         - users
       summary: Get a user by username.
-      description: ''
+      description: ""
       operationId: listUser
       parameters:
         - name: username
@@ -3738,20 +3720,21 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: "#/components/schemas/User"
       security:
-        - BEARER: []
-  '/users/{userId}':
+        - BEARER:
+            []
+  "/users/{userId}":
     get:
       tags:
         - users
       summary: Get user by id.
-      description: ''
+      description: ""
       operationId: getUser
       parameters:
         - name: userId
@@ -3762,20 +3745,21 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: "#/components/schemas/User"
       security:
-        - BEARER: []
-  '/users/{userId}/containers':
+        - BEARER:
+            []
+  "/users/{userId}/containers":
     get:
       tags:
         - users
       summary: List all tools owned by the logged-in user.
-      description: ''
+      description: ""
       operationId: userContainers
       parameters:
         - name: userId
@@ -3786,22 +3770,23 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DockstoreTool'
+                  $ref: "#/components/schemas/DockstoreTool"
       security:
-        - BEARER: []
-  '/users/{userId}/containers/published':
+        - BEARER:
+            []
+  "/users/{userId}/containers/published":
     get:
       tags:
         - users
       summary: List all published tools from a user.
-      description: ''
+      description: ""
       operationId: userPublishedContainers
       parameters:
         - name: userId
@@ -3812,22 +3797,23 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DockstoreTool'
+                  $ref: "#/components/schemas/DockstoreTool"
       security:
-        - BEARER: []
-  '/users/{userId}/containers/refresh':
+        - BEARER:
+            []
+  "/users/{userId}/containers/refresh":
     get:
       tags:
         - users
       summary: Refresh all tools owned by the logged-in user.
-      description: ''
+      description: ""
       operationId: refresh
       parameters:
         - name: userId
@@ -3838,24 +3824,24 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DockstoreTool'
+                  $ref: "#/components/schemas/DockstoreTool"
       security:
-        - BEARER: []
-  '/users/{userId}/containers/{organization}/refresh':
+        - BEARER:
+            []
+  "/users/{userId}/containers/{organization}/refresh":
     get:
       tags:
         - users
-      summary: >-
-        Refresh all tools owned by the logged-in user with specified
+      summary: Refresh all tools owned by the logged-in user with specified
         organization.
-      description: ''
+      description: ""
       operationId: refreshToolsByOrganization
       parameters:
         - name: userId
@@ -3872,22 +3858,23 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DockstoreTool'
+                  $ref: "#/components/schemas/DockstoreTool"
       security:
-        - BEARER: []
-  '/users/{userId}/tokens':
+        - BEARER:
+            []
+  "/users/{userId}/tokens":
     get:
       tags:
         - users
       summary: Get tokens with user id.
-      description: ''
+      description: ""
       operationId: getUserTokens
       parameters:
         - name: userId
@@ -3898,22 +3885,23 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Token'
+                  $ref: "#/components/schemas/Token"
       security:
-        - BEARER: []
-  '/users/{userId}/tokens/dockstore':
+        - BEARER:
+            []
+  "/users/{userId}/tokens/dockstore":
     get:
       tags:
         - users
       summary: Get Dockstore tokens with user id.
-      description: ''
+      description: ""
       operationId: getDockstoreUserTokens
       parameters:
         - name: userId
@@ -3924,22 +3912,23 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Token'
+                  $ref: "#/components/schemas/Token"
       security:
-        - BEARER: []
-  '/users/{userId}/tokens/github.com':
+        - BEARER:
+            []
+  "/users/{userId}/tokens/github.com":
     get:
       tags:
         - users
       summary: Get Github tokens with user id.
-      description: ''
+      description: ""
       operationId: getGithubUserTokens
       parameters:
         - name: userId
@@ -3950,22 +3939,23 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Token'
+                  $ref: "#/components/schemas/Token"
       security:
-        - BEARER: []
-  '/users/{userId}/tokens/gitlab.com':
+        - BEARER:
+            []
+  "/users/{userId}/tokens/gitlab.com":
     get:
       tags:
         - users
       summary: Get Gitlab tokens with user id.
-      description: ''
+      description: ""
       operationId: getGitlabUserTokens
       parameters:
         - name: userId
@@ -3976,22 +3966,23 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Token'
+                  $ref: "#/components/schemas/Token"
       security:
-        - BEARER: []
-  '/users/{userId}/tokens/quay.io':
+        - BEARER:
+            []
+  "/users/{userId}/tokens/quay.io":
     get:
       tags:
         - users
       summary: Get Quay tokens with user id.
-      description: ''
+      description: ""
       operationId: getQuayUserTokens
       parameters:
         - name: userId
@@ -4002,22 +3993,23 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Token'
+                  $ref: "#/components/schemas/Token"
       security:
-        - BEARER: []
-  '/users/{userId}/workflows':
+        - BEARER:
+            []
+  "/users/{userId}/workflows":
     get:
       tags:
         - users
       summary: List all workflows owned by the logged-in user.
-      description: ''
+      description: ""
       operationId: userWorkflows
       parameters:
         - name: userId
@@ -4028,22 +4020,23 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Workflow'
+                  $ref: "#/components/schemas/Workflow"
       security:
-        - BEARER: []
-  '/users/{userId}/workflows/published':
+        - BEARER:
+            []
+  "/users/{userId}/workflows/published":
     get:
       tags:
         - users
       summary: List all published workflows from a user.
-      description: ''
+      description: ""
       operationId: userPublishedWorkflows
       parameters:
         - name: userId
@@ -4054,22 +4047,23 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Workflow'
+                  $ref: "#/components/schemas/Workflow"
       security:
-        - BEARER: []
-  '/users/{userId}/workflows/refresh':
+        - BEARER:
+            []
+  "/users/{userId}/workflows/refresh":
     get:
       tags:
         - users
       summary: Refresh all workflows owned by the logged-in user.
-      description: ''
+      description: ""
       operationId: refreshWorkflows
       parameters:
         - name: userId
@@ -4080,24 +4074,24 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Workflow'
+                  $ref: "#/components/schemas/Workflow"
       security:
-        - BEARER: []
-  '/users/{userId}/workflows/{organization}/refresh':
+        - BEARER:
+            []
+  "/users/{userId}/workflows/{organization}/refresh":
     get:
       tags:
         - users
-      summary: >-
-        Refresh all workflows owned by the logged-in user with specified
+      summary: Refresh all workflows owned by the logged-in user with specified
         organization.
-      description: ''
+      description: ""
       operationId: refreshWorkflowsByOrganization
       parameters:
         - name: userId
@@ -4114,22 +4108,23 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Workflow'
+                  $ref: "#/components/schemas/Workflow"
       security:
-        - BEARER: []
+        - BEARER:
+            []
   /workflows/hostedEntry:
     post:
       tags:
         - hosted
       summary: Create a hosted workflow.
-      description: ''
+      description: ""
       operationId: createHostedWorkflow
       parameters:
         - name: registry
@@ -4163,20 +4158,21 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: "#/components/schemas/Workflow"
       security:
-        - BEARER: []
-  '/workflows/hostedEntry/{entryId}':
+        - BEARER:
+            []
+  "/workflows/hostedEntry/{entryId}":
     delete:
       tags:
         - hosted
       summary: Delete a revision of a hosted workflow
-      description: ''
+      description: ""
       operationId: deleteHostedWorkflowVersion
       parameters:
         - name: entryId
@@ -4193,19 +4189,20 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: "#/components/schemas/Workflow"
       security:
-        - BEARER: []
+        - BEARER:
+            []
     patch:
       tags:
         - hosted
       summary: Non-idempotent operation for creating new revisions of hosted workflows
-      description: ''
+      description: ""
       operationId: editHostedWorkflow
       parameters:
         - name: entryId
@@ -4215,17 +4212,18 @@ paths:
           schema:
             type: integer
             format: int64
+      requestBody:
+        $ref: "#/components/requestBodies/SourceFileArray"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: "#/components/schemas/Workflow"
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/SourceFileArray'
+        - BEARER:
+            []
   /workflows/manualRegister:
     post:
       tags:
@@ -4254,7 +4252,7 @@ paths:
             type: string
         - name: workflowName
           in: query
-          description: 'Workflow name, set to empty if none required'
+          description: Workflow name, set to empty if none required
           required: true
           schema:
             type: string
@@ -4271,15 +4269,16 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: "#/components/schemas/Workflow"
       security:
-        - BEARER: []
-  '/workflows/organization/{organization}/published':
+        - BEARER:
+            []
+  "/workflows/organization/{organization}/published":
     get:
       tags:
         - workflows
@@ -4294,15 +4293,15 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Workflow'
-  '/workflows/path/entry/{repository}':
+                  $ref: "#/components/schemas/Workflow"
+  "/workflows/path/entry/{repository}":
     get:
       tags:
         - workflows
@@ -4317,15 +4316,16 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: "#/components/schemas/Entry"
       security:
-        - BEARER: []
-  '/workflows/path/entry/{repository}/published':
+        - BEARER:
+            []
+  "/workflows/path/entry/{repository}/published":
     get:
       tags:
         - workflows
@@ -4340,13 +4340,13 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
-  '/workflows/path/workflow/{repository}':
+                $ref: "#/components/schemas/Entry"
+  "/workflows/path/workflow/{repository}":
     get:
       tags:
         - workflows
@@ -4362,25 +4362,26 @@ paths:
             type: string
         - name: include
           in: query
-          description: 'Comma-delimited list of fields to include: validations'
+          description: "Comma-delimited list of fields to include: validations"
           required: false
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: "#/components/schemas/Workflow"
       security:
-        - BEARER: []
-  '/workflows/path/workflow/{repository}/actions':
+        - BEARER:
+            []
+  "/workflows/path/workflow/{repository}/actions":
     get:
       tags:
         - workflows
       summary: Gets all actions a user can perform on a workflow.
-      description: ''
+      description: ""
       operationId: getWorkflowActions
       parameters:
         - name: repository
@@ -4390,7 +4391,7 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
@@ -4404,8 +4405,9 @@ paths:
                     - DELETE
                     - SHARE
       security:
-        - BEARER: []
-  '/workflows/path/workflow/{repository}/permissions':
+        - BEARER:
+            []
+  "/workflows/path/workflow/{repository}/permissions":
     get:
       tags:
         - workflows
@@ -4420,16 +4422,17 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Permission'
+                  $ref: "#/components/schemas/Permission"
       security:
-        - BEARER: []
+        - BEARER:
+            []
     delete:
       tags:
         - workflows
@@ -4460,22 +4463,22 @@ paths:
               - WRITER
               - READER
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Permission'
+                  $ref: "#/components/schemas/Permission"
       security:
-        - BEARER: []
+        - BEARER:
+            []
     patch:
       tags:
         - workflows
       summary: Set the specified permission for a user on a workflow.
-      description: >-
-        The user must be the workflow owner. Currently only supported on hosted
+      description: The user must be the workflow owner. Currently only supported on hosted
         workflows.
       operationId: addWorkflowPermission
       parameters:
@@ -4485,25 +4488,26 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Permission"
+        description: user permission
+        required: true
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Permission'
+                  $ref: "#/components/schemas/Permission"
       security:
-        - BEARER: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Permission'
-        description: user permission
-        required: true
-  '/workflows/path/workflow/{repository}/published':
+        - BEARER:
+            []
+  "/workflows/path/workflow/{repository}/published":
     get:
       tags:
         - workflows
@@ -4519,18 +4523,18 @@ paths:
             type: string
         - name: include
           in: query
-          description: 'Comma-delimited list of fields to include: validations'
+          description: "Comma-delimited list of fields to include: validations"
           required: false
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
-  '/workflows/path/{repository}':
+                $ref: "#/components/schemas/Workflow"
+  "/workflows/path/{repository}":
     get:
       tags:
         - workflows
@@ -4545,16 +4549,17 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Workflow'
+                  $ref: "#/components/schemas/Workflow"
       security:
-        - BEARER: []
+        - BEARER:
+            []
   /workflows/published:
     get:
       tags:
@@ -4565,8 +4570,7 @@ paths:
       parameters:
         - name: offset
           in: query
-          description: >-
-            Start index of paging. Pagination results can be based on numbers or
+          description: Start index of paging. Pagination results can be based on numbers or
             other values chosen by the registry implementor (for example, SHA
             values). If this exceeds the current result set return an empty
             set.  If not specified in the request, this will start at the
@@ -4576,7 +4580,7 @@ paths:
             type: string
         - name: limit
           in: query
-          description: 'Amount of records to return in a given page, limited to 100'
+          description: Amount of records to return in a given page, limited to 100
           required: false
           schema:
             type: integer
@@ -4586,7 +4590,7 @@ paths:
             default: 100
         - name: filter
           in: query
-          description: 'Filter, this is a search string that filters the results.'
+          description: Filter, this is a search string that filters the results.
           required: false
           schema:
             type: string
@@ -4608,15 +4612,15 @@ paths:
               - desc
             default: desc
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Workflow'
-  '/workflows/published/{workflowId}':
+                  $ref: "#/components/schemas/Workflow"
+  "/workflows/published/{workflowId}":
     get:
       tags:
         - workflows
@@ -4633,57 +4637,55 @@ paths:
             format: int64
         - name: include
           in: query
-          description: 'Comma-delimited list of fields to include: validations'
+          description: "Comma-delimited list of fields to include: validations"
           required: false
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: "#/components/schemas/Workflow"
   /workflows/shared:
     get:
       tags:
         - workflows
       summary: Retrieve all workflows shared with user.
-      description: ''
+      description: ""
       operationId: sharedWorkflows
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SharedWorkflows'
+                  $ref: "#/components/schemas/SharedWorkflows"
       security:
-        - BEARER: []
-  '/workflows/{entryId}/registerCheckerWorkflow/{descriptorType}':
+        - BEARER:
+            []
+  "/workflows/{entryId}/registerCheckerWorkflow/{descriptorType}":
     post:
       tags:
         - workflows
-      summary: >-
-        Register a checker workflow and associates it with the given
+      summary: Register a checker workflow and associates it with the given
         tool/workflow.
-      description: ''
+      description: ""
       operationId: registerCheckerWorkflow
       parameters:
         - name: checkerWorkflowPath
           in: query
-          description: >-
-            Path of the main descriptor of the checker workflow (located in
+          description: Path of the main descriptor of the checker workflow (located in
             associated tool/workflow repository)
           required: true
           schema:
             type: string
         - name: testParameterPath
           in: query
-          description: >-
-            Default path to test parameter files for the checker workflow. If
+          description: Default path to test parameter files for the checker workflow. If
             not specified will use that of the entry.
           required: false
           schema:
@@ -4697,7 +4699,7 @@ paths:
             format: int64
         - name: descriptorType
           in: path
-          description: 'Descriptor type of the workflow, either cwl or wdl.'
+          description: Descriptor type of the workflow, either cwl or wdl.
           required: true
           schema:
             type: string
@@ -4705,21 +4707,21 @@ paths:
               - cwl
               - wdl
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: "#/components/schemas/Entry"
       security:
-        - BEARER: []
-  '/workflows/{workflowId}':
+        - BEARER:
+            []
+  "/workflows/{workflowId}":
     get:
       tags:
         - workflows
       summary: Retrieve a workflow
-      description: >-
-        This is one of the few endpoints that returns the user object with
+      description: This is one of the few endpoints that returns the user object with
         populated properties (minus the userProfiles property)
       operationId: getWorkflow
       parameters:
@@ -4732,25 +4734,25 @@ paths:
             format: int64
         - name: include
           in: query
-          description: 'Comma-delimited list of fields to include: validations'
+          description: "Comma-delimited list of fields to include: validations"
           required: false
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: "#/components/schemas/Workflow"
       security:
-        - BEARER: []
+        - BEARER:
+            []
     put:
       tags:
         - workflows
       summary: Update the workflow with the given workflow.
-      description: >-
-        Updates descriptor type (if stub), default workflow path, default file
+      description: Updates descriptor type (if stub), default workflow path, default file
         path, and default version
       operationId: updateWorkflow
       parameters:
@@ -4761,24 +4763,24 @@ paths:
           schema:
             type: integer
             format: int64
+      requestBody:
+        $ref: "#/components/requestBodies/Workflow"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: "#/components/schemas/Workflow"
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/Workflow'
-  '/workflows/{workflowId}/cwl':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/cwl":
     get:
       tags:
         - workflows
       summary: Get the primary CWL descriptor file on Github.
-      description: >-
-        Does not require authentication for published workflows, authentication
+      description: Does not require authentication for published workflows, authentication
         can be provided for restricted workflows
       operationId: cwl
       parameters:
@@ -4795,21 +4797,21 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SourceFile'
+                $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-  '/workflows/{workflowId}/cwl/{relative-path}':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/cwl/{relative-path}":
     get:
       tags:
         - workflows
       summary: Get the corresponding CWL descriptor file on Github.
-      description: >-
-        Does not require authentication for published workflows, authentication
+      description: Does not require authentication for published workflows, authentication
         can be provided for restricted workflows
       operationId: secondaryCwlPath
       parameters:
@@ -4831,21 +4833,21 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SourceFile'
+                $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-  '/workflows/{workflowId}/dag/{workflowVersionId}':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/dag/{workflowVersionId}":
     get:
       tags:
         - workflows
       summary: Get the DAG for a given workflow version.
-      description: >-
-        Does not require authentication for published workflows, authentication
+      description: Does not require authentication for published workflows, authentication
         can be provided for restricted workflows
       operationId: getWorkflowDag
       parameters:
@@ -4864,20 +4866,21 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: string
       security:
-        - BEARER: []
-  '/workflows/{workflowId}/defaultVersion':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/defaultVersion":
     put:
       tags:
         - workflows
       summary: Update the default version of a workflow.
-      description: ''
+      description: ""
       operationId: updateWorkflowDefaultVersion
       parameters:
         - name: workflowId
@@ -4887,15 +4890,6 @@ paths:
           schema:
             type: integer
             format: int64
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Workflow'
-      security:
-        - BEARER: []
       requestBody:
         content:
           application/json:
@@ -4903,13 +4897,22 @@ paths:
               type: string
         description: Version name to set as default
         required: true
-  '/workflows/{workflowId}/labels':
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Workflow"
+      security:
+        - BEARER:
+            []
+  "/workflows/{workflowId}/labels":
     put:
       tags:
         - workflows
       summary: Update the labels linked to a workflow.
-      description: >-
-        Labels are alphanumerical (case-insensitive and may contain internal
+      description: Labels are alphanumerical (case-insensitive and may contain internal
         hyphens), given in a comma-delimited list.
       operationId: updateLabels
       parameters:
@@ -4926,24 +4929,24 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        $ref: "#/components/requestBodies/updateLabelsBody"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: "#/components/schemas/Workflow"
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/updateLabelsBody'
-  '/workflows/{workflowId}/nextflow':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/nextflow":
     get:
       tags:
         - workflows
       summary: Get the nextflow.config file on Github.
-      description: >-
-        Does not require authentication for published workflows, authentication
+      description: Does not require authentication for published workflows, authentication
         can be provided for restricted workflows
       operationId: nextflow
       parameters:
@@ -4960,21 +4963,21 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SourceFile'
+                $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-  '/workflows/{workflowId}/nextflow/{relative-path}':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/nextflow/{relative-path}":
     get:
       tags:
         - workflows
       summary: Get the corresponding nextflow documents on Github.
-      description: >-
-        Does not require authentication for published workflows, authentication
+      description: Does not require authentication for published workflows, authentication
         can be provided for restricted workflows
       operationId: secondaryNextFlowPath
       parameters:
@@ -4996,15 +4999,16 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SourceFile'
+                $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-  '/workflows/{workflowId}/publish':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/publish":
     post:
       tags:
         - workflows
@@ -5019,18 +5023,19 @@ paths:
           schema:
             type: integer
             format: int64
+      requestBody:
+        $ref: "#/components/requestBodies/PublishRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: "#/components/schemas/Workflow"
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/PublishRequest'
-  '/workflows/{workflowId}/refresh':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/refresh":
     get:
       tags:
         - workflows
@@ -5046,20 +5051,21 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: "#/components/schemas/Workflow"
       security:
-        - BEARER: []
-  '/workflows/{workflowId}/requestDOI/{workflowVersionId}':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/requestDOI/{workflowVersionId}":
     put:
       tags:
         - workflows
       summary: Request a DOI for this version of a workflow.
-      description: ''
+      description: ""
       operationId: requestDOIForWorkflowVersion
       parameters:
         - name: workflowId
@@ -5077,23 +5083,23 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/WorkflowVersion'
+                  $ref: "#/components/schemas/WorkflowVersion"
       security:
-        - BEARER: []
-  '/workflows/{workflowId}/resetVersionPaths':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/resetVersionPaths":
     put:
       tags:
         - workflows
       summary: Reset the workflow paths.
-      description: >-
-        Resets the workflow paths of all versions to match the default workflow
+      description: Resets the workflow paths of all versions to match the default workflow
         path from the workflow object passed.
       operationId: updateWorkflowPath
       parameters:
@@ -5104,23 +5110,24 @@ paths:
           schema:
             type: integer
             format: int64
+      requestBody:
+        $ref: "#/components/requestBodies/Workflow"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: "#/components/schemas/Workflow"
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/Workflow'
-  '/workflows/{workflowId}/restub':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/restub":
     get:
       tags:
         - workflows
       summary: Restub a workflow
-      description: 'Restubs a full, unpublished workflow.'
+      description: Restubs a full, unpublished workflow.
       operationId: restub
       parameters:
         - name: workflowId
@@ -5131,21 +5138,21 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: "#/components/schemas/Workflow"
       security:
-        - BEARER: []
-  '/workflows/{workflowId}/secondaryCwl':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/secondaryCwl":
     get:
       tags:
         - workflows
       summary: Get the corresponding cwl documents on Github.
-      description: >-
-        Does not require authentication for published workflows, authentication
+      description: Does not require authentication for published workflows, authentication
         can be provided for restricted workflows
       operationId: secondaryCwl
       parameters:
@@ -5162,23 +5169,23 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SourceFile'
+                  $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-  '/workflows/{workflowId}/secondaryNextflow':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/secondaryNextflow":
     get:
       tags:
         - workflows
       summary: Get the corresponding Nextflow documents on Github.
-      description: >-
-        Does not require authentication for published workflows, authentication
+      description: Does not require authentication for published workflows, authentication
         can be provided for restricted workflows
       operationId: secondaryNextflow
       parameters:
@@ -5195,23 +5202,23 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SourceFile'
+                  $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-  '/workflows/{workflowId}/secondaryWdl':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/secondaryWdl":
     get:
       tags:
         - workflows
       summary: Get the corresponding wdl documents on Github.
-      description: >-
-        Does not require authentication for published workflows, authentication
+      description: Does not require authentication for published workflows, authentication
         can be provided for restricted workflows
       operationId: secondaryWdl
       parameters:
@@ -5228,22 +5235,23 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SourceFile'
+                  $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-  '/workflows/{workflowId}/star':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/star":
     put:
       tags:
         - workflows
       summary: Star a workflow.
-      description: ''
+      description: ""
       operationId: starEntry
       parameters:
         - name: workflowId
@@ -5253,19 +5261,20 @@ paths:
           schema:
             type: integer
             format: int64
+      requestBody:
+        $ref: "#/components/requestBodies/StarRequest"
       responses:
         default:
           description: successful operation
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/StarRequest'
-  '/workflows/{workflowId}/starredUsers':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/starredUsers":
     get:
       tags:
         - workflows
       summary: Returns list of users who starred the given workflow.
-      description: ''
+      description: ""
       operationId: getStarredUsers
       parameters:
         - name: workflowId
@@ -5276,21 +5285,20 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/User'
-  '/workflows/{workflowId}/testParameterFiles':
+                  $ref: "#/components/schemas/User"
+  "/workflows/{workflowId}/testParameterFiles":
     get:
       tags:
         - workflows
       summary: Get the corresponding test parameter files.
-      description: >-
-        Does not require authentication for published workflows, authentication
+      description: Does not require authentication for published workflows, authentication
         can be provided for restricted workflows
       operationId: getTestParameterFiles
       parameters:
@@ -5307,21 +5315,22 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SourceFile'
+                  $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
+        - BEARER:
+            []
     put:
       tags:
         - workflows
       summary: Add test parameter files for a given version.
-      description: ''
+      description: ""
       operationId: addTestParameterFiles
       parameters:
         - name: workflowId
@@ -5345,8 +5354,10 @@ paths:
           required: false
           schema:
             type: string
+      requestBody:
+        $ref: "#/components/requestBodies/updateLabelsBody"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
@@ -5354,16 +5365,15 @@ paths:
                 type: array
                 uniqueItems: true
                 items:
-                  $ref: '#/components/schemas/SourceFile'
+                  $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/updateLabelsBody'
+        - BEARER:
+            []
     delete:
       tags:
         - workflows
       summary: Delete test parameter files for a given version.
-      description: ''
+      description: ""
       operationId: deleteTestParameterFiles
       parameters:
         - name: workflowId
@@ -5388,7 +5398,7 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
@@ -5396,16 +5406,16 @@ paths:
                 type: array
                 uniqueItems: true
                 items:
-                  $ref: '#/components/schemas/SourceFile'
+                  $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-  '/workflows/{workflowId}/tools/{workflowVersionId}':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/tools/{workflowVersionId}":
     get:
       tags:
         - workflows
       summary: Get the Tools for a given workflow version.
-      description: >-
-        Does not require authentication for published workflows, authentication
+      description: Does not require authentication for published workflows, authentication
         can be provided for restricted workflows
       operationId: getTableToolContent
       parameters:
@@ -5424,20 +5434,21 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: string
       security:
-        - BEARER: []
-  '/workflows/{workflowId}/unstar':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/unstar":
     delete:
       tags:
         - workflows
       summary: Unstar a workflow.
-      description: ''
+      description: ""
       operationId: unstarEntry
       parameters:
         - name: workflowId
@@ -5451,13 +5462,14 @@ paths:
         default:
           description: successful operation
       security:
-        - BEARER: []
-  '/workflows/{workflowId}/users':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/users":
     get:
       tags:
         - workflows
       summary: Get users of a workflow.
-      description: ''
+      description: ""
       operationId: getUsers
       parameters:
         - name: workflowId
@@ -5468,17 +5480,18 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/User'
+                  $ref: "#/components/schemas/User"
       security:
-        - BEARER: []
-  '/workflows/{workflowId}/verifiedSources':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/verifiedSources":
     get:
       tags:
         - workflows
@@ -5494,18 +5507,18 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: string
-  '/workflows/{workflowId}/verify/{workflowVersionId}':
+  "/workflows/{workflowId}/verify/{workflowVersionId}":
     put:
       tags:
         - workflows
       summary: Verify or unverify a workflow. ADMIN ONLY
-      description: ''
+      description: ""
       operationId: verifyWorkflowVersion
       parameters:
         - name: workflowId
@@ -5522,26 +5535,26 @@ paths:
           schema:
             type: integer
             format: int64
+      requestBody:
+        $ref: "#/components/requestBodies/VerifyRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/WorkflowVersion'
+                  $ref: "#/components/schemas/WorkflowVersion"
       security:
-        - BEARER: []
-      requestBody:
-        $ref: '#/components/requestBodies/VerifyRequest'
-  '/workflows/{workflowId}/wdl':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/wdl":
     get:
       tags:
         - workflows
       summary: Get the primary WDL descriptor file on Github.
-      description: >-
-        Does not require authentication for published workflows, authentication
+      description: Does not require authentication for published workflows, authentication
         can be provided for restricted workflows
       operationId: wdl
       parameters:
@@ -5558,21 +5571,21 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SourceFile'
+                $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-  '/workflows/{workflowId}/wdl/{relative-path}':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/wdl/{relative-path}":
     get:
       tags:
         - workflows
       summary: Get the corresponding WDL descriptor file on Github.
-      description: >-
-        Does not require authentication for published workflows, authentication
+      description: Does not require authentication for published workflows, authentication
         can be provided for restricted workflows
       operationId: secondaryWdlPath
       parameters:
@@ -5594,20 +5607,21 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SourceFile'
+                $ref: "#/components/schemas/SourceFile"
       security:
-        - BEARER: []
-  '/workflows/{workflowId}/workflowVersions':
+        - BEARER:
+            []
+  "/workflows/{workflowId}/workflowVersions":
     put:
       tags:
         - workflows
       summary: Update the workflow versions linked to a workflow.
-      description: 'Updates workflow path, reference, and hidden attributes.'
+      description: Updates workflow path, reference, and hidden attributes.
       operationId: updateWorkflowVersion
       parameters:
         - name: workflowId
@@ -5617,32 +5631,33 @@ paths:
           schema:
             type: integer
             format: int64
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/WorkflowVersion'
-      security:
-        - BEARER: []
       requestBody:
         content:
           application/json:
             schema:
               type: array
               items:
-                $ref: '#/components/schemas/WorkflowVersion'
+                $ref: "#/components/schemas/WorkflowVersion"
         description: List of modified workflow versions
         required: true
-  '/workflows/{workflowId}/zip/{workflowVersionId}':
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/WorkflowVersion"
+      security:
+        - BEARER:
+            []
+  "/workflows/{workflowId}/zip/{workflowVersionId}":
     get:
       tags:
         - workflows
       summary: Download a ZIP file of a workflow and all associated files.
-      description: ''
+      description: ""
       operationId: getWorkflowZip
       parameters:
         - name: workflowId
@@ -5663,10 +5678,11 @@ paths:
         default:
           description: successful operation
       security:
-        - BEARER: []
+        - BEARER:
+            []
 externalDocs:
   description: Dockstore documentation
-  url: 'https://www.dockstore.org/docs/getting-started'
+  url: https://www.dockstore.org/docs/getting-started
 servers:
   - url: https://dockstore.org:8443
 components:
@@ -5675,7 +5691,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/PublishRequest'
+            $ref: "#/components/schemas/PublishRequest"
       description: PublishRequest to refresh the list of repos for a user
       required: true
     updateLabelsBody:
@@ -5683,8 +5699,7 @@ components:
         application/json:
           schema:
             type: string
-      description: >-
-        This is here to appease Swagger. It requires PUT methods to have a body,
+      description: This is here to appease Swagger. It requires PUT methods to have a body,
         even if it is empty. Please leave it empty.
     addTokenBody:
       content:
@@ -5696,14 +5711,14 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Workflow'
+            $ref: "#/components/schemas/Workflow"
       description: Workflow with updated information
       required: true
     DockstoreTool:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/DockstoreTool'
+            $ref: "#/components/schemas/DockstoreTool"
       description: Tool with updated information
       required: true
     SourceFileArray:
@@ -5712,23 +5727,22 @@ components:
           schema:
             type: array
             items:
-              $ref: '#/components/schemas/SourceFile'
-      description: >-
-        Set of updated sourcefiles, add files by adding new files with unknown
+              $ref: "#/components/schemas/SourceFile"
+      description: Set of updated sourcefiles, add files by adding new files with unknown
         paths, delete files by including them with emptied content
       required: true
     StarRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/StarRequest'
+            $ref: "#/components/schemas/StarRequest"
       description: StarRequest to star a repo for a user
       required: true
     VerifyRequest:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/VerifyRequest'
+            $ref: "#/components/schemas/VerifyRequest"
       description: Object containing verification information.
       required: true
   securitySchemes:
@@ -5755,7 +5769,7 @@ components:
           type: array
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/Entry'
+            $ref: "#/components/schemas/Entry"
         dbCreateDate:
           type: string
           format: date-time
@@ -5768,7 +5782,7 @@ components:
           description: Name of the collection.
           minLength: 3
           maxLength: 39
-          pattern: '\d*[a-zA-Z][a-zA-Z\d]*'
+          pattern: "[a-zA-Z][a-zA-Z\\d]*"
         description:
           type: string
           description: Description of the collection
@@ -5802,7 +5816,7 @@ components:
           type: object
           description: aliases can be used as an alternate unique id for entries
           additionalProperties:
-            $ref: '#/components/schemas/Alias'
+            $ref: "#/components/schemas/Alias"
         dbCreateDate:
           type: string
           format: date-time
@@ -5824,45 +5838,41 @@ components:
           readOnly: true
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/FileFormat'
+            $ref: "#/components/schemas/FileFormat"
         output_file_formats:
           type: array
           readOnly: true
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/FileFormat'
+            $ref: "#/components/schemas/FileFormat"
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
         description:
           type: string
-          description: >-
-            This is a human-readable description of this container and what it
+          description: This is a human-readable description of this container and what it
             is trying to accomplish, required GA4GH
         labels:
           type: array
-          description: >-
-            Labels (i.e. meta tags) for describing the purpose and contents of
+          description: Labels (i.e. meta tags) for describing the purpose and contents of
             containers
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/Label'
+            $ref: "#/components/schemas/Label"
         users:
           type: array
-          description: >-
-            This indicates the users that have control over this entry,
+          description: This indicates the users that have control over this entry,
             dockstore specific
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/User'
+            $ref: "#/components/schemas/User"
         starredUsers:
           type: array
-          description: >-
-            This indicates the users that have starred this entry, dockstore
+          description: This indicates the users that have starred this entry, dockstore
             specific
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/User'
+            $ref: "#/components/schemas/User"
         email:
           type: string
           description: This is the email of the git organization
@@ -5882,8 +5892,7 @@ components:
           description: Implementation specific timestamp for last updated on webservice
         gitUrl:
           type: string
-          description: >-
-            This is a link to the associated repo with a descriptor, required
+          description: This is a link to the associated repo with a descriptor, required
             GA4GH
         checker_id:
           type: integer
@@ -5892,8 +5901,7 @@ components:
           readOnly: true
         mode:
           type: string
-          description: >-
-            This indicates what mode this is in which informs how we do things
+          description: This indicates what mode this is in which informs how we do things
             like refresh, dockstore specific
           enum:
             - AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS
@@ -5902,44 +5910,37 @@ components:
             - HOSTED
         name:
           type: string
-          description: 'This is the name of the container, required: GA4GH'
+          description: "This is the name of the container, required: GA4GH"
         default_dockerfile_path:
           type: string
-          description: >-
-            This indicates for the associated git repository, the default path
-            to the Dockerfile, required: GA4GH
+          description: "This indicates for the associated git repository, the default path
+            to the Dockerfile, required: GA4GH"
         default_cwl_path:
           type: string
-          description: >-
-            This indicates for the associated git repository, the default path
-            to the CWL document, required: GA4GH
+          description: "This indicates for the associated git repository, the default path
+            to the CWL document, required: GA4GH"
         default_wdl_path:
           type: string
-          description: >-
-            This indicates for the associated git repository, the default path
+          description: This indicates for the associated git repository, the default path
             to the WDL document
         defaultCWLTestParameterFile:
           type: string
-          description: >-
-            This indicates for the associated git repository, the default path
+          description: This indicates for the associated git repository, the default path
             to the CWL test parameter file
         defaultWDLTestParameterFile:
           type: string
-          description: >-
-            This indicates for the associated git repository, the default path
+          description: This indicates for the associated git repository, the default path
             to the WDL test parameter file
         tool_maintainer_email:
           type: string
-          description: >-
-            The email address of the tool maintainer. Required for private
+          description: The email address of the tool maintainer. Required for private
             repositories
         private_access:
           type: boolean
           description: Is the docker image private or not.
         toolname:
           type: string
-          description: >-
-            This is the tool name of the container, when not-present this will
+          description: 'This is the tool name of the container, when not-present this will
             function just like 0.1 dockstorewhen present, this can be used to
             distinguish between two containers based on the same image, but
             associated with different CWL and Dockerfile documents. i.e. two
@@ -5947,27 +5948,25 @@ components:
             toolnames will be two different entries in the dockstore
             registry/namespace/name/tool, different options to edit tags, and
             only the same insofar as they would "docker pull" the same image,
-            required: GA4GH
+            required: GA4GH'
         namespace:
           type: string
-          description: 'This is a docker namespace for the container, required: GA4GH'
+          description: "This is a docker namespace for the container, required: GA4GH"
         registry_string:
           type: string
-          description: >-
-            This is a specific docker provider like quay.io or dockerhub or
-            n/a?, required: GA4GH
+          description: "This is a specific docker provider like quay.io or dockerhub or
+            n/a?, required: GA4GH"
         lastBuild:
           type: string
           format: date-time
           description: Implementation specific timestamp for last built
         tags:
           type: array
-          description: >-
-            Implementation specific tracking of valid build tags for the docker
+          description: Implementation specific tracking of valid build tags for the docker
             container
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/Tag'
+            $ref: "#/components/schemas/Tag"
         path:
           type: string
         descriptorType:
@@ -6004,7 +6003,7 @@ components:
           type: object
           description: aliases can be used as an alternate unique id for entries
           additionalProperties:
-            $ref: '#/components/schemas/Alias'
+            $ref: "#/components/schemas/Alias"
         dbCreateDate:
           type: string
           format: date-time
@@ -6023,45 +6022,41 @@ components:
           readOnly: true
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/FileFormat'
+            $ref: "#/components/schemas/FileFormat"
         output_file_formats:
           type: array
           readOnly: true
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/FileFormat'
+            $ref: "#/components/schemas/FileFormat"
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
         description:
           type: string
-          description: >-
-            This is a human-readable description of this container and what it
+          description: This is a human-readable description of this container and what it
             is trying to accomplish, required GA4GH
         labels:
           type: array
-          description: >-
-            Labels (i.e. meta tags) for describing the purpose and contents of
+          description: Labels (i.e. meta tags) for describing the purpose and contents of
             containers
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/Label'
+            $ref: "#/components/schemas/Label"
         users:
           type: array
-          description: >-
-            This indicates the users that have control over this entry,
+          description: This indicates the users that have control over this entry,
             dockstore specific
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/User'
+            $ref: "#/components/schemas/User"
         starredUsers:
           type: array
-          description: >-
-            This indicates the users that have starred this entry, dockstore
+          description: This indicates the users that have starred this entry, dockstore
             specific
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/User'
+            $ref: "#/components/schemas/User"
         email:
           type: string
           description: This is the email of the git organization
@@ -6081,8 +6076,7 @@ components:
           description: Implementation specific timestamp for last updated on webservice
         gitUrl:
           type: string
-          description: >-
-            This is a link to the associated repo with a descriptor, required
+          description: This is a link to the associated repo with a descriptor, required
             GA4GH
         checker_id:
           type: integer
@@ -6115,23 +6109,17 @@ components:
           type: string
           format: date-time
         user:
-          description: User that the event is acting on.
-          $ref: '#/components/schemas/User'
+          $ref: "#/components/schemas/User"
         organisation:
-          description: Organisation that the event is acting on.
-          $ref: '#/components/schemas/Organisation'
+          $ref: "#/components/schemas/Organisation"
         tool:
-          description: Tool that the event is acting on.
-          $ref: '#/components/schemas/DockstoreTool'
+          $ref: "#/components/schemas/DockstoreTool"
         workflow:
-          description: Workflow that the event is acting on.
-          $ref: '#/components/schemas/Workflow'
+          $ref: "#/components/schemas/Workflow"
         collection:
-          description: Collection that the event is acting on.
-          $ref: '#/components/schemas/Collection'
+          $ref: "#/components/schemas/Collection"
         initiatorUser:
-          description: User initiating the event.
-          $ref: '#/components/schemas/User'
+          $ref: "#/components/schemas/User"
         type:
           type: string
           description: The event type.
@@ -6166,8 +6154,7 @@ components:
         value:
           type: string
           description: String representation of the file format
-      description: >-
-        This describes an input or output file format that is associated with an
+      description: This describes an input or output file format that is associated with an
         entry in the dockstore
     FileWrapper:
       type: object
@@ -6177,18 +6164,16 @@ components:
           description: The content of the file itself. One of url or content is required.
         url:
           type: string
-          description: >-
-            Optional url to the underlying content, should include version
+          description: Optional url to the underlying content, should include version
             information, and can include a git hash.  Note that this URL should
             resolve to the raw unwrapped content that would otherwise be
             available in content. One of url or content is required.
-      description: >-
-        A file provides content for one of - A tool descriptor is a metadata
+      description: "A file provides content for one of - A tool descriptor is a metadata
         document that describes one or more tools. - A tool document that
         describes how to test with one or more sample test JSON. - A
         containerfile is a document that describes how to build a particular
         container image. Examples include Dockerfiles for creating Docker images
-        and Singularity recipes for Singularity images 
+        and Singularity recipes for Singularity images "
     Label:
       type: object
       required:
@@ -6202,8 +6187,7 @@ components:
         value:
           type: string
           description: String representation of the tag
-      description: >-
-        This describes a descriptive label that can be placed on an entry in the
+      description: This describes a descriptive label that can be placed on an entry in the
         dockstore
     Metadata:
       type: object
@@ -6216,16 +6200,13 @@ components:
           description: The version of this registry
         api_version:
           type: string
-          description: >-
-            The version of the GA4GH tool-registry API supported by this
-            registry
+          description: The version of the GA4GH tool-registry API supported by this registry
         country:
           type: string
           description: A country code for the registry (ISO 3166-1 alpha-3)
         friendly_name:
           type: string
-          description: >-
-            A friendly name that can be used in addition to the hostname to
+          description: A friendly name that can be used in addition to the hostname to
             describe a registry
       description: Describes this registry to better allow for mirroring and indexing.
     MetadataV1:
@@ -6262,7 +6243,7 @@ components:
           description: Name of the organisation (ex. OICR)
           minLength: 3
           maxLength: 39
-          pattern: '\d*[a-zA-Z][a-zA-Z\d]*'
+          pattern: "[a-zA-Z][a-zA-Z\\d]*"
         description:
           type: string
           description: Description of the organisation
@@ -6288,11 +6269,11 @@ components:
         - role
       properties:
         id:
-          $ref: '#/components/schemas/OrganisationUserId'
+          $ref: "#/components/schemas/OrganisationUserId"
         user:
-          $ref: '#/components/schemas/User'
+          $ref: "#/components/schemas/User"
         organisation:
-          $ref: '#/components/schemas/Organisation'
+          $ref: "#/components/schemas/Organisation"
         role:
           type: string
           description: The role of the user in the organisation
@@ -6378,7 +6359,7 @@ components:
         workflows:
           type: array
           items:
-            $ref: '#/components/schemas/Workflow'
+            $ref: "#/components/schemas/Workflow"
     SourceControlBean:
       type: object
       properties:
@@ -6399,11 +6380,10 @@ components:
           description: Implementation specific ID for the source file in this web service
         verifiedBySource:
           type: object
-          description: >-
-            maps from platform to whether an entry successfully ran on it using
+          description: maps from platform to whether an entry successfully ran on it using
             this test json
           additionalProperties:
-            $ref: '#/components/schemas/VerificationInformation'
+            $ref: "#/components/schemas/VerificationInformation"
         type:
           type: string
           description: Enumerates the type of file
@@ -6456,7 +6436,7 @@ components:
           description: Cached validations for each version.
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/Validation'
+            $ref: "#/components/schemas/Validation"
         last_modified:
           type: string
           format: date-time
@@ -6466,25 +6446,22 @@ components:
           description: git commit/tag/branch
         sourceFiles:
           type: array
-          description: >-
-            Cached files for each version. Includes Dockerfile and Descriptor
+          description: Cached files for each version. Includes Dockerfile and Descriptor
             files
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/SourceFile'
+            $ref: "#/components/schemas/SourceFile"
         hidden:
           type: boolean
-          description: >-
-            Implementation specific, whether this row is visible to other users
+          description: Implementation specific, whether this row is visible to other users
             aside from the owner
         valid:
           type: boolean
-          description: >-
-            Implementation specific, whether this tag has valid files from
+          description: Implementation specific, whether this tag has valid files from
             source code repo
         name:
           type: string
-          description: 'Implementation specific, can be a quay.io or docker hub tag name'
+          description: Implementation specific, can be a quay.io or docker hub tag name
         dirtyBit:
           type: boolean
           description: True if user has altered the tag
@@ -6505,10 +6482,7 @@ components:
             - REQUESTED
             - CREATED
         versionEditor:
-          description: >-
-            Particularly for hosted workflows, this records who edited to create
-            a revision
-          $ref: '#/components/schemas/User'
+          $ref: "#/components/schemas/User"
         size:
           type: integer
           format: int64
@@ -6524,8 +6498,7 @@ components:
           description: Path for the WDL document
         automated:
           type: boolean
-          description: >-
-            Implementation specific, indicates whether this is an automated
+          description: Implementation specific, indicates whether this is an automated
             build on quay.io
         workingDirectory:
           type: string
@@ -6533,25 +6506,21 @@ components:
           type: string
         input_file_formats:
           type: array
-          description: >-
-            File formats for describing the input file formats of versions
+          description: File formats for describing the input file formats of versions
             (tag/workflowVersion)
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/FileFormat'
+            $ref: "#/components/schemas/FileFormat"
         output_file_formats:
           type: array
-          description: >-
-            File formats for describing the output file formats of versions
+          description: File formats for describing the output file formats of versions
             (tag/workflowVersion)
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/FileFormat'
+            $ref: "#/components/schemas/FileFormat"
         commitID:
           type: string
-          description: >-
-            This is the commit id for the source control that the files belong
-            to
+          description: This is the commit id for the source control that the files belong to
       description: This describes one tag associated with a container.
     Token:
       type: object
@@ -6569,7 +6538,7 @@ components:
           description: Contents of the access token
         username:
           type: string
-          description: 'When an integrated service is not aware of the username, we store it'
+          description: When an integrated service is not aware of the username, we store it
         refreshToken:
           type: string
         userId:
@@ -6579,8 +6548,7 @@ components:
           type: string
           description: Contents of the access token
           readOnly: true
-      description: >-
-        Access tokens for this web service and integrated services like quay.io
+      description: Access tokens for this web service and integrated services like quay.io
         and github
     Tool:
       type: object
@@ -6594,16 +6562,15 @@ components:
       properties:
         url:
           type: string
-          example: 'http://agora.broadinstitute.org/tools/123456'
+          example: http://agora.broadinstitute.org/tools/123456
           description: The URL for this tool in this registry
         id:
           type: string
-          example: '123456'
-          description: 'A unique identifier of the tool, scoped to this registry'
+          example: "123456"
+          description: A unique identifier of the tool, scoped to this registry
         aliases:
           type: array
-          description: >-
-            OPTIONAL A list of strings that can be used to identify this tool.
+          description: OPTIONAL A list of strings that can be used to identify this tool.
             This can be used to expose alternative ids (such as GUIDs) for a
             tool for registries. Can be used to match tools across registries.
           items:
@@ -6615,27 +6582,23 @@ components:
           type: string
           description: The name of the tool.
         toolclass:
-          $ref: '#/components/schemas/ToolClass'
+          $ref: "#/components/schemas/ToolClass"
         description:
           type: string
           description: The description of the tool.
         author:
           type: string
-          description: >-
-            Contact information for the author of this tool entry in the
+          description: Contact information for the author of this tool entry in the
             registry. (More complex authorship information is handled by the
             descriptor)
         meta_version:
           type: string
-          description: >-
-            The version of this tool in the registry. Iterates when fields like
+          description: The version of this tool in the registry. Iterates when fields like
             the description, author, etc. are updated.
         contains:
           type: array
           example: '"https://bio.tools/tool/mytum.de/SNAP2/1"'
-          description: >-
-            An array of IDs for the applications that are stored inside this
-            tool
+          description: An array of IDs for the applications that are stored inside this tool
           items:
             type: string
         has_checker:
@@ -6643,18 +6606,15 @@ components:
           description: Whether this tool has a checker tool associated with it
         checker_url:
           type: string
-          description: >-
-            Optional url to the checker tool that will exit successfully if this
+          description: Optional url to the checker tool that will exit successfully if this
             tool produced the expected result given test data.
         verified:
           type: boolean
-          description: >-
-            Reports whether this tool has been verified by a specific
+          description: Reports whether this tool has been verified by a specific
             organization or individual
         verified_source:
           type: string
-          description: >-
-            Source of metadata that can support a verified tool, such as an
+          description: Source of metadata that can support a verified tool, such as an
             email or URL
         signed:
           type: boolean
@@ -6663,9 +6623,8 @@ components:
           type: array
           description: A list of versions for this tool
           items:
-            $ref: '#/components/schemas/ToolVersion'
-      description: >-
-        A tool (or described tool) is defined as a tuple of a descriptor file
+            $ref: "#/components/schemas/ToolVersion"
+      description: A tool (or described tool) is defined as a tuple of a descriptor file
         (which potentially consists of multiple files), a set of container
         images, and a set of instructions for creating those images.
     ToolClass:
@@ -6679,11 +6638,8 @@ components:
           description: A short friendly name for the class
         description:
           type: string
-          description: >-
-            A longer explanation of what this class is and what it can
-            accomplish
-      description: >-
-        Describes a class (type) of tool allowing us to categorize workflows,
+          description: A longer explanation of what this class is and what it can accomplish
+      description: Describes a class (type) of tool allowing us to categorize workflows,
         tasks, and maybe even other entities (such as services) separately
     ToolDescriptor:
       type: object
@@ -6701,13 +6657,10 @@ components:
           description: The descriptor that represents this version of the tool.
         url:
           type: string
-          example: >-
-            https://raw.githubusercontent.com/ICGC-TCGA-PanCancer/pcawg_delly_workflow/ea2a5db69bd20a42976838790bc29294df3af02b/delly_docker/Delly.cwl
-          description: >-
-            Optional url to the underlying tool descriptor, should include
+          example: https://raw.githubusercontent.com/ICGC-TCGA-PanCancer/pcawg_delly_workflow/ea2a5db69bd20a42976838790bc29294df3af02b/delly_docker/Delly.cwl
+          description: Optional url to the underlying tool descriptor, should include
             version information, and can include a git hash
-      description: >-
-        A tool descriptor is a metadata document that describes one or more
+      description: A tool descriptor is a metadata document that describes one or more
         tools.
     ToolDockerfile:
       type: object
@@ -6719,21 +6672,18 @@ components:
           description: The dockerfile content for this tool.
         url:
           type: string
-          description: >-
-            Optional url to the dockerfile used to build this image, should
+          description: Optional url to the dockerfile used to build this image, should
             include version information, and can include a git hash  (e.g.
             https://raw.githubusercontent.com/ICGC-TCGA-PanCancer/pcawg_delly_workflow/c83478829802b4d36374870843821abe1b625a71/delly_docker/Dockerfile
             )
-      description: >-
-        A tool dockerfile is a document that describes how to build a particular
+      description: A tool dockerfile is a document that describes how to build a particular
         Docker image.
     ToolFile:
       type: object
       properties:
         path:
           type: string
-          description: >-
-            Relative path of the file.  A descriptor's path can be used with the
+          description: Relative path of the file.  A descriptor's path can be used with the
             GA4GH .../{type}/descriptor/{relative_path} endpoint
         file_type:
           type: string
@@ -6748,17 +6698,14 @@ components:
       properties:
         test:
           type: string
-          description: >-
-            Optional test JSON content for this tool. (Note that one of test and
+          description: Optional test JSON content for this tool. (Note that one of test and
             URL are required)
         url:
           type: string
-          description: >-
-            Optional url to the test JSON used to test this tool. Note that this
+          description: Optional url to the test JSON used to test this tool. Note that this
             URL should resolve to the raw unwrapped content that would otherwise
             be available in test.
-      description: >-
-        A tool document that describes how to test with one or more sample test
+      description: A tool document that describes how to test with one or more sample test
         JSON.
     ToolV1:
       type: object
@@ -6772,7 +6719,7 @@ components:
         toolname:
           type: string
         toolclass:
-          $ref: '#/components/schemas/ToolClass'
+          $ref: "#/components/schemas/ToolClass"
         description:
           type: string
         author:
@@ -6792,9 +6739,8 @@ components:
         versions:
           type: array
           items:
-            $ref: '#/components/schemas/ToolVersionV1'
-      description: >-
-        A tool (or described tool) describes one pairing of a tool as described
+            $ref: "#/components/schemas/ToolVersionV1"
+      description: A tool (or described tool) describes one pairing of a tool as described
         in a descriptor file (which potentially describes multiple tools) and a
         Docker image.
     ToolVersion:
@@ -6808,13 +6754,12 @@ components:
           description: The name of the version.
         url:
           type: string
-          example: 'http://agora.broadinstitute.org/tools/123456/1'
+          example: http://agora.broadinstitute.org/tools/123456/1
           description: The URL for this tool in this registry
         id:
           type: string
           example: v1
-          description: >-
-            An identifier of the version of this tool for this particular tool
+          description: An identifier of the version of this tool for this particular tool
             registry
         image:
           type: string
@@ -6822,8 +6767,7 @@ components:
           description: The docker path to the image (and version) for this tool
         registry_url:
           type: string
-          description: >-
-            A URL to a Singularity registry is provided when a specific type of
+          description: A URL to a Singularity registry is provided when a specific type of
             image does not use ids in the Docker format. Used along with
             image_name to locate a specific image.
         image_name:
@@ -6843,21 +6787,17 @@ components:
           description: Reports if this tool has a containerfile available.
         meta_version:
           type: string
-          description: >-
-            The version of this tool version in the registry. Iterates when
+          description: The version of this tool version in the registry. Iterates when
             fields like the description, author, etc. are updated.
         verified:
           type: boolean
-          description: >-
-            Reports whether this tool has been verified by a specific
+          description: Reports whether this tool has been verified by a specific
             organization or individual
         verified_source:
           type: string
-          description: >-
-            Source of metadata that can support a verified tool, such as an
+          description: Source of metadata that can support a verified tool, such as an
             email or URL
-      description: >-
-        A tool version describes a particular iteration of a tool as described
+      description: A tool version describes a particular iteration of a tool as described
         by a reference to a specific image and/or documents.
     ToolVersionV1:
       type: object
@@ -6885,8 +6825,7 @@ components:
           type: boolean
         verified-source:
           type: string
-      description: >-
-        A tool version describes a particular iteration of a tool as described
+      description: A tool version describes a particular iteration of a tool as described
         by a reference to a specific image and dockerfile.
     User:
       type: object
@@ -6902,11 +6841,10 @@ components:
           readOnly: true
         userProfiles:
           type: object
-          description: >-
-            Profile information of the user retrieved from 3rd party sites
+          description: Profile information of the user retrieved from 3rd party sites
             (GitHub, Google, etc)
           additionalProperties:
-            $ref: '#/components/schemas/Profile'
+            $ref: "#/components/schemas/Profile"
         username:
           type: string
           description: Username on dockstore
@@ -6993,7 +6931,7 @@ components:
           type: object
           description: aliases can be used as an alternate unique id for entries
           additionalProperties:
-            $ref: '#/components/schemas/Alias'
+            $ref: "#/components/schemas/Alias"
         dbCreateDate:
           type: string
           format: date-time
@@ -7016,45 +6954,41 @@ components:
           readOnly: true
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/FileFormat'
+            $ref: "#/components/schemas/FileFormat"
         output_file_formats:
           type: array
           readOnly: true
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/FileFormat'
+            $ref: "#/components/schemas/FileFormat"
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
         description:
           type: string
-          description: >-
-            This is a human-readable description of this container and what it
+          description: This is a human-readable description of this container and what it
             is trying to accomplish, required GA4GH
         labels:
           type: array
-          description: >-
-            Labels (i.e. meta tags) for describing the purpose and contents of
+          description: Labels (i.e. meta tags) for describing the purpose and contents of
             containers
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/Label'
+            $ref: "#/components/schemas/Label"
         users:
           type: array
-          description: >-
-            This indicates the users that have control over this entry,
+          description: This indicates the users that have control over this entry,
             dockstore specific
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/User'
+            $ref: "#/components/schemas/User"
         starredUsers:
           type: array
-          description: >-
-            This indicates the users that have starred this entry, dockstore
+          description: This indicates the users that have starred this entry, dockstore
             specific
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/User'
+            $ref: "#/components/schemas/User"
         email:
           type: string
           description: This is the email of the git organization
@@ -7074,8 +7008,7 @@ components:
           description: Implementation specific timestamp for last updated on webservice
         gitUrl:
           type: string
-          description: >-
-            This is a link to the associated repo with a descriptor, required
+          description: This is a link to the associated repo with a descriptor, required
             GA4GH
         checker_id:
           type: integer
@@ -7084,8 +7017,7 @@ components:
           readOnly: true
         mode:
           type: string
-          description: >-
-            This indicates what mode this is in which informs how we do things
+          description: This indicates what mode this is in which informs how we do things
             like refresh, dockstore specific
           enum:
             - FULL
@@ -7093,8 +7025,7 @@ components:
             - HOSTED
         workflowName:
           type: string
-          description: >-
-            This is the name of the workflow, not needed when only one workflow
+          description: This is the name of the workflow, not needed when only one workflow
             in a repo
         organization:
           type: string
@@ -7104,32 +7035,27 @@ components:
           description: This is a git repository name
         sourceControl:
           type: string
-          description: >-
-            This is a specific source control provider like github or bitbucket
-            or n/a?, required: GA4GH
+          description: "This is a specific source control provider like github or bitbucket
+            or n/a?, required: GA4GH"
         descriptorType:
           type: string
-          description: >-
-            This is a descriptor type for the workflow, either CWL or WDL
+          description: This is a descriptor type for the workflow, either CWL or WDL
             (Defaults to CWL)
         workflow_path:
           type: string
-          description: >-
-            This indicates for the associated git repository, the default path
+          description: This indicates for the associated git repository, the default path
             to the CWL document
         defaultTestParameterFilePath:
           type: string
-          description: >-
-            This indicates for the associated git repository, the default path
+          description: This indicates for the associated git repository, the default path
             to the test parameter file
         workflowVersions:
           type: array
-          description: >-
-            Implementation specific tracking of valid build workflowVersions for
+          description: Implementation specific tracking of valid build workflowVersions for
             the docker container
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/WorkflowVersion'
+            $ref: "#/components/schemas/WorkflowVersion"
         is_checker:
           type: boolean
         full_workflow_path:
@@ -7166,7 +7092,7 @@ components:
           description: Cached validations for each version.
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/Validation'
+            $ref: "#/components/schemas/Validation"
         workingDirectory:
           type: string
         last_modified:
@@ -7178,25 +7104,22 @@ components:
           description: git commit/tag/branch
         sourceFiles:
           type: array
-          description: >-
-            Cached files for each version. Includes Dockerfile and Descriptor
+          description: Cached files for each version. Includes Dockerfile and Descriptor
             files
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/SourceFile'
+            $ref: "#/components/schemas/SourceFile"
         hidden:
           type: boolean
-          description: >-
-            Implementation specific, whether this row is visible to other users
+          description: Implementation specific, whether this row is visible to other users
             aside from the owner
         valid:
           type: boolean
-          description: >-
-            Implementation specific, whether this tag has valid files from
+          description: Implementation specific, whether this tag has valid files from
             source code repo
         name:
           type: string
-          description: 'Implementation specific, can be a quay.io or docker hub tag name'
+          description: Implementation specific, can be a quay.io or docker hub tag name
         dirtyBit:
           type: boolean
           description: True if user has altered the tag
@@ -7217,32 +7140,25 @@ components:
             - REQUESTED
             - CREATED
         versionEditor:
-          description: >-
-            Particularly for hosted workflows, this records who edited to create
-            a revision
-          $ref: '#/components/schemas/User'
+          $ref: "#/components/schemas/User"
         workflow_path:
           type: string
           description: Path for the workflow
         input_file_formats:
           type: array
-          description: >-
-            File formats for describing the input file formats of versions
+          description: File formats for describing the input file formats of versions
             (tag/workflowVersion)
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/FileFormat'
+            $ref: "#/components/schemas/FileFormat"
         output_file_formats:
           type: array
-          description: >-
-            File formats for describing the output file formats of versions
+          description: File formats for describing the output file formats of versions
             (tag/workflowVersion)
           uniqueItems: true
           items:
-            $ref: '#/components/schemas/FileFormat'
+            $ref: "#/components/schemas/FileFormat"
         commitID:
           type: string
-          description: >-
-            This is the commit id for the source control that the files belong
-            to
+          description: This is the commit id for the source control that the files belong to
       description: This describes one workflow version associated with a workflow.

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.6.0-alpha.3"
+  version: "1.6.0-alpha.4-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:
@@ -5273,7 +5273,7 @@ definitions:
         description: "Name of the collection."
         minLength: 3
         maxLength: 39
-        pattern: "\\d*[a-zA-Z][a-zA-Z\\d]*"
+        pattern: "[a-zA-Z][a-zA-Z\\d]*"
       description:
         type: "string"
         position: 2
@@ -5792,7 +5792,7 @@ definitions:
         description: "Name of the organisation (ex. OICR)"
         minLength: 3
         maxLength: 39
-        pattern: "\\d*[a-zA-Z][a-zA-Z\\d]*"
+        pattern: "[a-zA-Z][a-zA-Z\\d]*"
       description:
         type: "string"
         position: 2


### PR DESCRIPTION

#2034

Saving a new hosted workflow version calls
`ElasticManager.handleIndexUpdate`, which would cause an error to be
logged if the the workflow is not published. Log it at info level
instead, since it's not an error condition.

The other option is to not call the method at all if the workflow is
not published, but the method is called from several places, and that
seemed slightly riskier.

Also noticed that if there is an error in the response from the
ElasticManager, that wasn't being logged at the error level.

