### PR TITLE
Doc fixes, typo

### DIFF
--- a/_docs/hosted-tools-and-workflows.md
+++ b/_docs/hosted-tools-and-workflows.md
@@ -17,7 +17,7 @@ A hosted tool or workflow is simply an entry where instead of files being stored
 **Note:** For hosted tools we do not store the Docker image in our own registry.
 
 ## Adding a Hosted Workflow
-In this example we are going to add a simple CWL workflow to Dockstore as a hosted workflows.
+In this example we are going to add a simple CWL workflow to Dockstore as a hosted workflow.
 
 To add a hosted workflow do the following:
 * Go to [my workflows](https://dockstore.org/my-workflows)


### PR DESCRIPTION
When going through hosted tools docs I noticed a small error, "as a hosted workflow" instead of the plural "as a hosted workflows".

I know these small PRs can be annoying to review one by one so I'm happy to leave it open to stage more fixes as I find them and close out before the next release cycle.