### PR TITLE
Better migration guess for absolute paths

### DIFF
--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.6.0-rc.2-SNAPSHOT</version>
+        <version>1.6.0-rc.3</version>
     </parent>
     <artifactId>dockstore-client</artifactId>
     <packaging>jar</packaging>
@@ -42,22 +42,22 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>openapi-java-wes-client</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-file-plugin-parent</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>

--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.6.0-rc.3</version>
+        <version>1.6.0-rc.4-SNAPSHOT</version>
     </parent>
     <artifactId>dockstore-client</artifactId>
     <packaging>jar</packaging>
@@ -42,22 +42,22 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>openapi-java-wes-client</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-file-plugin-parent</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.6.0-rc.2-SNAPSHOT</version>
+        <version>1.6.0-rc.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-common</artifactId>

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.6.0-rc.3</version>
+        <version>1.6.0-rc.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-common</artifactId>

--- a/dockstore-event-consumer/pom.xml
+++ b/dockstore-event-consumer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.6.0-rc.3</version>
+        <version>1.6.0-rc.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -30,12 +30,12 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>

--- a/dockstore-event-consumer/pom.xml
+++ b/dockstore-event-consumer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.6.0-rc.2-SNAPSHOT</version>
+        <version>1.6.0-rc.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -30,12 +30,12 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>

