### PR TITLE
Feature/2085/absolute path check

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -41,10 +41,13 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
+import io.dockstore.webservice.helpers.ZipSourceFileHelper;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This describes a cached copy of a remotely accessible file. Implementation specific.
@@ -67,6 +70,8 @@ public class SourceFile implements Comparable<SourceFile> {
         // Add supported descriptor types here
         DOCKSTORE_CWL, DOCKSTORE_WDL, DOCKERFILE, CWL_TEST_JSON, WDL_TEST_JSON, NEXTFLOW, NEXTFLOW_CONFIG, NEXTFLOW_TEST_PARAMS, DOCKSTORE_YML
     }
+
+    private static final Logger LOG = LoggerFactory.getLogger(SourceFile.class);
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -150,7 +155,11 @@ public class SourceFile implements Comparable<SourceFile> {
     }
 
     public void setAbsolutePath(String absolutePath) {
-        this.absolutePath = absolutePath;
+        // TODO: Figure out the actual absolute path before this workaround
+        this.absolutePath = ZipSourceFileHelper.addLeadingSlashIfNecessary((absolutePath));
+        if (this.absolutePath.equals(absolutePath)) {
+            LOG.warn("Absolute path workaround used, this should be fixed at some point");
+        }
     }
 
     @JsonIgnore

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -157,7 +157,7 @@ public class SourceFile implements Comparable<SourceFile> {
     public void setAbsolutePath(String absolutePath) {
         // TODO: Figure out the actual absolute path before this workaround
         this.absolutePath = ZipSourceFileHelper.addLeadingSlashIfNecessary((absolutePath));
-        if (this.absolutePath.equals(absolutePath)) {
+        if (!this.absolutePath.equals(absolutePath)) {
             LOG.warn("Absolute path workaround used, this should be fixed at some point");
         }
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZipSourceFileHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZipSourceFileHelper.java
@@ -157,7 +157,7 @@ public final class ZipSourceFileHelper {
         }
     }
 
-    private static String addLeadingSlashIfNecessary(final String name) {
+    public static String addLeadingSlashIfNecessary(final String name) {
         if (name.startsWith("/")) {
             return name;
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -67,8 +67,6 @@ import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.dockstore.webservice.helpers.ZipSourceFileHelper.addLeadingSlashIfNecessary;
-
 /**
  * Methods to create and edit hosted tool and workflows.
  * Reuse existing methods to GET them, add labels to them, and other operations.
@@ -252,7 +250,7 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
     private void updateUnsetAbsolutePaths(Set<SourceFile> sourceFiles) {
         sourceFiles.stream().forEach(sourceFile -> {
             if (sourceFile.getAbsolutePath() == null) {
-                sourceFile.setAbsolutePath(addLeadingSlashIfNecessary(sourceFile.getPath()));
+                sourceFile.setAbsolutePath(sourceFile.getPath());
             }
         });
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -67,6 +67,8 @@ import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.dockstore.webservice.helpers.ZipSourceFileHelper.addLeadingSlashIfNecessary;
+
 /**
  * Methods to create and edit hosted tool and workflows.
  * Reuse existing methods to GET them, add labels to them, and other operations.
@@ -250,7 +252,7 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
     private void updateUnsetAbsolutePaths(Set<SourceFile> sourceFiles) {
         sourceFiles.stream().forEach(sourceFile -> {
             if (sourceFile.getAbsolutePath() == null) {
-                sourceFile.setAbsolutePath(sourceFile.getPath());
+                sourceFile.setAbsolutePath(addLeadingSlashIfNecessary(sourceFile.getPath()));
             }
         });
     }

--- a/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
@@ -343,4 +343,9 @@
             UPDATE sourcefile SET absolutepath = CONCAT('/', absolutepath) WHERE absolutepath NOT LIKE '/%'
         </sql>
     </changeSet>
+    <changeSet id="checkAbsolutePath" author="gluu">
+        <sql dbms="postgresql">
+            ALTER TABLE sourcefile ADD CONSTRAINT absolutepath_check CHECK (absolutepath LIKE '/%')
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
@@ -345,7 +345,7 @@
     </changeSet>
     <changeSet id="checkAbsolutePath" author="gluu">
         <sql dbms="postgresql">
-            ALTER TABLE sourcefile ADD CONSTRAINT absolutepath_check CHECK (absolutepath LIKE '/%')
+            ALTER TABLE sourcefile ADD CONSTRAINT absolutepath_check CHECK (absolutepath LIKE '/%' OR absolutepath='')
         </sql>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
For #2085 

Workaround that makes sure absolute paths added resemble absolute paths.  Log warn message when workaround was used...this should be fixed correctly at some point.

Not sure if relevant but there are files being added that have an empty path and/or absolute path before this PR

Push cancelled because I don't care about it.
