### PR TITLE
Remove maven release steps from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,31 +194,6 @@ These include
 
 To update these, you will need to point at a new version of the swagger.yaml provided by a service. For example, update the equivalent of [inputSpec](https://github.com/ga4gh/dockstore/blob/0afe35682bdfb6fa7285b2acab8f80648346e835/dockstore-webservice/pom.xml#L854) in your branch.  
 
-### HubFlow Operations
-
-#### How to perform a Maven release for a Unstable Release
-
-This is for pre-release versions that have not been released to production. 
-
-1. Create a release tag and iterate pom file versions `mvn release:prepare`
-2. Release from the tag into artifactory (you may need permissions) `mvn release:perform`
-3. Merge to master if this is a stable release `git checkout master; git merge <your tag here>`
-
-Special note: If a test is failing during perform, but did not fail during prepare or Travis-CI builds, you may have a non-deterministic error. Skip tests during a release with `mvn release:perform -Darguments="-DskipTests"`
-
-After the release to Artifactory, document the release on GitHub via the Releases page. Take a look at commits since the last release and closed pull requests for information on what goes into the changelog. Also attach the newly created Dockstore script and shaded client jar.
-
-#### How to perform a Maven release for an Stable Release
-
-This is for release versions that have been released to production. 
-
-1. Create a hotfix branch  `mvn hf hotfix start <version>`
-2. Iterate pom file versions to a SNAPSHOT if needed `mvn versions:set -DnewVersion=<version>-SNAPSHOT` 
-3. Prepare the release and the perform it (you may need permissions) `mvn release:prepare` and `mvn release:perform`
-3. Merge to master and develop `mvn hf hotfix finish`
-
-As with the unstable release, document the release and attach the new Dockstore script and shaded client jar. 
-
 ### Encrypted Documents for Travis-CI
 
 Encrypted documents necessary for confidential testing are handled as indicated in the documents at Travis-CI for  


### PR DESCRIPTION
Doing a maven release is described in two places, here, and in
internal documentation.

Instead of maintaining the same info in two places and there being
confusion as to which one to follow, I propose we
just maintain the internal doc up to date and remove this info from
the README.

We can do it the other way around, if preferred. Please reject the
associated PR if so.