### PR TITLE
Update End User tutorials

### DIFF
--- a/_docs/dnastack-launch-with.md
+++ b/_docs/dnastack-launch-with.md
@@ -48,7 +48,7 @@ Note that as with the above approach, you will want to double-check that the wor
 
 ## Limitations
 0. While we support launching of WDL workflows, tools as listed in Dockstore are currently not supported.
-0. DNAStack does not currently support http(s) or file-path based imports.  Importing a workflow with those imports will result in an error.  See [cromwell imports docs](https://cromwell.readthedocs.io/en/develop/Imports/) for more info about imports.
+0. DNAstack does not currently support HTTP(S) or file-path based imports.  Importing a workflow with those imports will result in an error.  See [cromwell imports docs](https://cromwell.readthedocs.io/en/develop/Imports/) for more info about imports.
 
 ## See Also
 

--- a/_docs/language-support-backup.md
+++ b/_docs/language-support-backup.md
@@ -11,7 +11,7 @@ Sample markdown table
 | Tool registration      | ✔             | ✔     | 
 | Workflow registration  | ✔             | ✔     |  
 | DAG Display            | ✔             | ✔     |  
-| Launch-with Platforms  | N/A           | FireCloud<br>DNAStack |  
+| Launch-with Platforms  | N/A           | FireCloud<br>DNAstack |  
 | **CLI**                |               |       |
 | File Provisioning      | Local File System<br>HTTP<br>FTP<br>S3             | Local File System     | 
 | Local workflow engines | cwltool<br>Bunny<br>Toil (experimental)              | Cromwell* |

--- a/_docs/language-support.md
+++ b/_docs/language-support.md
@@ -15,12 +15,13 @@ To help lay out what parts of Dockstore are available in which languages, we cov
 <sup>[0] Available in both classic and <a href="https://view.commonwl.org/">CWL Viewer</a> modes 
 </sup>
 
-<sup>[1] Does not support file-path based imports. See [FireCloud Limitations](/docs/user-tutorials/firecloud-launch-with/#limitations) for limitations.
+<sup>[1] Available in both classic and WDL EPAM Pipeline Builder
 </sup>
 
-<sup>[2] Does not support file-path or http(s) based imports. See [DNAStack Limitations](/docs/user-tutorials/dnastack-launch-with/#limitations) for limitations.
+<sup>[2] Does not support file-path based imports. See [FireCloud Limitations](/docs/user-tutorials/firecloud-launch-with/#limitations) for limitations.
 </sup>
 
-<sup> [3] The small number of verified Dockstore WDL tools/workflows were tested successfully.  More verification/testing likely needed.</sup>
+<sup>[3] Does not support file-path or http(s) based imports. See [DNAstack Limitations](/docs/user-tutorials/dnastack-launch-with/#limitations) for limitations.
+</sup>
 
-<sup> [4] The official Nextflow CLI is not yet connected to Dockstore. However, the Nextflow CLI does have file provisioning directly baked in.</sup>
+<sup> [4] The small number of verified Dockstore WDL tools/workflows were tested successfully.  More verification/testing likely needed.</sup>

--- a/_docs/language-support.md
+++ b/_docs/language-support.md
@@ -24,4 +24,4 @@ To help lay out what parts of Dockstore are available in which languages, we cov
 <sup>[3] Does not support file-path or http(s) based imports. See [DNAstack Limitations](/docs/user-tutorials/dnastack-launch-with/#limitations) for limitations.
 </sup>
 
-<sup> [4] The small number of verified Dockstore WDL tools/workflows were tested successfully.  More verification/testing likely needed.</sup>
+<sup> [4] All verified Dockstore WDL tools/workflows were tested successfully. However, we anticipate that more testing is needed for WDL workflows that use language features not contained within that dataset.</sup>

--- a/_docs/launch.md
+++ b/_docs/launch.md
@@ -12,7 +12,7 @@ This tutorial is a continuation of <a href="/docs/publisher-tutorials/hosted-too
 
 ## Dockstore CLI
 
-The dockstore command-line includes basic tool and workflow launching capability built on top of [cwltool](https://github.com/common-workflow-language/cwltool). The Dockstore command-line also includes support for file provisioning via [plugins](https://github.com/ga4gh/dockstore/tree/develop/dockstore-file-plugin-parent) which allow for the reading of input files and the upload of output files from remote file systems. Support for http and https is built-in. Support for AWS S3 and [icgc-storage client](https://github.com/dockstore/icgc-storage-client-plugin) is provided via plugins installed by default.
+The dockstore command-line includes basic tool and workflow launching capability built on top of [cwltool](https://github.com/common-workflow-language/cwltool). The Dockstore command-line also includes support for file provisioning via [plugins](https://github.com/ga4gh/dockstore/tree/develop/dockstore-file-plugin-parent) which allow for the reading of input files and the upload of output files from remote file systems. Support for HTTP and HTTPS is built-in. Support for AWS S3 and [ICGC Score client](https://github.com/dockstore/icgc-storage-client-plugin) is provided via plugins installed by default.
 
 ### Launch Tools
 

--- a/_docs/starring.md
+++ b/_docs/starring.md
@@ -7,7 +7,7 @@ If you find a tool or a workflow interesting and want to keep track of it, you c
 
 
 ## How To Star an Entry
-To star an entry go to the public page of a tool or workflow and click on the star button. Beside the star is another button which shows the number of users who have also starred the entry. Clicking on the button will bring you to a page where you can view all the users who have also starred the entry.
+To star an entry, go to the public page of a tool or workflow and click on the star button. Beside the star is another button which shows the number of users who have also starred the entry. Clicking on the button will bring you to a page where you can view all the users who have also starred the entry.
 
 ## Other Reasons To Star an Entry
 Starring also gives an indication for how popular a tool or workflow is. When searching for tools and workflows you can sort by the number of stars. This means that starring is a good way to tell developers that you like their tool or workflow. This also tells the community that the entry is likely of better quality.

--- a/_includes/language-support.html
+++ b/_includes/language-support.html
@@ -74,7 +74,7 @@
                 <br>
                 <a href="/docs/user-tutorials/dnanexus-launch-with/">DNAnexus</a> (workflows only)
                 <br>
-                <a href="/docs/user-tutorials/terra-launch-with/">Terra</a> (workflows only)
+                Terra (workflows only)
             </td>
             <td class="warning">Not yet!</td>
         </tr>

--- a/_includes/language-support.html
+++ b/_includes/language-support.html
@@ -46,14 +46,16 @@
             <td><a href="/docs/publisher-tutorials/hosted-tools-and-workflows/">Hosted Workflows</a></td>
             <td class="success">Yes</td>
             <td class="success">Yes</td>
-            <td class="warning">Coming soon!</td>
+            <td class="success">Yes</td>
         </tr>
         <tr>
             <td>DAG Display</td>
             <td class="success">Yes (cwl version=>1.0)
                 <sup>[0]</sup>
             </td>
-            <td class="success">Yes (wdl version&lt;=draft-2)</td>
+            <td class="success">Yes (wdl version&lt;=draft-2)
+                <sup>[1]</sup>
+            </td>
             <td class="success">Limited support</td>
         </tr>
         <tr>
@@ -66,11 +68,13 @@
             <td>Launch-with Platforms</td>
             <td class="warning">Not yet!</td>
             <td class="success">
-                <a href="/docs/user-tutorials/firecloud-launch-with/">FireCloud</a> (workflows only)<sup>[1]</sup>
+                <a href="/docs/user-tutorials/firecloud-launch-with/">FireCloud</a> (workflows only)<sup>[2]</sup>
                 <br>
-                <a href="/docs/user-tutorials/dnastack-launch-with/">DNAStack</a> (workflows only)<sup>[2]</sup>
+                <a href="/docs/user-tutorials/dnastack-launch-with/">DNAstack</a> (workflows only)<sup>[3]</sup>
                 <br>
                 <a href="/docs/user-tutorials/dnanexus-launch-with/">DNAnexus</a> (workflows only)
+                <br>
+                <a href="/docs/user-tutorials/terra-launch-with/">Terra</a> (workflows only)
             </td>
             <td class="warning">Not yet!</td>
         </tr>
@@ -88,13 +92,12 @@
         </tr>
         <tr>
             <td><a href="/docs/user-tutorials/launch/#dockstore-cli">Local workflow engines</a></td>
-            <td class="success">cwltool
+            <td class="success">cwltool, Cromwell
             </td>
             <td class="success">Cromwell
-                <sup>[3]</sup>
+                <sup>[4]</sup>
             </td>
             <td class="success">Nextflow
-                <sup>[4]</sup>
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
The `<sup>` were merely shifted and had one altered, but Git thinks there's a lot more changed.