### PR TITLE
Feature/2303/refresh fix

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -697,7 +697,7 @@ public class WorkflowIT extends BaseIT {
         // Check that a workflow from my namespace is present
         assertTrue("Should have at least one repo from DockstoreTestUser2.", workflows.stream().anyMatch((Workflow workflow) -> workflow.getOrganization().equalsIgnoreCase("DockstoreTestUser2")));
 
-        // Check that a workflow from an organization I below to is present
+        // Check that a workflow from an organization I belong to is present
         assertTrue("Should have at least one repo from organization dockstoretesting.", workflows.stream().anyMatch((Workflow workflow) -> workflow.getOrganization().equalsIgnoreCase("dockstoretesting")));
 
         // Check that a workflow that I am a collaborator on is present

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -695,16 +695,24 @@ public class WorkflowIT extends BaseIT {
         assertNotNull("could get mta as a specific tool", toolV2);
 
         // Check that a workflow from my namespace is present
-        assertTrue("Should have at least one repo from DockstoreTestUser2.", workflows.stream().anyMatch((Workflow workflow) -> workflow.getOrganization().equalsIgnoreCase("DockstoreTestUser2")));
+        assertTrue("Should have at least one repo from DockstoreTestUser2.",
+                workflows.stream().anyMatch((Workflow workflow) -> workflow.getOrganization().equalsIgnoreCase("DockstoreTestUser2")));
 
         // Check that a workflow from an organization I belong to is present
-        assertTrue("Should have at least one repo from organization dockstoretesting.", workflows.stream().anyMatch((Workflow workflow) -> workflow.getOrganization().equalsIgnoreCase("dockstoretesting")));
+        assertTrue("Should have repository basic-workflow from organization dockstoretesting.",
+                workflows.stream().anyMatch((Workflow workflow) -> workflow.getOrganization().equalsIgnoreCase("dockstoretesting") &&
+                        workflow.getRepository().equalsIgnoreCase("basic-workflow")));
 
         // Check that a workflow that I am a collaborator on is present
-        assertTrue("Should have at least one repo from DockstoreTestUser.", workflows.stream().anyMatch((Workflow workflow) -> workflow.getOrganization().equalsIgnoreCase("DockstoreTestUser")));
+        assertTrue("Should have repository dockstore-whalesay-2 from DockstoreTestUser.", workflows.stream().anyMatch((Workflow workflow) ->
+                workflow.getOrganization().equalsIgnoreCase("DockstoreTestUser") &&
+                workflow.getRepository().equalsIgnoreCase("dockstore-whalesay-2")));
 
         // Check that for a repo from my organization that I forked to DockstoreTestUser2, that it along with the original repo are present
-        assertEquals("Should have two repos with name basic-workflow, one from DockstoreTestUser2 and one from dockstoretesting.", 2, workflows.stream().filter((Workflow workflow) -> workflow.getRepository().equalsIgnoreCase("basic-workflow")).count());
+        assertEquals("Should have two repos with name basic-workflow, one from DockstoreTestUser2 and one from dockstoretesting.", 2, workflows.stream().filter((Workflow workflow) ->
+                (workflow.getOrganization().equalsIgnoreCase("dockstoretesting") ||
+                workflow.getOrganization().equalsIgnoreCase("DockstoreTestUser2")) &&
+                workflow.getRepository().equalsIgnoreCase("basic-workflow")).count());
 
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -644,7 +644,7 @@ public class WorkflowIT extends BaseIT {
 
         final ApiClient webClient = getWebClient(USER_2_USERNAME);
         UsersApi usersApi = new UsersApi(webClient);
-        final List<Workflow> workflow = usersApi.refreshWorkflows(userId);
+        final List<Workflow> workflows = usersApi.refreshWorkflows(userId);
 
         // Check that there are multiple workflows
         final long count = testingPostgres.runSelectStatement("select count(*) from workflow", new ScalarHandler<>());
@@ -658,9 +658,9 @@ public class WorkflowIT extends BaseIT {
         assertEquals("No workflows are in full mode", 0, count3);
 
         // check that a nextflow workflow made it
-        long nfWorkflowCount = workflow.stream().filter(w -> w.getGitUrl().contains("mta-nf")).count();
+        long nfWorkflowCount = workflows.stream().filter(w -> w.getGitUrl().contains("mta-nf")).count();
         assertTrue("Nextflow workflow not found", nfWorkflowCount > 0);
-        Workflow mtaNf = workflow.stream().filter(w -> w.getGitUrl().contains("mta-nf")).findFirst().get();
+        Workflow mtaNf = workflows.stream().filter(w -> w.getGitUrl().contains("mta-nf")).findFirst().get();
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
         mtaNf.setWorkflowPath("/nextflow.config");
         mtaNf.setDescriptorType(LanguageType.NEXTFLOW.toString());
@@ -693,6 +693,19 @@ public class WorkflowIT extends BaseIT {
         assertTrue("could get mta as part of list", toolV2s.size() > 0 && toolV2s.stream().anyMatch(tool -> Objects
             .equals(tool.getId(), mtaWorkflowID)));
         assertNotNull("could get mta as a specific tool", toolV2);
+
+        // Check that a workflow from my namespace is present
+        assertTrue("Should have at least one repo from DockstoreTestUser2.", workflows.stream().anyMatch((Workflow workflow) -> workflow.getOrganization().equalsIgnoreCase("DockstoreTestUser2")));
+
+        // Check that a workflow from an organization I below to is present
+        assertTrue("Should have at least one repo from organization dockstoretesting.", workflows.stream().anyMatch((Workflow workflow) -> workflow.getOrganization().equalsIgnoreCase("dockstoretesting")));
+
+        // Check that a workflow that I am a collaborator on is present
+        assertTrue("Should have at least one repo from DockstoreTestUser.", workflows.stream().anyMatch((Workflow workflow) -> workflow.getOrganization().equalsIgnoreCase("DockstoreTestUser")));
+
+        // Check that for a repo from my organization that I forked to DockstoreTestUser2, that it along with the original repo are present
+        assertEquals("Should have two repos with name basic-workflow, one from DockstoreTestUser2 and one from dockstoretesting.", 2, workflows.stream().filter((Workflow workflow) -> workflow.getRepository().equalsIgnoreCase("basic-workflow")).count());
+
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -214,8 +214,12 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
     public Map<String, String> getWorkflowGitUrl2RepositoryId() {
         Map<String, String> reposByGitURl = new HashMap<>();
         try {
-            // get repos under the user directly
             // TODO: This code should be optimized. Ex. Only grab repositories from a specific org if refreshing by org.
+            // The filter all includes:
+            // * All repositories I own
+            // * All repositories I am a contributor on
+            // * All repositories from organizations I belong to
+
             final int pageSize = 30;
             Map<String, GHRepository> allMyRepos = new TreeMap<>();
             github.getMyself().listRepositories(pageSize, GHMyself.RepositoryListFilter.ALL).forEach((GHRepository r) -> allMyRepos.put(r.getFullName(), r));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -58,7 +58,6 @@ import org.kohsuke.github.GHBranch;
 import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHContent;
 import org.kohsuke.github.GHMyself;
-import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GHRateLimit;
 import org.kohsuke.github.GHRef;
 import org.kohsuke.github.GHRepository;
@@ -216,24 +215,15 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         Map<String, String> reposByGitURl = new HashMap<>();
         try {
             // get repos under the user directly
+            // TODO: This code should be optimized. Ex. Only grab repositories from a specific org if refreshing by org.
             final int pageSize = 30;
-            Map<String, GHRepository> repos = new TreeMap<>();
-            github.getMyself().listRepositories(pageSize, GHMyself.RepositoryListFilter.OWNER).forEach((GHRepository r) -> repos.put(r.getName(), r));
+            Map<String, GHRepository> allMyRepos = new TreeMap<>();
+            github.getMyself().listRepositories(pageSize, GHMyself.RepositoryListFilter.ALL).forEach((GHRepository r) -> allMyRepos.put(r.getFullName(), r));
 
-            Map<String, GHRepository> allRepositories = Collections.unmodifiableMap(repos);
+            Map<String, GHRepository> allRepositories = Collections.unmodifiableMap(allMyRepos);
 
             for (Map.Entry<String, GHRepository> innerEntry : allRepositories.entrySet()) {
                 reposByGitURl.put(innerEntry.getValue().getSshUrl(), innerEntry.getValue().getFullName());
-            }
-
-            // get organizations that user has access to
-            Map<String, GHOrganization> myOrganizations = github.getMyOrganizations();
-            for (Map.Entry<String, GHOrganization> entry : myOrganizations.entrySet()) {
-                GHOrganization organization = github.getOrganization(entry.getKey());
-                Map<String, GHRepository> repositories = organization.getRepositories();
-                for (Map.Entry<String, GHRepository> innerEntry : repositories.entrySet()) {
-                    reposByGitURl.put(innerEntry.getValue().getSshUrl(), innerEntry.getValue().getFullName());
-                }
             }
             return reposByGitURl;
         } catch (IOException e) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -22,11 +22,13 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -214,7 +216,12 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         Map<String, String> reposByGitURl = new HashMap<>();
         try {
             // get repos under the user directly
-            Map<String, GHRepository> allRepositories = github.getMyself().getAllRepositories();
+            final int pageSize = 30;
+            Map<String, GHRepository> repos = new TreeMap<>();
+            github.getMyself().listRepositories(pageSize, GHMyself.RepositoryListFilter.OWNER).forEach((GHRepository r) -> repos.put(r.getName(), r));
+
+            Map<String, GHRepository> allRepositories = Collections.unmodifiableMap(repos);
+
             for (Map.Entry<String, GHRepository> innerEntry : allRepositories.entrySet()) {
                 reposByGitURl.put(innerEntry.getValue().getSshUrl(), innerEntry.getValue().getFullName());
             }


### PR DESCRIPTION
Before we were grabbing all GitHub repos and storing into a map, with the key as the name. The issue is that the name is not necessarily unique, so in the case of forks they sometimes didn't work.
We were also doing an unnecessary call to grab all orgs for a user, then per org grab the repo, when we can do everything in one call and simply use the full name as the key (ex. agduncan94/foobar instead of foobar).

I am making this a draft so that it doesn't make a PR build yet.

https://github.com/ga4gh/dockstore/issues/2303