### PR TITLE
only return published entries for a collection

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -1164,6 +1164,21 @@ public class OrganizationIT extends BaseIT {
                 .runSelectStatement("select count(*) from event where type = 'ADD_TO_COLLECTION'", new ScalarHandler<>());
         assertEquals("There should be 2 events of type ADD_TO_COLLECTION, there are " + count3, 2, count3);
 
+        // Unpublish tool
+        PublishRequest unpublishRequest = SwaggerUtility.createPublishRequest(false);
+        containersApi.publish(entryId, unpublishRequest);
+
+        // Collection should have one tool returned
+        long entryCount = organizationsApi.getCollectionById(organization.getId(), collectionId).getEntries().size();
+        assertEquals("There should be one entry with the collection, there are " + entryCount, 1, entryCount);
+
+        // Publish tool
+        containersApi.publish(entryId, publishRequest);
+
+        // Collection should have two tools returned
+        entryCount = organizationsApi.getCollectionById(organization.getId(), collectionId).getEntries().size();
+        assertEquals("There should be two entries with the collection, there are " + entryCount, 2, entryCount);
+
         // Remove a tool from the collection
         organizationsApi.deleteEntryFromCollection(organization.getId(), collectionId, entryId);
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -136,7 +137,7 @@ public class Collection implements Serializable, Aliasable {
     }
 
     public Set<Entry> getEntries() {
-        return entries;
+        return entries.stream().filter(entry -> entry.getIsPublished()).collect(Collectors.toSet());
     }
 
     public void setEntries(Set<Entry> entries) {

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -6372,6 +6372,10 @@ components:
         custom_docker_registry_path:
           type: string
           readOnly: true
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -6387,10 +6391,6 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
@@ -6556,6 +6556,10 @@ components:
         dbUpdateDate:
           type: string
           format: date-time
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -6571,10 +6575,6 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
@@ -7528,6 +7528,10 @@ components:
           type: integer
           format: int64
           readOnly: true
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -7543,10 +7547,6 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3028,7 +3028,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Collection'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
   /organizations/name/{name}:
     get:
@@ -4317,7 +4317,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: '#/components/schemas/Entry'
           description: default response
   /workflows/hostedEntry/{entryId}:
     delete:
@@ -4343,7 +4343,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: '#/components/schemas/Entry'
           description: default response
     patch:
       operationId: editHosted_1

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5835,6 +5835,10 @@ definitions:
       custom_docker_registry_path:
         type: "string"
         readOnly: true
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -5850,10 +5854,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       author:
         type: "string"
         position: 1
@@ -6046,6 +6046,10 @@ definitions:
       dbUpdateDate:
         type: "string"
         format: "date-time"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -6061,10 +6065,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       author:
         type: "string"
         position: 1
@@ -7104,6 +7104,10 @@ definitions:
         type: "integer"
         format: "int64"
         readOnly: true
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -7119,10 +7123,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       author:
         type: "string"
         position: 1


### PR DESCRIPTION
If a tool is part of a collection, and then the tool is unpublished, it should not be returned with the collection.
If the tool is then published again, it should automatically reappear in the collection.

Do we want any indication that a tool used to be part of a collection but is unpublished? Worried this might be cutting it too close to release.