### PR TITLE
Ensure absolute path always set for hosted workflows

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
@@ -267,6 +267,19 @@ public class CRUDClientIT extends BaseIT {
         // files should be visible afterwards
         file = otherUserApi.cwl(dockstoreWorkflow.getId(), first.get().getName());
         assertTrue(!file.getContent().isEmpty());
+
+        // Check that absolute file gets set if not explicity set
+        SourceFile file4 = new SourceFile();
+        file4.setContent(FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("tar-param.cwl")), StandardCharsets.UTF_8));
+        file4.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
+        String ABS_PATH_TEST = "/no-absolute-path.cwl";
+        file4.setPath(ABS_PATH_TEST);
+        file4.setAbsolutePath(null); // Redundant, but clarifies intent of test
+        dockstoreWorkflow = api.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file4));
+        first = dockstoreWorkflow .getWorkflowVersions().stream().max(Comparator.comparingInt((WorkflowVersion t) -> Integer.parseInt(t.getName())));
+        Optional<SourceFile> msf = first.get().getSourceFiles().stream().filter(sf -> ABS_PATH_TEST.equals(sf.getPath())).findFirst();
+        String absolutePath = msf.get().getAbsolutePath();
+        assertEquals(ABS_PATH_TEST, absolutePath);
     }
 
     @Test

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -185,13 +185,7 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
             throw new CustomWebApplicationException("You have " + currentCount + " workflow versions which is at the current limit of " + calculatedEntryVersionLimit, HttpStatus.SC_PAYMENT_REQUIRED);
         }
 
-        // When submitted from UI absolutePath is null.
-        // Optionally, we could give an error here and force UI to set it.
-        sourceFiles.stream().forEach(sourceFile -> {
-            if (sourceFile.getAbsolutePath() == null) {
-                sourceFile.setAbsolutePath(sourceFile.getPath());
-            }
-        });
+        updateUnsetAbsolutePaths(sourceFiles);
 
         U version = getVersion(entry);
         Set<SourceFile> versionSourceFiles = handleSourceFileMerger(entryId, sourceFiles, entry, version);
@@ -217,6 +211,18 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
         T newTool = getEntryDAO().findById(entryId);
         elasticManager.handleIndexUpdate(newTool, ElasticMode.UPDATE);
         return newTool;
+    }
+
+    /**
+     * UI submits source files without the
+     * @param sourceFiles
+     */
+    private void updateUnsetAbsolutePaths(@ApiParam(value = "Set of updated sourcefiles, add files by adding new files with unknown paths, delete files by including them with emptied content", required = true) Set<SourceFile> sourceFiles) {
+        sourceFiles.stream().forEach(sourceFile -> {
+            if (sourceFile.getAbsolutePath() == null) {
+                sourceFile.setAbsolutePath(sourceFile.getPath());
+            }
+        });
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -185,6 +185,14 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
             throw new CustomWebApplicationException("You have " + currentCount + " workflow versions which is at the current limit of " + calculatedEntryVersionLimit, HttpStatus.SC_PAYMENT_REQUIRED);
         }
 
+        // When submitted from UI absolutePath is null.
+        // Optionally, we could give an error here and force UI to set it.
+        sourceFiles.stream().forEach(sourceFile -> {
+            if (sourceFile.getAbsolutePath() == null) {
+                sourceFile.setAbsolutePath(sourceFile.getPath());
+            }
+        });
+
         U version = getVersion(entry);
         Set<SourceFile> versionSourceFiles = handleSourceFileMerger(entryId, sourceFiles, entry, version);
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -214,10 +214,14 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
     }
 
     /**
-     * UI submits source files without the
+     * For all source files whose absolutePath is not set, set the absolutePath to the path.
+     *
+     * The absolutePath may not be null in the database, but it is not set when the UI invokes
+     * the Webservice API.
+     *
      * @param sourceFiles
      */
-    private void updateUnsetAbsolutePaths(@ApiParam(value = "Set of updated sourcefiles, add files by adding new files with unknown paths, delete files by including them with emptied content", required = true) Set<SourceFile> sourceFiles) {
+    private void updateUnsetAbsolutePaths(Set<SourceFile> sourceFiles) {
         sourceFiles.stream().forEach(sourceFile -> {
             if (sourceFile.getAbsolutePath() == null) {
                 sourceFile.setAbsolutePath(sourceFile.getPath());

--- a/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
@@ -191,4 +191,10 @@
         <addForeignKeyConstraint baseColumnNames="validationid" baseTableName="version_validation" constraintName="fkvalidationid" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="validation"/>
     </changeSet>
 
+    <changeSet id="AddNotNullAbsolutePathConstraint" author="coverbeck">
+        <sql dbms="postgres">
+            UPDATE sourcefile SET absolutepath=path WHERE absolutepath isnull
+        </sql>
+        <addNotNullConstraint tableName="sourcefile" columnName="absolutepath"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
@@ -193,7 +193,7 @@
 
     <changeSet id="AddNotNullAbsolutePathConstraint" author="coverbeck">
         <sql dbms="postgres">
-            UPDATE sourcefile SET absolutepath=path WHERE absolutepath isnull
+            UPDATE sourcefile SET absolutepath=path WHERE absolutepath is null
         </sql>
         <addNotNullConstraint tableName="sourcefile" columnName="absolutepath"/>
     </changeSet>


### PR DESCRIPTION

#2040 

The cause of downloading a zip failing was that the code was not expecting SourceFile.absolutePath to be null. Don't allow absolutePath to be null.

1. Enforce it in the database
2. If an API call is made with the absolutePath not set, set it to the path.