### PR TITLE
Docs/gcs plugin

### DIFF
--- a/_docs/advanced-features.md
+++ b/_docs/advanced-features.md
@@ -81,8 +81,6 @@ Get more information on the implementing plugin at [synapse-plugin
 
 ### Data Object Service (DOS)
 
-> For Dockstore 1.5.0+
-
 Currently, no additional configuration is directly supported by the Data Object Service plugin.
 However, specifying a DOS URI will lead to downloading a file by either built-in
 support or by one of the plugins. If one of the plugins, that plugin may need to be

--- a/_docs/advanced-features.md
+++ b/_docs/advanced-features.md
@@ -65,6 +65,8 @@ Get more information on the implementing plugin at [s3-plugin](https://github.co
 
 ### Google Cloud Storage
 
+> Automatically installed in Dockstore 1.6.0+
+
 For Google Cloud Storage, you can download, upload, and set metadata on uploaded objects with the gs-plugin.  The plugin handles urls with the `gs://` prefix such as `gs://genomics-public-data/references/GRCh38/chr1.fa.gz`. Get more information on the implementing plugin at [gs-plugin](https://github.com/dockstore/gs-plugin).
 
 ### ICGC Storage
@@ -204,3 +206,6 @@ dockstore tool launch --local-entry Dockstore.cwl --json test.json --uuid fakeUU
 ### Notes
 - To disable notifications, simply remove the webhook URL from the Dockstore config file
 - If the UUID is generated, the generated UUID will be displayed in beginning of the launch stdout
+<!--stackedit_data:
+eyJoaXN0b3J5IjpbMjA4MjI5MzQ4NV19
+-->

--- a/_docs/advanced-features.md
+++ b/_docs/advanced-features.md
@@ -52,6 +52,10 @@ For AWS S3, create a `~/.aws/credentials` file and a `~/.aws/config` file as doc
 
 Get more information on the implementing plugin at [s3-plugin](https://github.com/dockstore/s3-plugin).
 
+### Google Cloud Storage
+
+For Google Cloud Storage, you can download, upload, and set metadata on uploaded objects with the gs-plugin.  The plugin handles urls with the `gs://` prefix such as `gs://genomics-public-data/references/GRCh38/chr1.fa.gz`. Get more information on the implementing plugin at https://github.com/dockstore/gs-plugin.
+
 ### ICGC Storage
 
 For ICGC Storage, configure the location of the client using the configuration key `dockstore-file-icgc-storage-client-plugin.client` in `~/.dockstore/config` under the section `[dockstore-file-icgc-storage-client-plugin]`. Then configure the ICGC storage client as documented [here](https://docs.icgc.org/download/guide/#configuration).

--- a/_docs/advanced-features.md
+++ b/_docs/advanced-features.md
@@ -46,6 +46,15 @@ Provisioning for output files works in the same way and has been tested with S3 
 
 For some file provisioning methods, additional configuration may be required.
 
+The below summarizes some of the plugins available:
+
+| Plugin                                                                                | Prefix  | Example                                                                                          | Supported Operations                     |
+|---------------------------------------------------------------------------------------|:-------:|--------------------------------------------------------------------------------------------------|------------------------------------------|
+| [s3-plugin](https://github.com/dockstore/s3-plugin)                                   | s3://   | s3://oicr.temp/bamstats_report.zip                                                               | upload, download, set metadata on upload |
+| [icgc-storage-client-plugin](https://github.com/dockstore/icgc-storage-client-plugin) | icgc:// | icgc://eeca3ccd-fa4e-57bf-9fde-c9d0ddf69935                                                      | download directories                     |
+| [synapse-plugin](https://github.com/dockstore/synapse-plugin)                         | syn://  | syn://syn8299856                                                                                 | download                                 |
+| [data-object-service-plugin](https://github.com/dockstore/data-object-service-plugin) | dos://  | dos://ec2-52-26-45-130.us-west-2.compute.amazonaws.com:8080/911bda59-b6f9-4330-9543-c2bf96df1eca | download                                 |
+
 ### AWS S3
 
 For AWS S3, create a `~/.aws/credentials` file and a `~/.aws/config` file as documented at the following [location](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files).

--- a/_docs/advanced-features.md
+++ b/_docs/advanced-features.md
@@ -50,10 +50,12 @@ The below summarizes some of the plugins available:
 
 | Plugin                                                                                | Prefix  | Example                                                                                          | Supported Operations                     |
 |---------------------------------------------------------------------------------------|:-------:|--------------------------------------------------------------------------------------------------|------------------------------------------|
-| [s3-plugin](https://github.com/dockstore/s3-plugin)                                   | s3://   | s3://oicr.temp/bamstats_report.zip                                                               | upload, download, set metadata on upload |
+| [s3-plugin](https://github.com/dockstore/s3-plugin)                                   | s3://   | s3://oicr.temp/bamstats_report.zip                                                               | download, upload, set metadata on upload |
 | [icgc-storage-client-plugin](https://github.com/dockstore/icgc-storage-client-plugin) | icgc:// | icgc://eeca3ccd-fa4e-57bf-9fde-c9d0ddf69935                                                      | download directories                     |
 | [synapse-plugin](https://github.com/dockstore/synapse-plugin)                         | syn://  | syn://syn8299856                                                                                 | download                                 |
 | [data-object-service-plugin](https://github.com/dockstore/data-object-service-plugin) | dos://  | dos://ec2-52-26-45-130.us-west-2.compute.amazonaws.com:8080/911bda59-b6f9-4330-9543-c2bf96df1eca | download                                 |
+| [gcs-plugin](https://github.com/dockstore/gs-plugin)                                  | gs://   | gs://genomics-public-data/references/GRCh38/chr1.fa.gz                                           | download, upload, set metadata on upload |
+
 
 ### AWS S3
 
@@ -63,7 +65,7 @@ Get more information on the implementing plugin at [s3-plugin](https://github.co
 
 ### Google Cloud Storage
 
-For Google Cloud Storage, you can download, upload, and set metadata on uploaded objects with the gs-plugin.  The plugin handles urls with the `gs://` prefix such as `gs://genomics-public-data/references/GRCh38/chr1.fa.gz`. Get more information on the implementing plugin at https://github.com/dockstore/gs-plugin.
+For Google Cloud Storage, you can download, upload, and set metadata on uploaded objects with the gs-plugin.  The plugin handles urls with the `gs://` prefix such as `gs://genomics-public-data/references/GRCh38/chr1.fa.gz`. Get more information on the implementing plugin at [gs-plugin](https://github.com/dockstore/gs-plugin).
 
 ### ICGC Storage
 

--- a/_docs/best-practices/nfl-best-practices.md
+++ b/_docs/best-practices/nfl-best-practices.md
@@ -6,8 +6,6 @@ permalink: /docs/publisher-tutorials/nfl-best-practices/
 
 ## Authorship Metadata
 
-> For Dockstore 1.5.0+
-
 {% include_relative authorship-metadata-intro.md %}
 
 This example includes author and description metadata:

--- a/_docs/best-practices/wdl-best-practices.md
+++ b/_docs/best-practices/wdl-best-practices.md
@@ -6,8 +6,6 @@ permalink: /docs/publisher-tutorials/wdl-best-practices/
 
 ## Authorship Metadata
 
-> For Dockstore 1.5.0+
-
 {% include_relative authorship-metadata-intro.md %}
 
 This example includes author, email, and description metadata:

--- a/_docs/docs.md
+++ b/_docs/docs.md
@@ -23,8 +23,6 @@ A) Following our [tutorials](https://docs.dockstore.org/docs/prereqs/getting-sta
 
 B) Dockstore can retrieve your workflow descriptors from GitHub and other source control methods. You are responsible for ensuring that your descriptors point at valid Docker images.
 
-> For Dockstore 1.5.0+
-
 C) You will be able to use our new hosted workflows service to store tools and workflows directly on dockstore.org to quickly get started, prototype your ideas, and share workflows with a limited audience.
 
 In all three cases, you will have an opportunity to clean-up and configure your work before publishing to the rest of the world to see. 

--- a/_docs/guid-alias.md
+++ b/_docs/guid-alias.md
@@ -3,7 +3,6 @@ title: GUID Alias
 permalink: /docs/publisher-tutorials/guid-alias/
 ---
 # GUID Alias
-> For Dockstore 1.5.0+
 
 If you would like to setup aliases for your tool or workflow, you can now do so through our API for now. Aliases deal with the situation where there are multiple Dockstore-like sites (including Dockstore), and you have the same tool on each platform. You can use an alias to give this tool a unique name that could potentially be valid across all sites, independent of site specific naming conventions.
 

--- a/_docs/sharing-workflows.md
+++ b/_docs/sharing-workflows.md
@@ -3,8 +3,6 @@ title: Sharing Workflows
 permalink: /docs/publisher-tutorials/sharing-workflows/
 ---
 
-> For Dockstore 1.5.0+
-
 # Intro
 
 Starting in Dockstore 1.5, a limited sharing functionality has been introduced. With sharing,


### PR DESCRIPTION
For https://ucsc-cgl.atlassian.net/browse/SEAB-113

- Add short description + link to the gcs plugin.
- A chart summarizing plugins because there's quite a few now
- Removed 1.5.0 Dockstore stuff

Edit: I like https://stackedit.io/app# more.  Too bad it can't control the commit message and also puts a comment near the end.