### PR TITLE
Migration was not removing null values

### DIFF
--- a/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
@@ -192,9 +192,10 @@
     </changeSet>
 
     <changeSet id="AddNotNullAbsolutePathConstraint" author="coverbeck">
-        <sql dbms="postgres">
-            UPDATE sourcefile SET absolutepath=path WHERE absolutepath is null
-        </sql>
+        <update tableName="sourcefile">
+            <column name="absolutepath" valueComputed="path"/>
+            <where>absolutepath is null</where>
+        </update>
         <addNotNullConstraint tableName="sourcefile" columnName="absolutepath"/>
     </changeSet>
 


### PR DESCRIPTION
#2093

Running migrations was not removing null value from
absolutepath row, and the addNotNullConstraint would then fail.
Changed to use the `<update>` element.

