### PR TITLE
Feature/1915/update cwl tool version

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -59,6 +59,7 @@ import io.swagger.client.api.ContainersApi;
 import io.swagger.client.api.ContainertagsApi;
 import io.swagger.client.api.ExtendedGa4GhApi;
 import io.swagger.client.api.Ga4GhApi;
+import io.swagger.client.api.MetadataApi;
 import io.swagger.client.api.UsersApi;
 import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.auth.ApiKeyAuth;
@@ -110,6 +111,7 @@ public class Client {
     private UsersApi usersApi;
     private Ga4GhApi ga4ghApi;
     private ExtendedGa4GhApi extendedGA4GHApi;
+    private MetadataApi metadataApi;
 
     private boolean isAdmin = false;
     private ToolClient toolClient;
@@ -446,7 +448,7 @@ public class Client {
     public void checkForCWLDependencies() {
         CWLRunnerFactory.setConfig(Utilities.parseConfig(getConfigFile()));
         CWLRunnerInterface cwlrunner = CWLRunnerFactory.createCWLRunner();
-        cwlrunner.checkForCWLDependencies();
+        cwlrunner.checkForCWLDependencies(metadataApi);
     }
 
     /**
@@ -787,7 +789,7 @@ public class Client {
         this.usersApi = new UsersApi(defaultApiClient);
         this.ga4ghApi = new Ga4GhApi(defaultApiClient);
         this.extendedGA4GHApi = new ExtendedGa4GhApi(defaultApiClient);
-
+        this.metadataApi = new MetadataApi(defaultApiClient);
 
         try {
             if (this.usersApi.getApiClient() != null) {

--- a/dockstore-client/src/main/java/io/github/collaboratory/cwl/cwlrunner/CWLRunnerInterface.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/cwl/cwlrunner/CWLRunnerInterface.java
@@ -17,6 +17,8 @@ package io.github.collaboratory.cwl.cwlrunner;
 
 import java.util.List;
 
+import io.swagger.client.api.MetadataApi;
+
 /**
  * Abstracts out the interaction with cwlrunners (for example, cwltool or toil)
  */
@@ -25,7 +27,7 @@ public interface CWLRunnerInterface {
     /**
      * Checks that the environment is properly setup
      */
-    void checkForCWLDependencies();
+    void checkForCWLDependencies(MetadataApi metadataApi);
 
     /**
      *

--- a/dockstore-client/src/main/java/io/github/collaboratory/cwl/cwlrunner/CWLToolWrapper.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/cwl/cwlrunner/CWLToolWrapper.java
@@ -25,9 +25,7 @@ import javax.ws.rs.ProcessingException;
 import com.google.common.base.Joiner;
 import io.dockstore.client.cli.ArgumentUtility;
 import io.dockstore.client.cli.Client;
-import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
-import io.swagger.client.Configuration;
 import io.swagger.client.api.MetadataApi;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
@@ -35,7 +33,7 @@ import static io.dockstore.common.PipHelper.convertPipRequirementsStringToMap;
 
 public class CWLToolWrapper implements CWLRunnerInterface {
     @Override
-    public void checkForCWLDependencies() {
+    public void checkForCWLDependencies(MetadataApi metadataApi) {
         final String[] s1 = { "cwltool", "--version" };
         final ImmutablePair<String, String> pair1 = io.cwl.avro.Utilities
                 .executeCommand(Joiner.on(" ").join(Arrays.asList(s1)), false, com.google.common.base.Optional.absent(),
@@ -50,11 +48,10 @@ public class CWLToolWrapper implements CWLRunnerInterface {
         String[] split = pair2.getKey().split(" ");
         final String schemaSaladVersion = split[split.length - 1].trim();
 
-        ApiClient defaultApiClient = Configuration.getDefaultApiClient();
-        MetadataApi metadataApi = new MetadataApi(defaultApiClient);
         try {
+            String clientVersion = Client.getClientVersion();
             String runnerDependencies = metadataApi
-                .getRunnerDependencies(Client.getClientVersion(), "2", "cwltool", "text");
+                .getRunnerDependencies(clientVersion, "2", "cwltool", "text");
             Map<String, String> stringStringMap = convertPipRequirementsStringToMap(runnerDependencies);
             final String expectedCwltoolVersion = stringStringMap.get("cwltool");
             final String expectedSchemaSaladVersion = stringStringMap.get("schema-salad");

--- a/dockstore-client/src/main/java/io/github/collaboratory/cwl/cwlrunner/GenericCWLRunnerWrapper.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/cwl/cwlrunner/GenericCWLRunnerWrapper.java
@@ -22,11 +22,12 @@ import java.util.List;
 import com.google.common.base.Joiner;
 import io.dockstore.client.cli.ArgumentUtility;
 import io.dockstore.client.cli.Client;
+import io.swagger.client.api.MetadataApi;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 public class GenericCWLRunnerWrapper implements CWLRunnerInterface {
     @Override
-    public void checkForCWLDependencies() {
+    public void checkForCWLDependencies(MetadataApi metadataApi) {
         final String[] s1 = { "cwl-runner", "--version" };
         final ImmutablePair<String, String> pair1 = io.cwl.avro.Utilities
                 .executeCommand(Joiner.on(" ").join(Arrays.asList(s1)), false, com.google.common.base.Optional.absent(),

--- a/dockstore-client/src/main/java/io/github/collaboratory/cwl/cwlrunner/ToilWrapper.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/cwl/cwlrunner/ToilWrapper.java
@@ -22,11 +22,12 @@ import java.util.List;
 import com.google.common.base.Joiner;
 import io.dockstore.client.cli.ArgumentUtility;
 import io.dockstore.client.cli.Client;
+import io.swagger.client.api.MetadataApi;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 public class ToilWrapper implements CWLRunnerInterface {
     @Override
-    public void checkForCWLDependencies() {
+    public void checkForCWLDependencies(MetadataApi metadataApi) {
         final String[] s1 = { "toil-cwl-runner", "--version" };
         final ImmutablePair<String, String> pair1 = io.cwl.avro.Utilities
                 .executeCommand(Joiner.on(" ").join(Arrays.asList(s1)), false, com.google.common.base.Optional.absent(),

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchNoInternetTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchNoInternetTestIT.java
@@ -83,6 +83,7 @@ public class LaunchNoInternetTestIT {
             add(YAML_FILE.getAbsolutePath());
             add("--config");
             add(ResourceHelpers.resourceFilePath("config"));
+            add("--script");
         }};
         Client.main(args.toArray(new String[0]));
     }
@@ -110,6 +111,7 @@ public class LaunchNoInternetTestIT {
             add(YAML_FILE.getAbsolutePath());
             add("--config");
             add(configPath.getAbsolutePath());
+            add("--script");
         }};
         Client.main(args.toArray(new String[0]));
     }
@@ -136,6 +138,7 @@ public class LaunchNoInternetTestIT {
             add(YAML_FILE.getAbsolutePath());
             add("--config");
             add(configPath.getAbsolutePath());
+            add("--script");
         }};
         Client.main(args.toArray(new String[0]));
     }
@@ -167,6 +170,7 @@ public class LaunchNoInternetTestIT {
             add(YAML_FILE.getAbsolutePath());
             add("--config");
             add(configPath.getAbsolutePath());
+            add("--script");
         }};
         Client.main(args.toArray(new String[0]));
     }
@@ -191,6 +195,7 @@ public class LaunchNoInternetTestIT {
             add(YAML_FILE.getAbsolutePath());
             add("--config");
             add(configPath.getAbsolutePath());
+            add("--script");
         }};
         Client.main(args.toArray(new String[0]));
         Assert.assertTrue("Final process status was not success", systemOutRule.getLog().contains("Final process status is success"));
@@ -218,6 +223,7 @@ public class LaunchNoInternetTestIT {
             add(jsonFile.getAbsolutePath());
             add("--config");
             add(configPath.getAbsolutePath());
+            add("--script");
         }};
         Client.main(args.toArray(new String[0]));
         Assert.assertTrue("Final process status was not success", systemOutRule.getLog().contains("Saving copy of NextFlow stdout to: "));

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchNoInternetTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchNoInternetTestIT.java
@@ -223,7 +223,6 @@ public class LaunchNoInternetTestIT {
             add(jsonFile.getAbsolutePath());
             add("--config");
             add(configPath.getAbsolutePath());
-            add("--script");
         }};
         Client.main(args.toArray(new String[0]));
         Assert.assertTrue("Final process status was not success", systemOutRule.getLog().contains("Saving copy of NextFlow stdout to: "));

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
@@ -644,13 +644,13 @@ public class LaunchTestIT {
 
     private void runTool(File cwlFile, ArrayList<String> args, ContainersApi api, UsersApi usersApi, Client client, boolean useCache) {
         client.setConfigFile(ResourceHelpers.resourceFilePath(useCache ? "config.withCache" : "config"));
-
+        client.SCRIPT.set(true);
         runToolShared(cwlFile, args, api, usersApi, client);
     }
 
     private void runWorkflow(File cwlFile, ArrayList<String> args, WorkflowsApi api, UsersApi usersApi, Client client, boolean useCache) {
         client.setConfigFile(ResourceHelpers.resourceFilePath(useCache ? "config.withCache" : "config"));
-
+        client.SCRIPT.set(true);
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
         workflowClient.checkEntryFile(cwlFile.getAbsolutePath(), args, null);
 

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WorkflowInDirectoryTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WorkflowInDirectoryTestIT.java
@@ -42,7 +42,7 @@ public class WorkflowInDirectoryTestIT {
 
     @BeforeClass
     public static void setup() {
-        configFile = new File(ResourceHelpers.resourceFilePath("config"));
+        configFile = new File(ResourceHelpers.resourceFilePath("clientConfig"));
     }
 
     /**

--- a/dockstore-client/src/test/java/io/github/collaboratory/cwl/LauncherIT.java
+++ b/dockstore-client/src/test/java/io/github/collaboratory/cwl/LauncherIT.java
@@ -172,7 +172,7 @@ public abstract class LauncherIT {
 
     @Test
     public void testCheckingSystemDependencies() {
-        MetadataApi metadataApi = new MetadataApi(Configuration.getDefaultApiClient());
+        MetadataApi metadataApi = new MetadataApi(Configuration.getDefaultApiClient().setBasePath("http://localhost:8080"));
         CWLRunnerFactory.setConfig(Utilities.parseConfig(getConfigFile()));
         CWLRunnerInterface cwlrunner = CWLRunnerFactory.createCWLRunner();
         cwlrunner.checkForCWLDependencies(metadataApi);

--- a/dockstore-client/src/test/java/io/github/collaboratory/cwl/LauncherIT.java
+++ b/dockstore-client/src/test/java/io/github/collaboratory/cwl/LauncherIT.java
@@ -32,6 +32,8 @@ import io.dockstore.common.FileProvisioning;
 import io.dockstore.common.Utilities;
 import io.github.collaboratory.cwl.cwlrunner.CWLRunnerFactory;
 import io.github.collaboratory.cwl.cwlrunner.CWLRunnerInterface;
+import io.swagger.client.Configuration;
+import io.swagger.client.api.MetadataApi;
 import org.apache.commons.configuration2.INIConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
@@ -170,9 +172,10 @@ public abstract class LauncherIT {
 
     @Test
     public void testCheckingSystemDependencies() {
+        MetadataApi metadataApi = new MetadataApi(Configuration.getDefaultApiClient());
         CWLRunnerFactory.setConfig(Utilities.parseConfig(getConfigFile()));
         CWLRunnerInterface cwlrunner = CWLRunnerFactory.createCWLRunner();
-        cwlrunner.checkForCWLDependencies();
+        cwlrunner.checkForCWLDependencies(metadataApi);
     }
 
 }

--- a/dockstore-client/src/test/resources/clientConfig
+++ b/dockstore-client/src/test/resources/clientConfig
@@ -1,0 +1,1 @@
+server-url: http://localhost:8080

--- a/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
@@ -27,7 +27,10 @@ public final class PipHelper {
             semVerString = "9001.9001.9001";
         }
         Version semVer = Version.valueOf(semVerString);
-        // Use the 1.5.0 even for snapshot
+        // Use the 1.6.0 even for snapshot
+        if (semVer.greaterThan(Version.valueOf("1.5.0"))) {
+            return "1.6.0";
+        }
         if (semVer.greaterThan(Version.valueOf("1.4.0"))) {
             return "1.5.0";
         } else {

--- a/dockstore-common/src/test/java/io/dockstore/common/PipHelperTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/PipHelperTest.java
@@ -12,8 +12,10 @@ import static org.junit.Assert.*;
 public class PipHelperTest {
     @Test
     public void convertSemVerToAvailableVersion() throws Exception {
-        Assert.assertEquals("1.5.0", PipHelper.convertSemVerToAvailableVersion(PipHelper.DEV_SEM_VER));
-        Assert.assertEquals("1.5.0", PipHelper.convertSemVerToAvailableVersion(null));
+        Assert.assertEquals("1.6.0", PipHelper.convertSemVerToAvailableVersion(PipHelper.DEV_SEM_VER));
+        Assert.assertEquals("1.6.0", PipHelper.convertSemVerToAvailableVersion(null));
+        Assert.assertEquals("1.6.0", PipHelper.convertSemVerToAvailableVersion("1.6.0-snapshot"));
+        Assert.assertEquals("1.6.0", PipHelper.convertSemVerToAvailableVersion("1.6.0"));
         Assert.assertEquals("1.5.0", PipHelper.convertSemVerToAvailableVersion("1.5.0-snapshot"));
         Assert.assertEquals("1.5.0", PipHelper.convertSemVerToAvailableVersion("1.5.0"));
         Assert.assertEquals("1.4.0", PipHelper.convertSemVerToAvailableVersion("1.4.0-snapshot"));

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowRegressionIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowRegressionIT.java
@@ -83,10 +83,10 @@ public class GeneralWorkflowRegressionIT extends BaseIT {
         dockstore = temporaryFolder.newFile("dockstore");
         FileUtils.copyURLToFile(url, dockstore);
         assertTrue(dockstore.setExecutable(true));
-        url = new URL("https://raw.githubusercontent.com/DockstoreTestUser2/md5sum-checker/master/checker-input-cwl.json");
+        url = new URL("https://raw.githubusercontent.com/DockstoreTestUser2/md5sum-checker/1.6.0/checker-input-cwl.json");
         md5sumJson = temporaryFolder.newFile("md5sum-wrapper-tool.json");
         FileUtils.copyURLToFile(url, md5sumJson);
-        url = new URL("https://raw.githubusercontent.com/DockstoreTestUser2/md5sum-checker/master/md5sum.input");
+        url = new URL("https://raw.githubusercontent.com/DockstoreTestUser2/md5sum-checker/1.6.0/md5sum.input");
         File md5sumInput = temporaryFolder.newFile("md5sum.input");
         FileUtils.copyURLToFile(url, md5sumInput);
     }

--- a/dockstore-webservice/src/main/resources/requirements/1.6.0/requirements.txt
+++ b/dockstore-webservice/src/main/resources/requirements/1.6.0/requirements.txt
@@ -2,6 +2,6 @@ setuptools==40.8.0
 cwl-runner
 cwltool==1.0.20181217162649
 schema-salad==3.0.20181206233650
-avro==1.8.1
-ruamel.yaml==0.14.12
-requests==2.18.4
+avro==1.8.2
+ruamel.yaml==0.15.77
+requests==2.21.0

--- a/dockstore-webservice/src/main/resources/requirements/1.6.0/requirements.txt
+++ b/dockstore-webservice/src/main/resources/requirements/1.6.0/requirements.txt
@@ -1,0 +1,7 @@
+setuptools==40.8.0
+cwl-runner
+cwltool==1.0.20181217162649
+schema-salad==3.0.20181206233650
+avro==1.8.1
+ruamel.yaml==0.14.12
+requests==2.18.4

--- a/dockstore-webservice/src/main/resources/requirements/1.6.0/requirements3.txt
+++ b/dockstore-webservice/src/main/resources/requirements/1.6.0/requirements3.txt
@@ -1,0 +1,7 @@
+setuptools==40.8.0
+cwl-runner
+cwltool==1.0.20181217162649
+schema-salad==3.0.20181206233650
+avro-cwl==1.8.3
+ruamel.yaml==0.14.12
+requests==2.18.4

--- a/dockstore-webservice/src/main/resources/requirements/1.6.0/requirements3.txt
+++ b/dockstore-webservice/src/main/resources/requirements/1.6.0/requirements3.txt
@@ -2,6 +2,6 @@ setuptools==40.8.0
 cwl-runner
 cwltool==1.0.20181217162649
 schema-salad==3.0.20181206233650
-avro-cwl==1.8.3
-ruamel.yaml==0.14.12
-requests==2.18.4
+avro-cwl==1.8.9
+ruamel.yaml==0.15.8
+requests==2.21.0

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -14,9 +14,9 @@ fi
 if [ "${TESTING_PROFILE}" = "toil-integration-tests" ]; then
     pip2.7 install --user toil[cwl]==3.15.0
 elif [ "${TESTING_PROFILE}" = "regression-integration-tests" ]; then
-    pip2.7 install --user -r dockstore-webservice/src/main/resources/requirements/1.4.0/requirements.txt
-else
     pip2.7 install --user -r dockstore-webservice/src/main/resources/requirements/1.5.0/requirements.txt
+else
+    pip2.7 install --user -r dockstore-webservice/src/main/resources/requirements/1.6.0/requirements.txt
 fi
 
 # hook up integration tests with elastic search


### PR DESCRIPTION
For ga4gh/dockstore#1915

- Updates the CWL dependencies.
- Partly fixes the issue with the tests calling the Dockstore production webservice.  The issue is that when the test has no config file or a config file does not have a `server-url` specified, it will by default set it to production.  To fix this, some tests now have a correct config file with `server-url` or it has `--script` flag which skips checking the dependencies

Appears to work with all previously tested cwl tools/workflows except pcawg delly, dkfz, sanger, and bwa-mem.  Linda is working on the delly and sanger, jun jun is working dkfz, i have a PR for bwa-mem.  biowardrobe workflow was updated for the new cwltool version.
