### PR TITLE
Don't save token from authorization header

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -48,6 +48,7 @@ import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 import javax.persistence.UniqueConstraint;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -159,6 +160,16 @@ public class User implements Principal, Comparable<User>, Serializable {
     @Column()
     @JsonIgnore
     private Integer hostedEntryVersionsLimit;
+
+    /**
+     * A temporary credential to hold the access token of a request made to Dockstore with
+     * a token not minted by/through Dockstore. For example, if a user got an access token
+     * by logging into Google outside of Dockstore, then made an API call to Dockstore using that token,
+     * this field is used to hold the token.
+     */
+    @Transient
+    @JsonIgnore
+    private String temporaryCredential;
 
 
     public User() {
@@ -385,6 +396,16 @@ public class User implements Principal, Comparable<User>, Serializable {
     public void setHostedEntryVersionsLimit(Integer hostedEntryVersionsLimit) {
         this.hostedEntryVersionsLimit = hostedEntryVersionsLimit;
     }
+
+    public String getTemporaryCredential() {
+        return temporaryCredential;
+    }
+
+    public void setTemporaryCredential(String temporaryCredential) {
+        this.temporaryCredential = temporaryCredential;
+    }
+
+
 
     /**
      * The profile of a user using a token (Google profile, GitHub profile, etc)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
@@ -156,7 +156,7 @@ public class SamPermissionsImpl implements PermissionsInterface {
 
     @Override
     public Map<Role, List<String>> workflowsSharedWithUser(User user) {
-        if (googleToken(user) == null) {
+        if (!hasGoogleToken(user)) {
             return Collections.emptyMap();
         }
         ResourcesApi resourcesApi = getResourcesApi(user);
@@ -333,7 +333,7 @@ public class SamPermissionsImpl implements PermissionsInterface {
 
     @Override
     public void selfDestruct(User user) {
-        if (googleToken(user) != null) {
+        if (hasGoogleToken(user)) {
             final ResourcesApi resourcesApi = getResourcesApi(user);
             try {
                 final List<String> resourceIds = ownedResourceIds(resourcesApi);
@@ -352,7 +352,7 @@ public class SamPermissionsImpl implements PermissionsInterface {
 
     @Override
     public boolean isSharing(User user) {
-        if (googleToken(user) == null) {
+        if (!hasGoogleToken(user)) {
             return false;
         }
         final ResourcesApi resourcesApi = getResourcesApi(user);
@@ -437,6 +437,9 @@ public class SamPermissionsImpl implements PermissionsInterface {
      * @return
      */
     Optional<String> googleAccessToken(User user) {
+        if (user.getTemporaryCredential() != null) {
+            return Optional.of(user.getTemporaryCredential());
+        }
         Token token = googleToken(user);
         if (token != null) {
             return GoogleHelper.getValidAccessToken(token).map(accessToken -> {
@@ -453,6 +456,10 @@ public class SamPermissionsImpl implements PermissionsInterface {
     Token googleToken(User user) {
         List<Token> tokens = tokenDAO.findByUserId(user.getId());
         return Token.extractToken(tokens, TokenType.GOOGLE_COM);
+    }
+
+    boolean hasGoogleToken(User user) {
+        return user.getTemporaryCredential() != null || googleToken(user) != null;
     }
 
     /**

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1077,7 +1077,7 @@ paths:
           description: default response
   /api/ga4gh/v2/extended/containers/{organization}:
     get:
-      operationId: entriesOrgGet_1
+      operationId: entriesOrgGet
       parameters:
       - in: path
         name: organization
@@ -1092,7 +1092,7 @@ paths:
           description: default response
   /api/ga4gh/v2/extended/organizations:
     get:
-      operationId: entriesOrgGet
+      operationId: entriesOrgGet_1
       responses:
         default:
           content:
@@ -2772,7 +2772,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
   /entries/{id}/collections:
     get:
@@ -3023,7 +3023,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Collection'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
   /organizations/name/{name}:
     get:
@@ -3755,7 +3755,7 @@ paths:
                 type: boolean
           description: default response
     get:
-      operationId: getUser
+      operationId: getUser_1
       requestBody:
         content:
           '*/*':
@@ -3914,7 +3914,7 @@ paths:
           description: default response
   /users/{userId}:
     get:
-      operationId: getUser_1
+      operationId: getUser
       parameters:
       - in: path
         name: userId
@@ -4316,7 +4316,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Workflow'
           description: default response
     patch:
       operationId: editHosted_1

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/SimpleAuthenticatorTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/SimpleAuthenticatorTest.java
@@ -35,7 +35,6 @@ public class SimpleAuthenticatorTest {
         userDAO = Mockito.mock(UserDAO.class);
         simpleAuthenticator = spy(new SimpleAuthenticator(tokenDAO, userDAO));
         doNothing().when(simpleAuthenticator).initializeUserProfiles(user);
-        doNothing().when(simpleAuthenticator).updateGoogleToken(credentials, user);
     }
 
     @Test
@@ -61,7 +60,7 @@ public class SimpleAuthenticatorTest {
         doReturn(Optional.of(userinfoplus)).when(simpleAuthenticator).userinfoPlusFromToken(credentials);
         when(userinfoplus.getEmail()).thenReturn(USER_EMAIL);
         when(userDAO.findByUsername(USER_EMAIL)).thenReturn(null);
-        doReturn(user).when(simpleAuthenticator).createUser(credentials, userinfoplus);
+        doReturn(user).when(simpleAuthenticator).createUser(userinfoplus);
         Assert.assertEquals(user, simpleAuthenticator.authenticate(credentials).get());
     }
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/SimpleAuthenticatorTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/SimpleAuthenticatorTest.java
@@ -25,7 +25,7 @@ public class SimpleAuthenticatorTest {
     private final String credentials = "asdfafds";
     private static final Long USER_ID = new Long(1);
     private final Token token = Mockito.mock(Token.class);
-    private final User user = Mockito.mock(User.class);
+    private final User user = new User();
     private final Userinfoplus userinfoplus = Mockito.mock(Userinfoplus.class);
     private final static String USER_EMAIL = "jdoe@example.com";
 
@@ -42,7 +42,8 @@ public class SimpleAuthenticatorTest {
         when(token.getUserId()).thenReturn(USER_ID);
         when(tokenDAO.findByContent(credentials)).thenReturn(token);
         when(userDAO.findById(USER_ID)).thenReturn(user);
-        Assert.assertEquals(user, simpleAuthenticator.authenticate(credentials).get());
+        final User authenticatedUser = simpleAuthenticator.authenticate(credentials).get();
+        Assert.assertNull(authenticatedUser.getTemporaryCredential());
     }
 
     @Test
@@ -51,7 +52,8 @@ public class SimpleAuthenticatorTest {
         doReturn(Optional.of(userinfoplus)).when(simpleAuthenticator).userinfoPlusFromToken(credentials);
         when(userinfoplus.getEmail()).thenReturn(USER_EMAIL);
         when(userDAO.findByGoogleEmail(USER_EMAIL)).thenReturn(user);
-        Assert.assertEquals(user, simpleAuthenticator.authenticate(credentials).get());
+        final User authenticatedUser = simpleAuthenticator.authenticate(credentials).get();
+        Assert.assertEquals(credentials, authenticatedUser.getTemporaryCredential());
     }
 
     @Test
@@ -60,8 +62,8 @@ public class SimpleAuthenticatorTest {
         doReturn(Optional.of(userinfoplus)).when(simpleAuthenticator).userinfoPlusFromToken(credentials);
         when(userinfoplus.getEmail()).thenReturn(USER_EMAIL);
         when(userDAO.findByUsername(USER_EMAIL)).thenReturn(null);
-        doReturn(user).when(simpleAuthenticator).createUser(userinfoplus);
-        Assert.assertEquals(user, simpleAuthenticator.authenticate(credentials).get());
+        final User authenticatedUser = simpleAuthenticator.authenticate(credentials).get();
+        Assert.assertEquals(credentials, authenticatedUser.getTemporaryCredential());
     }
 
     @Test


### PR DESCRIPTION

When Dockstore API is invoked with a Google token,
we look up the user based on the email associated with that
token. If we don't find a user, we create one. Then we would
save the token along with the user; this was
done to use that token to authenticate subsequent API calls to SAM.

Instead, don't persist the token to the database.

Added a transient field to User to hold the token and when
calls are made to SAM, check that field first.

Not wild about changing the User class to not directly map
to the database -- we don't use @transient anywhere else. But this
seems to be the lowest impact way of implementing this.