### PR TITLE
Feature/ignore unknown wdl methods

### DIFF
--- a/dockstore-common/src/main/scala/io/dockstore/common/Bridge.scala
+++ b/dockstore-common/src/main/scala/io/dockstore/common/Bridge.scala
@@ -92,15 +92,13 @@ class Bridge(basePath : String) {
     * @throws wdl4s.parser.WdlParser.SyntaxError
     */
   @throws(classOf[WdlParser.SyntaxError])
+  @throws(classOf[NoSuchMethodException])
   def isValidWorkflow(file: JFile) = {
     try {
       val lines = scala.io.Source.fromFile(file).mkString
       WdlNamespaceWithWorkflow.load(lines, Seq(resolveHttpAndSecondaryFiles _)).get
     } catch {
       case ex: NullPointerException => throw new WdlParser.SyntaxError("At least one of the imported files is missing. Ensure that all imported files exist and are valid WDL documents.")
-      case ex: NoSuchMethodException =>
-      //FIXME: the best we can do is be generous and assume that unknown methods are WDL 1.0 methods until we update
-      // https://github.com/ga4gh/dockstore/issues/2139
     }
   }
 

--- a/dockstore-common/src/main/scala/io/dockstore/common/Bridge.scala
+++ b/dockstore-common/src/main/scala/io/dockstore/common/Bridge.scala
@@ -156,13 +156,19 @@ class Bridge(basePath : String) {
     val lines = scala.io.Source.fromFile(file).mkString
     val importMap = new util.LinkedHashMap[String, String]()
 
-    val ns = WdlNamespaceWithWorkflow.load(lines, Seq(resolveHttpAndSecondaryFiles _)).get
+    try {
+      val ns = WdlNamespaceWithWorkflow.load(lines, Seq(resolveHttpAndSecondaryFiles _)).get
 
-    ns.imports foreach { imported =>
-      val importNamespace = imported.namespaceName
-      if (!importNamespace.isEmpty) {
-        importMap.put(importNamespace, imported.uri)
+      ns.imports foreach { imported =>
+        val importNamespace = imported.namespaceName
+        if (!importNamespace.isEmpty) {
+          importMap.put(importNamespace, imported.uri)
+        }
       }
+    } catch {
+      case ex: NoSuchMethodException =>
+        //FIXME: the best we can do is be generous and assume that unknown methods are WDL 1.0 methods until we update
+        // https://github.com/ga4gh/dockstore/issues/2139
     }
 
     importMap
@@ -206,7 +212,7 @@ class Bridge(basePath : String) {
       case ex: NoSuchMethodException =>
         //FIXME: the best we can do is be generous and assume that unknown methods are WDL 1.0 methods until we update
         // https://github.com/ga4gh/dockstore/issues/2139
-      null
+        new util.LinkedHashMap[String, String]()
     }
   }
 
@@ -267,7 +273,7 @@ class Bridge(basePath : String) {
       case ex: NoSuchMethodException =>
         //FIXME: the best we can do is be generous and assume that unknown methods are WDL 1.0 methods until we update
         // https://github.com/ga4gh/dockstore/issues/2139
-        null
+        new util.LinkedHashMap[String, util.List[String]]()
     }
   }
 

--- a/dockstore-common/src/main/scala/io/dockstore/common/Bridge.scala
+++ b/dockstore-common/src/main/scala/io/dockstore/common/Bridge.scala
@@ -98,6 +98,8 @@ class Bridge(basePath : String) {
       WdlNamespaceWithWorkflow.load(lines, Seq(resolveHttpAndSecondaryFiles _)).get
     } catch {
       case ex: NullPointerException => throw new WdlParser.SyntaxError("At least one of the imported files is missing. Ensure that all imported files exist and are valid WDL documents.")
+      case ex: NoSuchMethodException =>
+        //FIXME: the best we can do is be generous and assume that unknown methods are WDL 1.0 methods until we update
     }
   }
 

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: This describes the dockstore API, a webservice that manages pairs of Docker
     images and associated metadata such as CWL documents and Dockerfiles used to
     build those images
-  version: 1.6.0-beta.1-SNAPSHOT
+  version: 1.6.0-beta.2-SNAPSHOT
   title: Dockstore API
   termsOfService: TBD
   contact:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -4262,7 +4262,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Workflow'
           description: default response
   /workflows/hostedEntry/{entryId}:
     delete:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1075,7 +1075,7 @@ paths:
           description: default response
   /api/ga4gh/v2/extended/containers/{organization}:
     get:
-      operationId: entriesOrgGet_1
+      operationId: entriesOrgGet
       parameters:
       - in: path
         name: organization
@@ -1090,7 +1090,7 @@ paths:
           description: default response
   /api/ga4gh/v2/extended/organizations:
     get:
-      operationId: entriesOrgGet
+      operationId: entriesOrgGet_1
       responses:
         default:
           content:
@@ -3727,7 +3727,7 @@ paths:
                 type: boolean
           description: default response
     get:
-      operationId: getUser_1
+      operationId: getUser
       requestBody:
         content:
           '*/*':
@@ -3886,7 +3886,7 @@ paths:
           description: default response
   /users/{userId}:
     get:
-      operationId: getUser
+      operationId: getUser_1
       parameters:
       - in: path
         name: userId
@@ -4288,7 +4288,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: '#/components/schemas/Entry'
           description: default response
     patch:
       operationId: editHosted_1

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.6.0-beta.1"
+  version: "1.6.0-beta.2-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:


### PR DESCRIPTION
Possible solution for #2139 

* the specific problem is that wdl4s doesn't understand wdl some 1.0 methods created afterwards
* without major changes (i.e. a big switch and update to womtool?) a hacky temporary solution is to assume that people using custom methods know what they are doing and allow them to pass validation, this does break the dag tool display for those specific workflows though as a heads-up
