### PR TITLE
Provide Cromwell stdout and stderr to console

### DIFF
--- a/dockstore-client/src/main/java/io/github/collaboratory/wdl/WDLClient.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/wdl/WDLClient.java
@@ -199,7 +199,7 @@ public class WDLClient implements LanguageClientInterface {
                 // TODO: probably want to make a new library call so that we can stream output properly and get this exit code
                 final String join = Joiner.on(" ").join(arguments);
                 System.out.println(join);
-                final ImmutablePair<String, String> execute = Utilities.executeCommand(join, localPrimaryDescriptorFile.getParentFile());
+                final ImmutablePair<String, String> execute = Utilities.executeCommand(join, System.out, System.err, localPrimaryDescriptorFile.getParentFile());
                 stdout = execute.getLeft();
                 stderr = execute.getRight();
             } catch (RuntimeException e) {

--- a/dockstore-common/src/main/java/io/dockstore/common/Utilities.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/Utilities.java
@@ -93,6 +93,10 @@ public final class Utilities {
         return executeCommand(command, true, Optional.of(stdoutStream), Optional.of(stderrStream), null);
     }
 
+    public static ImmutablePair<String, String> executeCommand(String command, OutputStream stdoutStream, OutputStream stderrStream, File workingDir) {
+        return executeCommand(command, true, Optional.of(stdoutStream), Optional.of(stderrStream), workingDir);
+    }
+
     /**
      * Execute a command and return stdout and stderr
      *


### PR DESCRIPTION
Provides Cromwell stdout and stderr to the console as Cromwell is running a workflow so you don't have to wait until Cromwell is finished to see its output.