### PR TITLE
Change Organiziation Create Resource HTTP annotation and regenerate swagger

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
@@ -324,7 +324,7 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
         return organizations;
     }
 
-    @PUT
+    @POST
     @Timed
     @UnitOfWork
     @ApiOperation(value = "Create an organization.", notes = "Organization requires approval by an admin before being made public.", authorizations = {
@@ -359,7 +359,7 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
         return organizationDAO.findById(id);
     }
 
-    @POST
+    @PUT
     @Timed
     @UnitOfWork
     @Path("{organizationId}")

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: This describes the dockstore API, a webservice that manages pairs of Docker
     images and associated metadata such as CWL documents and Dockerfiles used to
     build those images
-  version: 1.6.0-beta.0-SNAPSHOT
+  version: 1.6.0-beta.1-SNAPSHOT
   title: Dockstore API
   termsOfService: TBD
   contact:
@@ -2976,7 +2976,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Organization"
-    put:
+    post:
       tags:
         - organizations
       summary: Create an organization.
@@ -3157,7 +3157,7 @@ paths:
       security:
         - BEARER:
             []
-    post:
+    put:
       tags:
         - organizations
       summary: Update an organization.

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1063,7 +1063,7 @@ paths:
           description: default response
   /api/ga4gh/v2/extended/containers/{organization}:
     get:
-      operationId: entriesOrgGet
+      operationId: entriesOrgGet_1
       parameters:
       - in: path
         name: organization
@@ -1078,7 +1078,7 @@ paths:
           description: default response
   /api/ga4gh/v2/extended/organizations:
     get:
-      operationId: entriesOrgGet_1
+      operationId: entriesOrgGet
       responses:
         default:
           content:
@@ -1692,7 +1692,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Tool'
+                $ref: '#/components/schemas/Entry'
           description: default response
   /containers/hostedEntry/{entryId}:
     delete:
@@ -1718,7 +1718,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Tool'
+                $ref: '#/components/schemas/Entry'
           description: default response
     patch:
       operationId: editHosted
@@ -2938,7 +2938,7 @@ paths:
                   $ref: '#/components/schemas/Organization'
                 type: array
           description: default response
-    put:
+    post:
       operationId: createOrganization
       requestBody:
         content:
@@ -3070,7 +3070,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Organization'
           description: default response
-    post:
+    put:
       operationId: updateOrganization
       parameters:
       - in: path
@@ -4207,7 +4207,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Workflow'
           description: default response
   /workflows/hostedEntry/{entryId}:
     delete:
@@ -4233,7 +4233,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: '#/components/schemas/Entry'
           description: default response
     patch:
       operationId: editHosted_1

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.6.0-beta.0-SNAPSHOT"
+  version: "1.6.0-beta.1-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:
@@ -2711,7 +2711,7 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/Organization"
-    put:
+    post:
       tags:
       - "organizations"
       summary: "Create an organization."
@@ -2885,7 +2885,7 @@ paths:
             $ref: "#/definitions/Organization"
       security:
       - BEARER: []
-    post:
+    put:
       tags:
       - "organizations"
       summary: "Update an organization."
@@ -5725,6 +5725,10 @@ definitions:
       custom_docker_registry_path:
         type: "string"
         readOnly: true
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -5740,10 +5744,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       author:
         type: "string"
         position: 1
@@ -5936,6 +5936,10 @@ definitions:
       dbUpdateDate:
         type: "string"
         format: "date-time"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -5951,10 +5955,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       author:
         type: "string"
         position: 1
@@ -6979,6 +6979,10 @@ definitions:
         type: "integer"
         format: "int64"
         readOnly: true
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -6994,10 +6998,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       author:
         type: "string"
         position: 1


### PR DESCRIPTION
Changes PUT to POST at the Create Organization endpoint. This changes alters the swagger and OpenAPI descriptions. These changes also require the typescript client to be regenerated in the UI.

It seems like the placement of the date/time schemas moved in the OpenAPI2 document, but the content is the same. The ordering of the OpenAPI3 document is also changed and the diff shows Entries being replaced by Workflows when in fact those components are present before and after the PR.