### PR TITLE
Feature/force db consistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,8 @@ before_cache:
 - rm -rf $HOME/.m2/repository/.cache/download-maven-plugin directory
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash) -F ${TESTING_PROFILE//-} || echo "Codecov did not collect coverage reports"
+- scripts/check_migrations.sh 
+- bash <(curl -s https://codecov.io/bash) -F ${TESTING_PROFILE//-} || echo "Codecov did not collect coverage reports"
   
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,9 @@ jobs:
       jdk: openjdk10
       env:
       - TESTING_PROFILE=automated-review
-      script: mvn --batch-mode clean install -DskipTests -P$TESTING_PROFILE
+      script:
+      - mvn --batch-mode clean install -DskipTests -P$TESTING_PROFILE
+      - scripts/check_migrations.sh
 
     # no point in running integration tests if we don't pass unit tests
     # run a few tests with oraclejdk8 for backwards compat
@@ -92,7 +94,7 @@ jobs:
       script: mvn --batch-mode clean install jacoco:report-integration jacoco:report-aggregate coveralls:report -P$TESTING_PROFILE,coverage -DskipClientITs=true
       env:
         - TESTING_PROFILE=other-integration-tests
-# build lifecycle is before_install, install, before_script, script, after_script
+# build lifecycle is before_install, install, before_script, script, before_cache, after_success/after_failure, after_script
 
 before_install:
 - export M2_HOME=$HOME/apache-maven-3.5.4
@@ -124,7 +126,6 @@ before_cache:
 - rm -rf $HOME/.m2/repository/.cache/download-maven-plugin directory
 
 after_success:
-- scripts/check_migrations.sh 
 - bash <(curl -s https://codecov.io/bash) -F ${TESTING_PROFILE//-} || echo "Codecov did not collect coverage reports"
   
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,12 @@ jobs:
       - TESTING_PROFILE=unit-tests
       script: mvn --batch-mode clean install -P$TESTING_PROFILE
 
+    - stage: automated-review
+      jdk: openjdk10
+      env:
+      - TESTING_PROFILE=automated-review
+      script: mvn --batch-mode clean install -DskipTests -P$TESTING_PROFILE
+
     # no point in running integration tests if we don't pass unit tests
     # run a few tests with oraclejdk8 for backwards compat
     - stage: integration-tests

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 # Dockstore
 
 Dockstore provides a place for users to share tools encapsulated in Docker and described with the Common 
-Workflow Language (CWL) or WDL (Workflow Description Language). This enables scientists to share analytical 
+Workflow Language (CWL), WDL (Workflow Description Language), or Nextflow. This enables scientists to share analytical 
 workflows so that they are  machine readable as well as runnable in a variety of environments. While the 
 Dockstore is focused on serving researchers in the biosciences, the combination of Docker + CWL/WDL can be used by 
 anyone to describe the tools and services in their Docker images in a standardized, machine-readable way.  

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
@@ -23,19 +23,14 @@ import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
@@ -87,12 +82,6 @@ public class Token implements Comparable<Token> {
     @ApiModelProperty(position = 4)
     private String refreshToken;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "userId", insertable = false, updatable = false, foreignKey = @ForeignKey(name = "fk_userid_with_enduser"))
-    @JsonIgnore
-    private User user;
-
-    // TODO: tokens will need to be associated with a particular user
     @Column
     @ApiModelProperty(position = 5)
     private long userId;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
@@ -23,14 +23,19 @@ import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
@@ -46,7 +51,7 @@ import org.hibernate.annotations.UpdateTimestamp;
  */
 @ApiModel(value = "Token", description = "Access tokens for this web service and integrated services like quay.io and github")
 @Entity
-@Table(name = "token", uniqueConstraints = @UniqueConstraint(columnNames = { "username", "tokenSource" }))
+@Table(name = "token", uniqueConstraints = @UniqueConstraint(name = "one_token_link_per_identify", columnNames = { "username", "tokenSource" }))
 @NamedQueries({
     @NamedQuery(name = "io.dockstore.webservice.core.Token.findByContent", query = "SELECT t FROM Token t WHERE t.content = :content"),
     @NamedQuery(name = "io.dockstore.webservice.core.Token.findByUserId", query = "SELECT t FROM Token t WHERE t.userId = :userId"),
@@ -81,6 +86,11 @@ public class Token implements Comparable<Token> {
     @Column
     @ApiModelProperty(position = 4)
     private String refreshToken;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId", insertable = false, updatable = false, foreignKey = @ForeignKey(name = "fk_userid_with_enduser"))
+    @JsonIgnore
+    private User user;
 
     // TODO: tokens will need to be associated with a particular user
     @Column

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -61,7 +61,7 @@ import org.hibernate.annotations.Check;
         "This describes one entry in the dockstore. Logically, this currently means one tuple of registry (either quay or docker hub), organization, image name, and toolname which can be\n"
                 + " * associated with CWL and Dockerfile documents")
 @Entity
-@Table(uniqueConstraints = @UniqueConstraint(columnNames = { "registry", "namespace", "name", "toolname" }))
+@Table(uniqueConstraints = @UniqueConstraint(name = "ukbq5vy17y4ocaist3d3r3imcus", columnNames = { "registry", "namespace", "name", "toolname" }))
 @NamedQueries({
         @NamedQuery(name = "io.dockstore.webservice.core.Tool.findByNameAndNamespaceAndRegistry", query = "SELECT c FROM Tool c WHERE c.name = :name AND c.namespace = :namespace AND c.registry = :registry"),
         @NamedQuery(name = "io.dockstore.webservice.core.Tool.findPublishedById", query = "SELECT c FROM Tool c WHERE c.id = :id AND c.isPublished = true"),

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Validation.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Validation.java
@@ -55,6 +55,7 @@ public class Validation implements Comparable<Validation> {
     private long id;
 
     @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "text")
     @ApiModelProperty(value = "Enumerates the type of file", required = true, position = 1)
     private SourceFile.FileType type;
 
@@ -62,7 +63,7 @@ public class Validation implements Comparable<Validation> {
     @ApiModelProperty(value = "Is the file type valid", required = true, position = 2)
     private boolean valid = false;
 
-    @Column
+    @Column(columnDefinition = "text")
     @ApiModelProperty(value = "Mapping of filepath to validation message", required = true, position = 3)
     private String message;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -58,7 +58,7 @@ import org.hibernate.annotations.Check;
  */
 @ApiModel(value = "Workflow", description = "This describes one workflow in the dockstore")
 @Entity
-@Table(uniqueConstraints = @UniqueConstraint(columnNames = { "sourceControl", "organization", "repository", "workflowName" }))
+@Table(uniqueConstraints = @UniqueConstraint(name = "unique_workflow_paths", columnNames = { "sourceControl", "organization", "repository", "workflowName" }))
 @NamedQueries({
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findPublishedById", query = "SELECT c FROM Workflow c WHERE c.id = :id AND c.isPublished = true"),
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.countAllPublished", query = "SELECT COUNT(c.id)" + Workflow.PUBLISHED_QUERY),

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -34,8 +34,6 @@ import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.OrderBy;
-import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -58,7 +56,6 @@ import org.hibernate.annotations.Check;
  */
 @ApiModel(value = "Workflow", description = "This describes one workflow in the dockstore")
 @Entity
-@Table(uniqueConstraints = @UniqueConstraint(name = "unique_workflow_paths", columnNames = { "sourceControl", "organization", "repository", "workflowName" }))
 @NamedQueries({
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findPublishedById", query = "SELECT c FROM Workflow c WHERE c.id = :id AND c.isPublished = true"),
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.countAllPublished", query = "SELECT COUNT(c.id)" + Workflow.PUBLISHED_QUERY),

--- a/dockstore-webservice/src/main/resources/import.sql
+++ b/dockstore-webservice/src/main/resources/import.sql
@@ -5,5 +5,7 @@
 COMMENT ON COLUMN sourcefile_verified.platformversion IS 'By default set to null';
 COMMENT ON COLUMN validation.message IS 'A mapping of file path to message.';
 -- postgres partial indexes seem unsupported https://stackoverflow.com/questions/12025844/how-to-annotate-unique-constraint-with-where-clause-in-jpa
+CREATE UNIQUE INDEX full_workflow_name ON workflow USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
+CREATE UNIQUE INDEX full_tool_name ON tool USING btree (registry, namespace, name, toolname) WHERE toolname IS NOT NULL;
 CREATE UNIQUE INDEX partial_workflow_name ON workflow USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
 CREATE UNIQUE INDEX partial_tool_name ON tool USING btree (registry, namespace, name) WHERE toolname IS NULL;

--- a/dockstore-webservice/src/main/resources/import.sql
+++ b/dockstore-webservice/src/main/resources/import.sql
@@ -9,3 +9,5 @@ CREATE UNIQUE INDEX full_workflow_name ON workflow USING btree (sourcecontrol, o
 CREATE UNIQUE INDEX full_tool_name ON tool USING btree (registry, namespace, name, toolname) WHERE toolname IS NOT NULL;
 CREATE UNIQUE INDEX partial_workflow_name ON workflow USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
 CREATE UNIQUE INDEX partial_tool_name ON tool USING btree (registry, namespace, name) WHERE toolname IS NULL;
+-- unable to convert this to JPA properly
+ALTER TABLE token ADD CONSTRAINT fk_userid_with_enduser FOREIGN KEY (userid) REFERENCES public.enduser (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION

--- a/dockstore-webservice/src/main/resources/import.sql
+++ b/dockstore-webservice/src/main/resources/import.sql
@@ -1,0 +1,9 @@
+-- this file is a last chance to modify any database schema in create mode with postgres-specific
+-- changes not possible in JPA
+
+-- column remark support in JPA does not seem to work for postgres, possible starting point https://stackoverflow.com/questions/28773022/jpa-column-annotation-to-create-comment-description 
+COMMENT ON COLUMN sourcefile_verified.platformversion IS 'By default set to null';
+COMMENT ON COLUMN validation.message IS 'A mapping of file path to message.';
+-- postgres partial indexes seem unsupported https://stackoverflow.com/questions/12025844/how-to-annotate-unique-constraint-with-where-clause-in-jpa
+CREATE UNIQUE INDEX partial_workflow_name ON workflow USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
+CREATE UNIQUE INDEX partial_tool_name ON tool USING btree (registry, namespace, name) WHERE toolname IS NULL;

--- a/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
@@ -235,4 +235,13 @@
                       tableName="event"/>
         <sql dbms="postgres">ALTER SEQUENCE organisation_id_seq RENAME TO organization_id_seq</sql>
     </changeSet>
+
+    <changeSet author="dyuen" id="maintain_consistency">
+        <!-- looks like the above attempt didn't take -->
+        <renameSequence oldSequenceName="organisation_id_seq" newSequenceName="organization_id_seq"/>
+        <addUniqueConstraint columnNames="sourcecontrol, organization, repository, workflowname" constraintName="unique_workflow_paths" tableName="workflow"/>
+        <modifyDataType columnName="name" newDataType="varchar(39)" tableName="organization"/>
+        <modifyDataType columnName="type" newDataType="clob" tableName="validation"/>
+        <modifyDataType columnName="message" newDataType="clob" tableName="validation"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
@@ -239,7 +239,6 @@
     <changeSet author="dyuen" id="maintain_consistency">
         <!-- looks like the above attempt didn't take -->
         <renameSequence oldSequenceName="organisation_id_seq" newSequenceName="organization_id_seq"/>
-        <addUniqueConstraint columnNames="sourcecontrol, organization, repository, workflowname" constraintName="unique_workflow_paths" tableName="workflow"/>
         <modifyDataType columnName="name" newDataType="varchar(39)" tableName="organization"/>
         <modifyDataType columnName="type" newDataType="clob" tableName="validation"/>
         <modifyDataType columnName="message" newDataType="clob" tableName="validation"/>

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -6000,6 +6000,10 @@ components:
         custom_docker_registry_path:
           type: string
           readOnly: true
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -6015,10 +6019,6 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
@@ -6184,6 +6184,10 @@ components:
         dbUpdateDate:
           type: string
           format: date-time
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -6199,10 +6203,6 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
@@ -7128,6 +7128,10 @@ components:
           type: integer
           format: int64
           readOnly: true
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -7143,10 +7147,6 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1659,7 +1659,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Tool'
           description: default response
   /containers/hostedEntry/{entryId}:
     delete:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1030,7 +1030,7 @@ paths:
           description: default response
   /api/ga4gh/v2/extended/containers/{organization}:
     get:
-      operationId: entriesOrgGet_1
+      operationId: entriesOrgGet
       parameters:
       - in: path
         name: organization
@@ -1045,7 +1045,7 @@ paths:
           description: default response
   /api/ga4gh/v2/extended/organizations:
     get:
-      operationId: entriesOrgGet
+      operationId: entriesOrgGet_1
       responses:
         default:
           content:
@@ -1659,7 +1659,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Tool'
+                $ref: '#/components/schemas/Entry'
           description: default response
   /containers/hostedEntry/{entryId}:
     delete:
@@ -4049,7 +4049,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: '#/components/schemas/Entry'
           description: default response
     patch:
       operationId: editHosted_1

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1659,7 +1659,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Tool'
+                $ref: '#/components/schemas/Entry'
           description: default response
   /containers/hostedEntry/{entryId}:
     delete:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5482,6 +5482,10 @@ definitions:
       custom_docker_registry_path:
         type: "string"
         readOnly: true
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -5497,10 +5501,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       author:
         type: "string"
         position: 1
@@ -5693,6 +5693,10 @@ definitions:
       dbUpdateDate:
         type: "string"
         format: "date-time"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -5708,10 +5712,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       author:
         type: "string"
         position: 1
@@ -6721,6 +6721,10 @@ definitions:
         type: "integer"
         format: "int64"
         readOnly: true
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -6736,10 +6740,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       author:
         type: "string"
         position: 1

--- a/dockstore-webservice/src/test/java/io/swagger/model/ToolVersionV1Test.java
+++ b/dockstore-webservice/src/test/java/io/swagger/model/ToolVersionV1Test.java
@@ -1,9 +1,9 @@
 package io.swagger.model;
 
+import java.util.Collections;
+
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.Collections;
 
 public class ToolVersionV1Test {
     /**

--- a/scripts/check_migrations.sh
+++ b/scripts/check_migrations.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Checks that the JPA classes are consistent with the liquibase migrations
+# Includes Bash3 Boilerplate. Copyright (c) 2014, kvz.io
+
+set -o errexit
+set -o pipefail
+set -o nounset
+set -o xtrace
+
+if [ "${TESTING_PROFILE}" = "unit-tests" ]; then
+    bash propose_migration.sh
+    ! grep "changeSet" dockstore-webservice/target/detected-migrations.xml
+    exit 0;
+fi

--- a/scripts/check_migrations.sh
+++ b/scripts/check_migrations.sh
@@ -9,6 +9,6 @@ set -o xtrace
 
 if [ "${TESTING_PROFILE}" = "automated-review" ]; then
     bash propose_migration.sh
-    ! grep "changeSet" dockstore-webservice/target/detected-migrations.xml
+    (! grep "changeSet" dockstore-webservice/target/detected-migrations.xml)
     exit 0;
 fi

--- a/scripts/check_migrations.sh
+++ b/scripts/check_migrations.sh
@@ -7,7 +7,7 @@ set -o pipefail
 set -o nounset
 set -o xtrace
 
-if [ "${TESTING_PROFILE}" = "unit-tests" ]; then
+if [ "${TESTING_PROFILE}" = "automated-review" ]; then
     bash propose_migration.sh
     ! grep "changeSet" dockstore-webservice/target/detected-migrations.xml
     exit 0;

--- a/scripts/decrypt.sh
+++ b/scripts/decrypt.sh
@@ -8,7 +8,7 @@ set -o pipefail
 set -o nounset
 set -o xtrace
 
-if [[ "${TESTING_PROFILE}" == *"integration-tests"* ]]; then
+if [[ "${TESTING_PROFILE}" == *"integration-tests"* ]] || [[ "${TESTING_PROFILE}" == "automated-review" ]]; then
     openssl aes-256-cbc -K $encrypted_56104cec4f5a_key -iv $encrypted_56104cec4f5a_iv -in secrets.tar.enc -out secrets.tar -d
     tar xvf secrets.tar
 fi

--- a/scripts/decrypt.template.mustache
+++ b/scripts/decrypt.template.mustache
@@ -8,7 +8,7 @@ set -o pipefail
 set -o nounset
 set -o xtrace
 
-if [[ "${TESTING_PROFILE}" == *"integration-tests"* ]]; then
+if [[ "${TESTING_PROFILE}" == *"integration-tests"* ]] || [[ "${TESTING_PROFILE}" == "automated-review" ]]; then
     openssl aes-256-cbc -K $encrypted_{{ name }}_key -iv $encrypted_{{ name }}_iv -in secrets.tar.enc -out secrets.tar -d
     tar xvf secrets.tar
 fi

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -7,7 +7,7 @@ set -o pipefail
 set -o nounset
 set -o xtrace
 
-if [ "${TESTING_PROFILE}" = "unit-tests" ]; then
+if [ "${TESTING_PROFILE}" = "unit-tests" ] || [ "${TESTING_PROFILE}" == "automated-review" ]; then
     exit 0;
 fi
 


### PR DESCRIPTION
Make and enforce consistency between JPA generated database and our migration scripts
* ways found to express certain schema we have in JPA with some effort
* uses an import.sql for last ditch schema not supported by JPA (needs explanation)
* travis-ci check for consistency