### PR TITLE
switch keywords in WES help

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -1287,8 +1287,8 @@ public abstract class AbstractEntryClient<T> {
 
     protected void wesLaunchHelp() {
         printHelpHeader();
-        out("Usage: dockstore wes " + getEntryType().toLowerCase() + " launch --help");
-        out("       dockstore wes " + getEntryType().toLowerCase() + " launch [parameters]");
+        out("Usage: dockstore " + getEntryType().toLowerCase() + " wes launch --help");
+        out("       dockstore " + getEntryType().toLowerCase() + " wes launch [parameters]");
         printLaunchHelpBody();
         printWesHelpFooter();
         printHelpFooter();


### PR DESCRIPTION
Fixes the word order in a help message for launching a WES run
Mistake found in verification
issue 2203
and DOCK-575
