### PR TITLE
change TRS V1 response objects to correctly link to v1 response url

### DIFF
--- a/dockstore-webservice/src/main/java/io/swagger/model/ToolV1.java
+++ b/dockstore-webservice/src/main/java/io/swagger/model/ToolV1.java
@@ -73,6 +73,10 @@ public class ToolV1 {
                 ToolVersionV1 oldVersion = new ToolVersionV1(version);
                 versions.add(oldVersion);
             }
+            // if request is V1 api, make sure url reflects this after conversion
+            if (this.getUrl() != null) {
+                this.setUrl(this.getUrl().replaceFirst("/ga4gh/v2/", "/ga4gh/v1/"));
+            }
         } catch (IllegalAccessException | InvocationTargetException e) {
             LOG.error("unable to backwards convert toolVersion");
             throw new RuntimeException(e);

--- a/dockstore-webservice/src/main/java/io/swagger/model/ToolVersionV1.java
+++ b/dockstore-webservice/src/main/java/io/swagger/model/ToolVersionV1.java
@@ -57,6 +57,10 @@ public class ToolVersionV1  {
             // looks like BeanUtils has issues due to https://issues.apache.org/jira/browse/BEANUTILS-321 and https://github.com/swagger-api/swagger-codegen/issues/7764
             this.dockerfile = toolVersion.isContainerfile();
             this.verified = toolVersion.isVerified();
+            // if request is V1 api, make sure url reflects this after conversion
+            if (this.getUrl() != null) {
+                this.setUrl(this.getUrl().replaceFirst("/ga4gh/v2/", "/ga4gh/v1/"));
+            }
             // descriptor type seems to have issues, maybe because nextflow didn't exist
             List<DescriptorType> newTypes = toolVersion.getDescriptorType();
             descriptorType.clear();

--- a/dockstore-webservice/src/test/java/io/swagger/model/ToolV1Test.java
+++ b/dockstore-webservice/src/test/java/io/swagger/model/ToolV1Test.java
@@ -1,0 +1,31 @@
+package io.swagger.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ToolV1Test {
+    /**
+     * This tests that urls with /ga4gh/v1/ api requests correctly have V1 urls in response after api conversion.
+     */
+    @Test
+    public void checkToolV1URL() {
+        Tool tool = new Tool();
+        tool.setVerified(true);
+        tool.setSigned(true);
+        tool.setUrl("https://dockstore.org/api/api/ga4gh/v2/tools/quay.io%2Fpancancer%2Fpcawg-bwa-mem-workflow/versions/2.6.7");
+        ToolV1 toolV1 = new ToolV1(tool);
+        Assert.assertEquals("https://dockstore.org/api/api/ga4gh/v1/tools/quay.io%2Fpancancer%2Fpcawg-bwa-mem-workflow/versions/2.6.7", toolV1.getUrl());
+    }
+
+    /**
+     * This tests that a null value url is not effected by url api version check
+     */
+    @Test
+    public void checkToolV1Null(){
+        Tool tool = new Tool();
+        tool.setVerified(true);
+        tool.setSigned(true);
+        ToolV1 toolV1 = new ToolV1(tool);
+        Assert.assertEquals(null, toolV1.getUrl());
+    }
+}

--- a/dockstore-webservice/src/test/java/io/swagger/model/ToolVersionV1Test.java
+++ b/dockstore-webservice/src/test/java/io/swagger/model/ToolVersionV1Test.java
@@ -1,0 +1,36 @@
+package io.swagger.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+public class ToolVersionV1Test {
+    /**
+     * This tests that the urls with /gagh4/V1/ api requests correctly have V1 urls in response in all tool versions after api conversion.
+     */
+    @Test
+    public void checkToolVersionURL() {
+        ToolVersion toolVersion = new ToolVersion();
+        toolVersion.setContainerfile(true);
+        toolVersion.setVerified(true);
+        toolVersion.setDescriptorType(Collections.emptyList());
+        toolVersion.setUrl("https://dockstore.org/api/api/ga4gh/v2/tools/quay.io%2Fpancancer%2Fpcawg-bwa-mem-workflow/versions/2.6.7");
+        ToolVersionV1 toolVersionV1 = new ToolVersionV1(toolVersion);
+        Assert.assertEquals("https://dockstore.org/api/api/ga4gh/v1/tools/quay.io%2Fpancancer%2Fpcawg-bwa-mem-workflow/versions/2.6.7", toolVersionV1.getUrl());
+    }
+
+    /**
+     * This tests that a null value url is not effected by url api version check
+     */
+    @Test
+    public void checkToolVersionNull() {
+        ToolVersion toolVersion = new ToolVersion();
+        toolVersion.setContainerfile(true);
+        toolVersion.setVerified(true);
+        toolVersion.setDescriptorType(Collections.emptyList());
+        ToolVersionV1 toolVersionV1 = new ToolVersionV1(toolVersion);
+        Assert.assertEquals(null, toolVersionV1.getUrl());
+    }
+}
+


### PR DESCRIPTION
When given a GA4GHV1 api request, the tool would first create a v2 objects then would convert to V1 objects. In this process the url wasn't handled to reflect v1 in the response, but otherwise the code worked. This fix includes adding a change in the conversion to correctly reflect v1 in urls of a ga4gh/v1 request. Also added unit tests.

A v1 api request now correctly returns a v1 url response.
A v2 api request still correctly returns a v2 url response.

Can test by running curls locally:
v1:
`curl http://localhost:8080/api/ga4gh/v1/tools/quay.io%2Fpancancer%2Fpcawg-bwa-mem-workflow`
v2:
`curl http://localhost:8080/api/ga4gh/v2/tools/quay.io%2Fpancancer%2Fpcawg-bwa-mem-workflow`