--- a/dockstore-file-plugin-parent/pom.xml
+++ b/dockstore-file-plugin-parent/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <version>1.6.0-rc.2-SNAPSHOT</version>
+        <version>1.6.0-rc.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/dockstore-file-plugin-parent/pom.xml
+++ b/dockstore-file-plugin-parent/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <version>1.6.0-rc.3</version>
+        <version>1.6.0-rc.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.6.0-rc.3</version>
+        <version>1.6.0-rc.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-integration-testing</artifactId>
@@ -34,30 +34,30 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-client</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>openapi-java-client</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
         </dependency>
 
         <!-- testing -->
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.6.0-rc.2-SNAPSHOT</version>
+        <version>1.6.0-rc.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-integration-testing</artifactId>
@@ -34,30 +34,30 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-client</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
         </dependency>
 
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>openapi-java-client</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
         </dependency>
 
         <!-- testing -->
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ValidationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ValidationIT.java
@@ -151,21 +151,21 @@ public class ValidationIT extends BaseIT {
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
         workflow = workflowsApi.refresh(workflow.getId());
-        Assert.assertTrue("Should be invalid", !isWorkflowVersionValid(workflow, "master"));
+        Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
         // change to missing import - should be invalid
         workflow.setWorkflowPath("/missingImport.wdl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
         workflow = workflowsApi.refresh(workflow.getId());
-        Assert.assertTrue("Should be invalid", !isWorkflowVersionValid(workflow, "master"));
+        Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
         // change to missing workflow section - should be invalid
         workflow.setWorkflowPath("/missingWorkflowSection.wdl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
         workflow = workflowsApi.refresh(workflow.getId());
-        Assert.assertTrue("Should be invalid", !isWorkflowVersionValid(workflow, "master"));
+        Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
         // change to valid tool - should be valid
         workflow.setWorkflowPath("/validTool.wdl");
@@ -186,7 +186,7 @@ public class ValidationIT extends BaseIT {
         testParameterFiles.add("/invalidJson.json");
         workflowsApi.addTestParameterFiles(workflow.getId(), testParameterFiles, "", "master");
         workflow = workflowsApi.refresh(workflow.getId());
-        Assert.assertTrue("Should be invalid", !isWorkflowVersionValid(workflow, "master"));
+        Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
         workflowsApi.deleteTestParameterFiles(workflow.getId(), testParameterFiles, "master");
         workflow = workflowsApi.refresh(workflow.getId());
 
@@ -217,21 +217,21 @@ public class ValidationIT extends BaseIT {
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
         workflow = workflowsApi.refresh(workflow.getId());
-        Assert.assertTrue("Should be invalid", !isWorkflowVersionValid(workflow, "master"));
+        Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
         // change to wrong version - should be invalid
         workflow.setWorkflowPath("/wrongVersion.cwl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
         workflow = workflowsApi.refresh(workflow.getId());
-        Assert.assertTrue("Should be invalid", !isWorkflowVersionValid(workflow, "master"));
+        Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
         // change to tool - should be invalid
         workflow.setWorkflowPath("/validTool.cwl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
         workflow = workflowsApi.refresh(workflow.getId());
-        Assert.assertTrue("Should be invalid", !isWorkflowVersionValid(workflow, "master"));
+        Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
         // change back to valid workflow - should be valid
         workflow.setWorkflowPath("/validWorkflow.cwl");
@@ -245,7 +245,7 @@ public class ValidationIT extends BaseIT {
         testParameterFiles.add("/invalidJson.json");
         workflowsApi.addTestParameterFiles(workflow.getId(), testParameterFiles, "", "master");
         workflow = workflowsApi.refresh(workflow.getId());
-        Assert.assertTrue("Should be invalid", !isWorkflowVersionValid(workflow, "master"));
+        Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
         workflowsApi.deleteTestParameterFiles(workflow.getId(), testParameterFiles, "master");
         workflow = workflowsApi.refresh(workflow.getId());
 
@@ -277,14 +277,14 @@ public class ValidationIT extends BaseIT {
         tool = toolsApi.updateContainer(tool.getId(), tool);
         toolsApi.updateTagContainerPath(tool.getId(), tool);
         tool = toolsApi.refresh(tool.getId());
-        Assert.assertTrue("Should be invalid", !isTagValid(tool, "master"));
+        Assert.assertFalse(isTagValid(tool, "master"));
 
         // Change to invalid cwl version
         tool.setDefaultCwlPath("/wrongVersion.cwl");
         tool = toolsApi.updateContainer(tool.getId(), tool);
         toolsApi.updateTagContainerPath(tool.getId(), tool);
         tool = toolsApi.refresh(tool.getId());
-        Assert.assertTrue("Should be invalid", !isTagValid(tool, "master"));
+        Assert.assertFalse(isTagValid(tool, "master"));
 
         // Change to valid cwl tool
         tool.setDefaultCwlPath("/validTool.cwl");
@@ -298,7 +298,7 @@ public class ValidationIT extends BaseIT {
         testParameterFiles.add("/invalidJson.json");
         toolsApi.addTestParameterFiles(tool.getId(), testParameterFiles, "CWL", "", "master");
         tool = toolsApi.refresh(tool.getId());
-        Assert.assertTrue("Should be invalid", !isTagValid(tool, "master"));
+        Assert.assertFalse(isTagValid(tool, "master"));
         toolsApi.deleteTestParameterFiles(tool.getId(), testParameterFiles, "CWL", "master");
         tool = toolsApi.refresh(tool.getId());
 
@@ -323,7 +323,7 @@ public class ValidationIT extends BaseIT {
         tool = toolsApi.updateContainer(tool.getId(), tool);
         toolsApi.updateTagContainerPath(tool.getId(), tool);
         tool = toolsApi.refresh(tool.getId());
-        Assert.assertTrue("Should be invalid", !isTagValid(tool, "master"));
+        Assert.assertFalse(isTagValid(tool, "master"));
 
         // make wdl valid - should be valid
         tool.setDefaultWdlPath("/validTool.wdl");
@@ -337,28 +337,28 @@ public class ValidationIT extends BaseIT {
         tool = toolsApi.updateContainer(tool.getId(), tool);
         toolsApi.updateTagContainerPath(tool.getId(), tool);
         tool = toolsApi.refresh(tool.getId());
-        Assert.assertTrue("Should be invalid", !isTagValid(tool, "master"));
+        Assert.assertFalse(isTagValid(tool, "master"));
 
         // make wdl missing import - should be invalid
         tool.setDefaultWdlPath("/missingImport.wdl");
         tool = toolsApi.updateContainer(tool.getId(), tool);
         toolsApi.updateTagContainerPath(tool.getId(), tool);
         tool = toolsApi.refresh(tool.getId());
-        Assert.assertTrue("Should be invalid", !isTagValid(tool, "master"));
+        Assert.assertFalse(isTagValid(tool, "master"));
 
         // make wdl missing workflow section - should be invalid
         tool.setDefaultWdlPath("/missingWorkflowSection.wdl");
         tool = toolsApi.updateContainer(tool.getId(), tool);
         toolsApi.updateTagContainerPath(tool.getId(), tool);
         tool = toolsApi.refresh(tool.getId());
-        Assert.assertTrue("Should be invalid", !isTagValid(tool, "master"));
+        Assert.assertFalse(isTagValid(tool, "master"));
 
         // make wdl which is valid workflow, not tool - should be invalid
         tool.setDefaultWdlPath("/validWorkflow.wdl");
         tool = toolsApi.updateContainer(tool.getId(), tool);
         toolsApi.updateTagContainerPath(tool.getId(), tool);
         tool = toolsApi.refresh(tool.getId());
-        Assert.assertTrue("Should be invalid", !isTagValid(tool, "master"));
+        Assert.assertFalse(isTagValid(tool, "master"));
 
         // make wdl valid again - should be valid
         tool.setDefaultWdlPath("/validTool.wdl");
@@ -372,7 +372,7 @@ public class ValidationIT extends BaseIT {
         testParameterFiles.add("/invalidJson.json");
         toolsApi.addTestParameterFiles(tool.getId(), testParameterFiles, "WDL", "", "master");
         tool = toolsApi.refresh(tool.getId());
-        Assert.assertTrue("Should be invalid", !isTagValid(tool, "master"));
+        Assert.assertFalse(isTagValid(tool, "master"));
         toolsApi.deleteTestParameterFiles(tool.getId(), testParameterFiles, "WDL", "master");
         tool = toolsApi.refresh(tool.getId());
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -81,6 +81,7 @@ import org.junit.rules.ExpectedException;
 
 import static io.dockstore.common.CommonTestUtilities.getTestingPostgres;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
@@ -217,7 +218,7 @@ public class WorkflowIT extends BaseIT {
         FileWrapper toolDescriptor = adminGa4Ghv2Api
             .toolsIdVersionsVersionIdTypeDescriptorGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW, "testCWL");
         String content = IOUtils.toString(new URI(toolDescriptor.getUrl()), StandardCharsets.UTF_8);
-        Assert.assertTrue("could not find content from generated URL", !content.isEmpty());
+        assertFalse(content.isEmpty());
         checkForRelativeFile(adminGa4Ghv2Api, "#workflow/" + DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW, "testCWL", "Dockstore.cwl");
 
 
@@ -273,8 +274,7 @@ public class WorkflowIT extends BaseIT {
         assertEquals("There should be one user of the workflow after manually registering it.", 1, workflow.getUsers().size());
         Workflow refresh = workflowApi.refresh(workflow.getId());
 
-
-        Assert.assertTrue("workflow is already published for some reason", !refresh.isIsPublished());
+        assertFalse(refresh.isIsPublished());
 
         // should be able to launch properly with correct credentials even though the workflow is not published
         FileUtils.writeStringToFile(new File("md5sum.input"), "foo" , StandardCharsets.UTF_8);
@@ -412,7 +412,7 @@ public class WorkflowIT extends BaseIT {
         } catch (ApiException ex) {
             success = false;
         } finally {
-            assertTrue("User does not have access to workflow.", !success);
+            assertFalse(success);
         }
         // Other user: Should fail
         success = true;
@@ -421,7 +421,7 @@ public class WorkflowIT extends BaseIT {
         } catch (ApiException ex) {
             success = false;
         } finally {
-            assertTrue("User does not have access to workflow.", !success);
+            assertFalse(success);
         }
 
         // Publish
@@ -450,7 +450,7 @@ public class WorkflowIT extends BaseIT {
                 .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
                         "test", "cwl", null);
         Workflow refresh = workflowApi.refresh(workflow.getId());
-        Assert.assertTrue("workflow is already published for some reason", !refresh.isIsPublished());
+        assertFalse(refresh.isIsPublished());
         workflowApi.registerCheckerWorkflow("checker-workflow-wrapping-workflow.cwl", workflow.getId(), "cwl", "checker-input-cwl.json");
         workflowApi.refresh(workflow.getId());
 
@@ -486,7 +486,7 @@ public class WorkflowIT extends BaseIT {
                 .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
                         "test", "cwl", null);
         Workflow refresh = workflowApi.refresh(workflow.getId());
-        Assert.assertTrue("workflow is already published for some reason", !refresh.isIsPublished());
+        Assert.assertFalse(refresh.isIsPublished());
 
         workflowApi.registerCheckerWorkflow("/checker-workflow-wrapping-workflow.cwl", workflow.getId(), "cwl", "checker-input-cwl.json");
 
@@ -619,8 +619,8 @@ public class WorkflowIT extends BaseIT {
             .findFirst();
         String tableToolContent = workflowApi.getTableToolContent(refreshGithub.getId(), first.get().getId());
         String workflowDag = workflowApi.getWorkflowDag(refreshGithub.getId(), first.get().getId());
-        assertTrue("tool table should be present", !tableToolContent.isEmpty());
-        assertTrue("workflow dag should be present", !workflowDag.isEmpty());
+            assertFalse(tableToolContent.isEmpty());
+            assertFalse(workflowDag.isEmpty());
         Gson gson = new Gson();
         List<Map<String, String>> list = gson.fromJson(tableToolContent, List.class);
         Map<Map,List> map = gson.fromJson(workflowDag, Map.class);
@@ -900,8 +900,8 @@ public class WorkflowIT extends BaseIT {
         source1.setContent(FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("hosted_metadata/sorttool.cwl")), StandardCharsets.UTF_8));
         source2.setContent(FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("hosted_metadata/revtool.cwl")), StandardCharsets.UTF_8));
         Workflow workflow = hostedApi.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(source, source1, source2));
-        assertTrue(!workflow.getInputFileFormats().isEmpty());
-        assertTrue(!workflow.getOutputFileFormats().isEmpty());
+        assertFalse(workflow.getInputFileFormats().isEmpty());
+        assertFalse(workflow.getOutputFileFormats().isEmpty());
 
 
         // launch the workflow, note that the latest version of the workflow should launch (i.e. the working one)
@@ -978,7 +978,7 @@ public class WorkflowIT extends BaseIT {
         FileWrapper toolDescriptor = ga4Ghv2Api
             .toolsIdVersionsVersionIdTypeDescriptorGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_MORE_IMPORT_STRUCTURE, "0.4.0");
         String content = IOUtils.toString(new URI(toolDescriptor.getUrl()), StandardCharsets.UTF_8);
-        Assert.assertTrue("could not find content from generated URL", !content.isEmpty());
+        assertFalse(content.isEmpty());
         // check slashed paths
         checkForRelativeFile(ga4Ghv2Api, "#workflow/" + DOCKSTORE_TEST_USER2_MORE_IMPORT_STRUCTURE, "0.4.0", "toolkit/if_input_is_bz2_convert_to_gz_else_just_rename.cwl");
         checkForRelativeFile(ga4Ghv2Api, "#workflow/" + DOCKSTORE_TEST_USER2_MORE_IMPORT_STRUCTURE, "0.4.0", "toolkit/if_file_name_is_bz2_then_return_null_else_return_in_json_to_output.cwl");
@@ -1034,7 +1034,7 @@ public class WorkflowIT extends BaseIT {
         FileWrapper toolDescriptor = ga4Ghv2Api
             .toolsIdVersionsVersionIdTypeDescriptorGet("CWL", DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_TOOL, "symbolic.v1");
         String content = IOUtils.toString(new URI(toolDescriptor.getUrl()), StandardCharsets.UTF_8);
-        Assert.assertTrue("could not find content from generated URL", !content.isEmpty());
+        assertFalse(content.isEmpty());
         // check slashed paths
         checkForRelativeFile(ga4Ghv2Api, DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_TOOL, "symbolic.v1", "/cgpmap-bamOut.cwl");
         // check paths without slash
@@ -1062,7 +1062,7 @@ public class WorkflowIT extends BaseIT {
         toolDescriptor = ga4Ghv2Api
             .toolsIdVersionsVersionIdTypeDescriptorRelativePathGet("CWL", dockstoreTestUser2RelativeImportsTool, reference, filename);
         content = IOUtils.toString(new URI(toolDescriptor.getUrl()), StandardCharsets.UTF_8);
-        Assert.assertTrue("could not find " + filename + " from generated URL", !content.isEmpty());
+        assertFalse(content.isEmpty());
     }
 
     /**
@@ -1088,7 +1088,7 @@ public class WorkflowIT extends BaseIT {
         } catch (ApiException c) {
             success = false;
         } finally {
-            assertTrue("The workflow cannot be registered as it is a duplicate.", !success);
+            assertFalse(success);
         }
 
         success = true;
@@ -1097,7 +1097,7 @@ public class WorkflowIT extends BaseIT {
         } catch (ApiException c) {
             success = false;
         } finally {
-            assertTrue("The workflow cannot be registered as the repository doesn't exist.", !success);
+            assertFalse(success);
         }
     }
 
@@ -1181,7 +1181,7 @@ public class WorkflowIT extends BaseIT {
         FileWrapper toolDescriptor = ga4Ghv2Api
             .toolsIdVersionsVersionIdTypeDescriptorGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, "master");
         String content = IOUtils.toString(new URI(toolDescriptor.getUrl()), StandardCharsets.UTF_8);
-        Assert.assertTrue("could not find content from generated URL", !content.isEmpty());
+        assertFalse(content.isEmpty());
         checkForRelativeFile(ga4Ghv2Api, "#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, "master", "adtex.cwl");
         // ignore extra separators
         checkForRelativeFile(ga4Ghv2Api, "#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, "master", "/adtex.cwl");
@@ -1198,7 +1198,7 @@ public class WorkflowIT extends BaseIT {
         assertTrue("could not find tool tests", toolTests.size() > 0);
         for(FileWrapper test: toolTests) {
             content = IOUtils.toString(new URI(test.getUrl()), StandardCharsets.UTF_8);
-            Assert.assertTrue("could not find content from generated test JSON URL", !content.isEmpty());
+            assertFalse(content.isEmpty());
         }
     }
 
@@ -1256,13 +1256,13 @@ public class WorkflowIT extends BaseIT {
                 // enable later with a simplification to TRS
                 FileWrapper test = adminGa4Ghv2Api.toolsIdVersionsVersionIdTypeDescriptorRelativePathGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW,
                     "master", file.getPath());
-                assertTrue("test exists", !test.getContent().isEmpty());
+                assertFalse(test.getContent().isEmpty());
                 count.incrementAndGet();
             } else if (file.getFileType() == ToolFile.FileTypeEnum.PRIMARY_DESCRIPTOR || file.getFileType() == ToolFile.FileTypeEnum.SECONDARY_DESCRIPTOR) {
                 // annoyingly, some files are tool tests, some are tooldescriptor
                 FileWrapper toolDescriptor = adminGa4Ghv2Api.toolsIdVersionsVersionIdTypeDescriptorRelativePathGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW,
                     "master", file.getPath());
-                assertTrue("descriptor exists", !toolDescriptor.getContent().isEmpty());
+                assertFalse(toolDescriptor.getContent().isEmpty());
                 count.incrementAndGet();
             } else {
                 fail();

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -27,7 +27,7 @@
     </properties>
 
     <parent>
-        <version>1.6.0-rc.2-SNAPSHOT</version>
+        <version>1.6.0-rc.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -57,22 +57,22 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-quay-client</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-sam-client</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-bitbucket-client</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
@@ -534,7 +534,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -27,7 +27,7 @@
     </properties>
 
     <parent>
-        <version>1.6.0-rc.3</version>
+        <version>1.6.0-rc.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -57,22 +57,22 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-quay-client</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-sam-client</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-bitbucket-client</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
@@ -534,7 +534,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -42,6 +42,7 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
+import io.dockstore.webservice.helpers.ZipSourceFileHelper;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.hibernate.annotations.CreationTimestamp;
@@ -151,11 +152,19 @@ public class SourceFile implements Comparable<SourceFile> {
     }
 
     public String getAbsolutePath() {
+        if (absolutePath == null) {
+            return null;
+        }
         return Paths.get(absolutePath).normalize().toString();
     }
 
     public void setAbsolutePath(String absolutePath) {
-        this.absolutePath = absolutePath;
+        // TODO: Figure out the actual absolute path before this workaround
+        // FIXME: it looks like dockstore tool test_parameter --add and a number of other CLI commands depend on this now
+        this.absolutePath = ZipSourceFileHelper.addLeadingSlashIfNecessary((absolutePath));
+        if (!this.absolutePath.equals(absolutePath)) {
+            LOG.warn("Absolute path workaround used, this should be fixed at some point");
+        }
     }
 
     @JsonIgnore

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -16,6 +16,7 @@
 
 package io.dockstore.webservice.core;
 
+import java.nio.file.Paths;
 import java.sql.Timestamp;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -41,7 +42,6 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
-import io.dockstore.webservice.helpers.ZipSourceFileHelper;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.hibernate.annotations.CreationTimestamp;
@@ -151,15 +151,11 @@ public class SourceFile implements Comparable<SourceFile> {
     }
 
     public String getAbsolutePath() {
-        return absolutePath;
+        return Paths.get(absolutePath).normalize().toString();
     }
 
     public void setAbsolutePath(String absolutePath) {
-        // TODO: Figure out the actual absolute path before this workaround
-        this.absolutePath = ZipSourceFileHelper.addLeadingSlashIfNecessary((absolutePath));
-        if (!this.absolutePath.equals(absolutePath)) {
-            LOG.warn("Absolute path workaround used, this should be fixed at some point");
-        }
+        this.absolutePath = absolutePath;
     }
 
     @JsonIgnore

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -317,7 +317,7 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
                 // Sourcefile doesn't exist, add a stub which will have it's content filled on refresh
                 SourceFile sourceFile = new SourceFile();
                 sourceFile.setPath(path);
-                sourceFile.setAbsolutePath(path);
+                sourceFile.setAbsolutePath(Paths.get(StringUtils.prependIfMissing(workflowVersion.getWorkingDirectory(), "/")).resolve(path).toString());
                 sourceFile.setType(fileType);
 
                 long id = fileDAO.create(sourceFile);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -421,10 +421,11 @@ public class WorkflowResource
 
             // Update source files for each version
             Map<String, SourceFile> existingFileMap = new HashMap<>();
-            workflowVersionFromDB.getSourceFiles().forEach(file -> existingFileMap.put(file.getType().toString() + file.getPath(), file));
+            workflowVersionFromDB.getSourceFiles().forEach(file -> existingFileMap.put(file.getType().toString() + file.getAbsolutePath(), file));
+
             for (SourceFile file : version.getSourceFiles()) {
-                if (existingFileMap.containsKey(file.getType().toString() + file.getPath())) {
-                    existingFileMap.get(file.getType().toString() + file.getPath()).setContent(file.getContent());
+                if (existingFileMap.containsKey(file.getType().toString() + file.getAbsolutePath())) {
+                    existingFileMap.get(file.getType().toString() + file.getAbsolutePath()).setContent(file.getContent());
                 } else {
                     final long fileID = fileDAO.create(file);
                     final SourceFile fileFromDB = fileDAO.findById(fileID);
@@ -432,11 +433,11 @@ public class WorkflowResource
                 }
             }
 
-            // Remove existing files that are no longer present
+            // Remove existing files that are no longer present on remote
             for (Map.Entry<String, SourceFile> entry : existingFileMap.entrySet()) {
                 boolean toDelete = true;
                 for (SourceFile file : version.getSourceFiles()) {
-                    if (entry.getKey().equals(file.getType().toString() + file.getPath())) {
+                    if (entry.getKey().equals(file.getType().toString() + file.getAbsolutePath())) {
                         toDelete = false;
                     }
                 }

--- a/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.6.0.xml
@@ -348,4 +348,35 @@
             ALTER TABLE sourcefile ADD CONSTRAINT absolutepath_check CHECK (absolutepath LIKE '/%' OR absolutepath='')
         </sql>
     </changeSet>
+    <changeSet id="epicAbsolutePathFix" author="dyuen">
+        <sql dbms="postgresql">
+            update sourcefile s set absolutepath = subquery.concat_ws FROM (
+                with workflow_paths as (
+                    select w.giturl, w.mode, wv.workflowpath, s.id, s.path, s.absolutepath, s.type, CONCAT_WS('/', NULLIF(LEFT(wv.workflowpath, LENGTH (wv.workflowpath) - POSITION('/' in REVERSE(wv.workflowpath))),''), path) as concat_ws     from workflow w, workflow_workflowversion wwv, workflowversion wv, version_sourcefile vs, sourcefile s where w.id = wwv.workflowid and wwv.workflowversionid = wv.id and wv.id = vs.versionid and  vs.sourcefileid = s.id
+                    and workflowpath != path -- ignore primary descriptors, primary descriptors already use absolute path
+                    and s.type != 'CWL_TEST_JSON' -- these use absolute paths already too
+                    and s.type != 'WDL_TEST_JSON' -- these use absolute paths already too
+                    and s.type != 'NEXTFLOW_CONFIG' -- these use absolute paths already too
+                    order by w.id
+                )
+                select concat_ws, id from workflow_paths
+                where path != concat_ws -- our calculations result in no change when these are secondary files with a primary at the root, so ignore them
+            ) as subquery WHERE subquery.id = s.id;
+        </sql>
+        <sql dbms="postgresql">
+            update sourcefile s set absolutepath = subquery.concat_ws FROM (
+                with tool_paths as (
+                    select t.giturl, t.mode, ta.cwlpath, ta.wdlpath, coalesce(nullif(ta.cwlpath,''), nullif(ta.wdlpath,'')) as toolpath, s.id, s.path, s.absolutepath, s.type from tool t, tool_tag tt, tag ta, version_sourcefile vs, sourcefile s where t.id = tt.toolid and tt.tagid = ta.id and ta.id = vs.versionid and  vs.sourcefileid = s.id
+                    and cwlpath != path -- ignore primary descriptors, primary descriptors already use absolute path
+                    and wdlpath != path
+                    and s.type != 'CWL_TEST_JSON' -- these use absolute paths already too
+                    and s.type != 'WDL_TEST_JSON' -- these use absolute paths already too
+                    and s.type != 'DOCKERFILE' -- these use absolute paths already too
+                    order by t.id
+                )
+                select id,concat_ws from (select *, CONCAT_WS('/', NULLIF(LEFT(toolpath, LENGTH (toolpath) - POSITION('/' in REVERSE(toolpath))),''), path) as concat_ws from tool_paths
+                ) p  where path != concat_ws -- our calculations result in no change when these are secondary files with a primary at the root, so ignore them
+            ) as subquery WHERE subquery.id = s.id;
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/readme.md
+++ b/dockstore-webservice/src/main/resources/readme.md
@@ -1,1 +1,1 @@
-This is the natively generated swagger2 which is also auto-converted to an openapi3 description. 
+This directory contains the natively generated swagger2 which is also auto-converted to an openapi3 description. 

--- a/openapi-java-client/pom.xml
+++ b/openapi-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>openapi-java-client</name>
 
     <parent>
-        <version>1.6.0-rc.2-SNAPSHOT</version>
+        <version>1.6.0-rc.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -289,7 +289,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/openapi-java-client/pom.xml
+++ b/openapi-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>openapi-java-client</name>
 
     <parent>
-        <version>1.6.0-rc.3</version>
+        <version>1.6.0-rc.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -289,7 +289,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/openapi-java-wes-client/pom.xml
+++ b/openapi-java-wes-client/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.6.0-rc.2-SNAPSHOT</version>
+        <version>1.6.0-rc.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/openapi-java-wes-client/pom.xml
+++ b/openapi-java-wes-client/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.6.0-rc.3</version>
+        <version>1.6.0-rc.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>io.dockstore</groupId>
     <artifactId>dockstore</artifactId>
-    <version>1.6.0-rc.3</version>
+    <version>1.6.0-rc.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>dockstore</name>
@@ -70,7 +70,7 @@
         <connection>${github.url}</connection>
         <developerConnection>${github.url}</developerConnection>
         <url>${github.url}</url>
-        <tag>1.6.0-rc.3</tag>
+        <tag>1.5.2</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>io.dockstore</groupId>
     <artifactId>dockstore</artifactId>
-    <version>1.6.0-rc.2-SNAPSHOT</version>
+    <version>1.6.0-rc.3</version>
     <packaging>pom</packaging>
 
     <name>dockstore</name>
@@ -70,7 +70,7 @@
         <connection>${github.url}</connection>
         <developerConnection>${github.url}</developerConnection>
         <url>${github.url}</url>
-        <tag>1.5.2</tag>
+        <tag>1.6.0-rc.3</tag>
     </scm>
 
     <repositories>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.6.0-rc.2-SNAPSHOT</version>
+        <version>1.6.0-rc.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -29,22 +29,22 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-client</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-integration-testing</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
         </dependency>
     </dependencies>
 

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.6.0-rc.3</version>
+        <version>1.6.0-rc.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -29,22 +29,22 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-client</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-integration-testing</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/swagger-java-bitbucket-client/pom.xml
+++ b/swagger-java-bitbucket-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.6.0-rc.2-SNAPSHOT</version>
+        <version>1.6.0-rc.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/swagger-java-bitbucket-client/pom.xml
+++ b/swagger-java-bitbucket-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.6.0-rc.3</version>
+        <version>1.6.0-rc.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/swagger-java-client/pom.xml
+++ b/swagger-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-client</name>
 
     <parent>
-        <version>1.6.0-rc.3</version>
+        <version>1.6.0-rc.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -265,7 +265,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.6.0-rc.3</version>
+            <version>1.6.0-rc.4-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/swagger-java-client/pom.xml
+++ b/swagger-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-client</name>
 
     <parent>
-        <version>1.6.0-rc.2-SNAPSHOT</version>
+        <version>1.6.0-rc.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -265,7 +265,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.6.0-rc.2-SNAPSHOT</version>
+            <version>1.6.0-rc.3</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/swagger-java-quay-client/pom.xml
+++ b/swagger-java-quay-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-quay-client</name>
 
     <parent>
-        <version>1.6.0-rc.3</version>
+        <version>1.6.0-rc.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-quay-client/pom.xml
+++ b/swagger-java-quay-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-quay-client</name>
 
     <parent>
-        <version>1.6.0-rc.2-SNAPSHOT</version>
+        <version>1.6.0-rc.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-sam-client/pom.xml
+++ b/swagger-java-sam-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.6.0-rc.2-SNAPSHOT</version>
+        <version>1.6.0-rc.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/swagger-java-sam-client/pom.xml
+++ b/swagger-java-sam-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.6.0-rc.3</version>
+        <version>1.6.0-rc.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
This provides a better guess for the absolute path than the current guess 
(previous migrations essentially assumed "/" + path)

This looks at the path to the primary descriptor, takes the directory containing it and appends the path to it. This results in having to do normalization on of the paths when using them since it can result in paths with `../' or `./` operations

Certain paths were ignored since primary descriptors, test parameters, and dockerfiles already stored absolute paths for their relative paths (!) 

You can get an idea what the migration is doing by taking out the subquery and selecting more