### PR TITLE
Improve UnitOfWork annotations

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
@@ -93,7 +93,7 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/collections/{alias}/aliases")
     @ApiOperation(nickname = "getCollectionByAlias", value = "Retrieves a collection by alias.", response = Collection.class)
     public Collection getCollectionByAlias(@ApiParam(value = "Alias", required = true) @PathParam("alias") String alias) {
@@ -102,7 +102,7 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("{organizationId}/collections/{collectionId}")
     @ApiOperation(value = "Retrieves a collection by ID.", notes = OPTIONAL_AUTH_MESSAGE, authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Collection.class)
     public Collection getCollectionById(@ApiParam(hidden = true) @Auth Optional<User> user,
@@ -125,7 +125,7 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("{organizationName}/collections/{collectionName}/name")
     @ApiOperation(value = "Retrieves a collection by ID.", notes = OPTIONAL_AUTH_MESSAGE, authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Collection.class)
     public Collection getCollectionByName(@ApiParam(hidden = true) @Auth Optional<User> user,
@@ -285,7 +285,7 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("{organizationId}/collections")
     @ApiOperation(value = "Retrieve all collections for an organization.", notes = OPTIONAL_AUTH_MESSAGE, authorizations = {
             @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, responseContainer = "List", response = Collection.class)
@@ -459,7 +459,7 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("{organizationId}/collections/{collectionId}/description")
     @ApiOperation(value = "Retrieves a collection description by organization ID and collection ID.", notes = OPTIONAL_AUTH_MESSAGE, authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = String.class)
     public String getCollectionDescription(@ApiParam(hidden = true) @Auth Optional<User> user,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoTagResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoTagResource.java
@@ -80,7 +80,7 @@ public class DockerRepoTagResource implements AuthenticatedResourceInterface {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/path/{containerId}/tags")
     @ApiOperation(value = "Get tags for a tool by id.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tag.class, responseContainer = "Set")
     public Set<Tag> getTagsByPath(@ApiParam(hidden = true) @Auth User user,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -82,7 +82,7 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
     @GET
     @Path("/{id}/collections")
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @ApiOperation(value = "Get the collections and organizations that contain the published entry", notes = "Entry must be published", response = CollectionOrganization.class, responseContainer = "List")
     public List<CollectionOrganization> entryCollections(@ApiParam(value = "id", required = true) @PathParam("id") Long id) {
         Entry<? extends Entry, ? extends Version> entry = toolDAO.getGenericEntryById(id);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -276,7 +277,6 @@ public class MetadataResource {
 
     @GET
     @Timed
-    @UnitOfWork
     @Path("/descriptorLanguageList")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get the list of descriptor languages supported on Dockstore", description = "Get the list of descriptor languages supported on Dockstore, NO authentication")
@@ -285,14 +285,13 @@ public class MetadataResource {
         array = @ArraySchema(schema = @Schema(implementation = DescriptorLanguage.DescriptorLanguageBean.class))))
     @ApiOperation(value = "Get the list of descriptor languages supported on Dockstore.", notes = "NO authentication", response = DescriptorLanguage.DescriptorLanguageBean.class, responseContainer = "List")
     public List<DescriptorLanguage.DescriptorLanguageBean> getDescriptorLanguages() {
-        List<DescriptorLanguage.DescriptorLanguageBean> descriptorLanguageList = new ArrayList<>();
-        Arrays.asList(DescriptorLanguage.values()).forEach(descriptorLanguage -> descriptorLanguageList.add(new DescriptorLanguage.DescriptorLanguageBean(descriptorLanguage)));
-        return descriptorLanguageList;
+        return new ArrayList<DescriptorLanguage>()
+                .stream().map((descriptorLanguage) -> new DescriptorLanguage.DescriptorLanguageBean(descriptorLanguage))
+                .collect(Collectors.toList());
     }
 
     @GET
     @Timed
-    @UnitOfWork
     @Path("/okHttpCachePerformance")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get measures of cache performance", description = "Get measures of cache performance, NO authentication")
@@ -306,11 +305,14 @@ public class MetadataResource {
 
     public static Map<String, String> extractCacheStatistics() {
         Cache cache = DockstoreWebserviceApplication.getCache();
-        Map<String, String> results = new HashMap<>();
-        results.put("requestCount", String.valueOf(cache.requestCount()));
-        results.put("networkCount", String.valueOf(cache.networkCount()));
-        results.put("hitCount", String.valueOf(cache.hitCount()));
-        results.put("maxSize", String.valueOf(cache.maxSize()) + " bytes");
+        Map<String, String> results = new HashMap<String, String>() {
+                {
+                    put("requestCount", String.valueOf(cache.requestCount()));
+                    put("networkCount", String.valueOf(cache.networkCount()));
+                    put("hitCount", String.valueOf(cache.hitCount()));
+                    put("maxSize", String.valueOf(cache.maxSize()) + " bytes");
+                }
+        };
         try {
             results.put("size", String.valueOf(cache.size()) + " bytes");
         } catch (IOException e) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -21,13 +21,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -252,9 +252,9 @@ public class MetadataResource {
         array = @ArraySchema(schema = @Schema(implementation = SourceControl.SourceControlBean.class))))
     @ApiOperation(value = "Get the list of source controls supported on Dockstore.", notes = "NO authentication", response = SourceControl.SourceControlBean.class, responseContainer = "List")
     public List<SourceControl.SourceControlBean> getSourceControlList() {
-        return new ArrayList<SourceControl>().stream()
-                .map(repo -> new SourceControl.SourceControlBean(repo))
-                .collect(Collectors.toList());
+        List<SourceControl.SourceControlBean> sourceControlList = new ArrayList<>();
+        Arrays.asList(SourceControl.values()).forEach(sourceControl -> sourceControlList.add(new SourceControl.SourceControlBean(sourceControl)));
+        return sourceControlList;
     }
 
     @GET
@@ -267,9 +267,9 @@ public class MetadataResource {
         array = @ArraySchema(schema = @Schema(implementation = Registry.RegistryBean.class))))
     @ApiOperation(value = "Get the list of docker registries supported on Dockstore.", notes = "NO authentication", response = Registry.RegistryBean.class, responseContainer = "List")
     public List<Registry.RegistryBean> getDockerRegistries() {
-        return new ArrayList<Registry>().stream()
-                .map(registry -> new Registry.RegistryBean(registry))
-                .collect(Collectors.toList());
+        List<Registry.RegistryBean> registryList = new ArrayList<>();
+        Arrays.asList(Registry.values()).forEach(registry -> registryList.add(new Registry.RegistryBean(registry)));
+        return registryList;
     }
 
     @GET
@@ -282,9 +282,9 @@ public class MetadataResource {
         array = @ArraySchema(schema = @Schema(implementation = DescriptorLanguage.DescriptorLanguageBean.class))))
     @ApiOperation(value = "Get the list of descriptor languages supported on Dockstore.", notes = "NO authentication", response = DescriptorLanguage.DescriptorLanguageBean.class, responseContainer = "List")
     public List<DescriptorLanguage.DescriptorLanguageBean> getDescriptorLanguages() {
-        return new ArrayList<DescriptorLanguage>()
-                .stream().map((descriptorLanguage) -> new DescriptorLanguage.DescriptorLanguageBean(descriptorLanguage))
-                .collect(Collectors.toList());
+        List<DescriptorLanguage.DescriptorLanguageBean> descriptorLanguageList = new ArrayList<>();
+        Arrays.asList(DescriptorLanguage.values()).forEach(descriptorLanguage -> descriptorLanguageList.add(new DescriptorLanguage.DescriptorLanguageBean(descriptorLanguage)));
+        return descriptorLanguageList;
     }
 
     @GET

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -302,14 +302,12 @@ public class MetadataResource {
 
     public static Map<String, String> extractCacheStatistics() {
         Cache cache = DockstoreWebserviceApplication.getCache();
-        Map<String, String> results = new HashMap<String, String>() {
-                {
-                    put("requestCount", String.valueOf(cache.requestCount()));
-                    put("networkCount", String.valueOf(cache.networkCount()));
-                    put("hitCount", String.valueOf(cache.hitCount()));
-                    put("maxSize", String.valueOf(cache.maxSize()) + " bytes");
-                }
-        };
+        Map<String, String> results = new HashMap<>();
+        results.put("requestCount", String.valueOf(cache.requestCount()));
+        results.put("networkCount", String.valueOf(cache.networkCount()));
+        results.put("hitCount", String.valueOf(cache.hitCount()));
+        results.put("maxSize", String.valueOf(cache.maxSize()) + " bytes");
+
         try {
             results.put("size", String.valueOf(cache.size()) + " bytes");
         } catch (IOException e) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -108,7 +107,7 @@ public class MetadataResource {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("sitemap")
     @Operation(summary = "List all published workflow and tool paths", description = "List all published workflow and tool paths, NO authentication")
     @ApiOperation(value = "List all published workflow and tool paths.", notes = "NO authentication")
@@ -140,7 +139,7 @@ public class MetadataResource {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("rss")
     @Produces(MediaType.TEXT_XML)
     @Operation(summary = "List all published tools and workflows in creation order", description = "List all published tools and workflows in creation order, NO authentication")
@@ -245,7 +244,6 @@ public class MetadataResource {
 
     @GET
     @Timed
-    @UnitOfWork
     @Path("/sourceControlList")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get the list of source controls supported on Dockstore", description = "Get the list of source controls supported on Dockstore, NO authentication")
@@ -254,14 +252,13 @@ public class MetadataResource {
         array = @ArraySchema(schema = @Schema(implementation = SourceControl.SourceControlBean.class))))
     @ApiOperation(value = "Get the list of source controls supported on Dockstore.", notes = "NO authentication", response = SourceControl.SourceControlBean.class, responseContainer = "List")
     public List<SourceControl.SourceControlBean> getSourceControlList() {
-        List<SourceControl.SourceControlBean> sourceControlList = new ArrayList<>();
-        Arrays.asList(SourceControl.values()).forEach(sourceControl -> sourceControlList.add(new SourceControl.SourceControlBean(sourceControl)));
-        return sourceControlList;
+        return new ArrayList<SourceControl>().stream()
+                .map(repo -> new SourceControl.SourceControlBean(repo))
+                .collect(Collectors.toList());
     }
 
     @GET
     @Timed
-    @UnitOfWork
     @Path("/dockerRegistryList")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get the list of docker registries supported on Dockstore", description = "Get the list of docker registries supported on Dockstore, NO authentication")
@@ -270,9 +267,9 @@ public class MetadataResource {
         array = @ArraySchema(schema = @Schema(implementation = Registry.RegistryBean.class))))
     @ApiOperation(value = "Get the list of docker registries supported on Dockstore.", notes = "NO authentication", response = Registry.RegistryBean.class, responseContainer = "List")
     public List<Registry.RegistryBean> getDockerRegistries() {
-        List<Registry.RegistryBean> registryList = new ArrayList<>();
-        Arrays.asList(Registry.values()).forEach(registry -> registryList.add(new Registry.RegistryBean(registry)));
-        return registryList;
+        return new ArrayList<Registry>().stream()
+                .map(registry -> new Registry.RegistryBean(registry))
+                .collect(Collectors.toList());
     }
 
     @GET

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
@@ -77,7 +77,7 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @ApiOperation(value = "List all available organizations.", notes = "NO Authentication", responseContainer = "List", response = Organization.class)
     public List<Organization> getApprovedOrganizations() {
         return organizationDAO.findAllApproved();
@@ -166,7 +166,7 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/name/{name}/")
     @ApiOperation(value = "Retrieves an organization by name.", notes = OPTIONAL_AUTH_MESSAGE, authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Organization.class)
@@ -211,7 +211,7 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{organizationId}")
     @ApiOperation(value = "Retrieves an organization by ID.", notes = OPTIONAL_AUTH_MESSAGE, authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Organization.class)
@@ -222,7 +222,7 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{organizationId}/description")
     @ApiOperation(value = "Retrieves an organization description by organization ID.", notes = OPTIONAL_AUTH_MESSAGE, authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = String.class)
@@ -270,7 +270,7 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{organizationId}/members")
     @ApiOperation(value = "Retrieves all members for an organization.", notes = OPTIONAL_AUTH_MESSAGE, authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = OrganizationUser.class, responseContainer = "Set")
@@ -281,7 +281,7 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{organizationId}/events")
     @ApiOperation(value = "Retrieves all events for an organization.", notes = OPTIONAL_AUTH_MESSAGE, authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Event.class, responseContainer = "List")
@@ -328,7 +328,7 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/all")
     @RolesAllowed({ "curator", "admin" })
     @ApiOperation(value = "List all organizations.", authorizations = {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -140,7 +140,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     @GET
     @Path("/{tokenId}")
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @ApiOperation(value = "Get a specific token by id.", authorizations = {
             @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Token.class)
     @ApiResponses({ @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = "Invalid ID supplied"),
@@ -411,7 +411,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     @UnitOfWork
     @Path("/github")
     @ApiOperation(value = "Allow satellizer to post a new GitHub token to dockstore, used by login, can create new users.", authorizations = {
-        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "A post method is required by saetillizer to send the GitHub token", response = Token.class)
+        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "A post method is required by satellizer to send the GitHub token", response = Token.class)
     public Token addToken(@ApiParam("code") String satellizerJson) {
         Gson gson = new Gson();
         JsonElement element = gson.fromJson(satellizerJson, JsonElement.class);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -109,7 +109,7 @@ public class UserResource implements AuthenticatedResourceInterface {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/username/{username}")
     @ApiOperation(value = "Get a user by username.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
     public User listUser(@ApiParam(hidden = true) @Auth User authUser,
@@ -122,7 +122,7 @@ public class UserResource implements AuthenticatedResourceInterface {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{userId}")
     @ApiOperation(value = "Get user by id.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
     public User getUser(@ApiParam(hidden = true) @Auth User authUser, @ApiParam("User to return") @PathParam("userId") long userId) {
@@ -136,7 +136,7 @@ public class UserResource implements AuthenticatedResourceInterface {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/user")
     @ApiOperation(value = "Get the logged-in user.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
     public User getUser(@ApiParam(hidden = true) @Auth User user) {
@@ -147,7 +147,7 @@ public class UserResource implements AuthenticatedResourceInterface {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/user/memberships")
     @ApiOperation(value = "Get the logged-in users memberships.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = OrganizationUser.class, responseContainer = "set")
     public Set<OrganizationUser> getUserMemberships(@ApiParam(hidden = true) @Auth User user) {
@@ -161,7 +161,7 @@ public class UserResource implements AuthenticatedResourceInterface {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/user/extended")
     @ApiOperation(value = "Get additional information about the logged-in user.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = ExtendedUserData.class)
     public ExtendedUserData getExtendedUserData(@ApiParam(hidden = true) @Auth User user) {
@@ -245,7 +245,7 @@ public class UserResource implements AuthenticatedResourceInterface {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/checkUser/{username}")
     @ApiOperation(value = "Check if user with some username exists.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Boolean.class)
     public boolean checkUserExists(@ApiParam(hidden = true) @Auth User user,
@@ -257,7 +257,7 @@ public class UserResource implements AuthenticatedResourceInterface {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{userId}/tokens")
     @ApiOperation(value = "Get tokens with user id.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Token.class, responseContainer = "List")
     public List<Token> getUserTokens(@ApiParam(hidden = true) @Auth User user,
@@ -268,7 +268,7 @@ public class UserResource implements AuthenticatedResourceInterface {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{userId}/tokens/github.com")
     @ApiOperation(value = "Get Github tokens with user id.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Token.class, responseContainer = "List")
     public List<Token> getGithubUserTokens(@ApiParam(hidden = true) @Auth User user,
@@ -279,7 +279,7 @@ public class UserResource implements AuthenticatedResourceInterface {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{userId}/tokens/gitlab.com")
     @ApiOperation(value = "Get Gitlab tokens with user id.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Token.class, responseContainer = "List")
     public List<Token> getGitlabUserTokens(@ApiParam(hidden = true) @Auth User user,
@@ -290,7 +290,7 @@ public class UserResource implements AuthenticatedResourceInterface {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{userId}/tokens/quay.io")
     @ApiOperation(value = "Get Quay tokens with user id.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Token.class, responseContainer = "List")
     public List<Token> getQuayUserTokens(@ApiParam(hidden = true) @Auth User user,
@@ -301,7 +301,7 @@ public class UserResource implements AuthenticatedResourceInterface {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{userId}/tokens/dockstore")
     @ApiOperation(value = "Get Dockstore tokens with user id.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Token.class, responseContainer = "List")
     public List<Token> getDockstoreUserTokens(@ApiParam(hidden = true) @Auth User user,
@@ -312,7 +312,7 @@ public class UserResource implements AuthenticatedResourceInterface {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{userId}/containers/published")
     @ApiOperation(value = "List all published tools from a user.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tool.class, responseContainer = "List")
     public List<Tool> userPublishedContainers(@ApiParam(hidden = true) @Auth User user,
@@ -330,7 +330,7 @@ public class UserResource implements AuthenticatedResourceInterface {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{userId}/workflows/published")
     @ApiOperation(value = "List all published workflows from a user.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class, responseContainer = "List")
     public List<Workflow> userPublishedWorkflows(@ApiParam(hidden = true) @Auth User user,
@@ -485,7 +485,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     @GET
     @Path("/{userId}/workflows")
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @ApiOperation(value = "List all workflows owned by the logged-in user.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class, responseContainer = "List")
     public List<Workflow> userWorkflows(@ApiParam(hidden = true) @Auth User user,
             @ApiParam(value = "User ID", required = true) @PathParam("userId") Long userId) {
@@ -507,7 +507,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     @GET
     @Path("/{userId}/containers")
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @ApiOperation(value = "List all tools owned by the logged-in user.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tool.class, responseContainer = "List")
     public List<Tool> userContainers(@ApiParam(hidden = true) @Auth User user,
             @ApiParam(value = "User ID", required = true) @PathParam("userId") Long userId) {
@@ -520,7 +520,7 @@ public class UserResource implements AuthenticatedResourceInterface {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/starredTools")
     @ApiOperation(value = "Get the logged-in user's starred tools.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Entry.class, responseContainer = "List")
     public Set<Entry> getStarredTools(@ApiParam(hidden = true) @Auth User user) {
@@ -531,7 +531,7 @@ public class UserResource implements AuthenticatedResourceInterface {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/starredWorkflows")
     @ApiOperation(value = "Get the logged-in user's starred workflows.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Entry.class, responseContainer = "List")
     public Set<Entry> getStarredWorkflows(@ApiParam(hidden = true) @Auth User user) {
@@ -577,7 +577,7 @@ public class UserResource implements AuthenticatedResourceInterface {
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @RolesAllowed({"admin", "curator"})
     @Path("/user/{userId}/limits")
     @ApiOperation(value = "Returns the specified user's limits. ADMIN or CURATOR only", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Limits.class)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -644,7 +644,7 @@ public class WorkflowResource
             if (!version.isDirtyBit()) {
                 version.setWorkflowPath(workflow.getDefaultWorkflowPath());
             }
-        }https://www.javatpoint.com/java-enummap
+        }
         elasticManager.handleIndexUpdate(wf, ElasticMode.UPDATE);
         return wf;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -454,7 +454,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{workflowId}")
     @ApiOperation(value = "Retrieve a workflow", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class, notes = "This is one of the few endpoints that returns the user object with populated properties (minus the userProfiles property)")
@@ -644,14 +644,14 @@ public class WorkflowResource
             if (!version.isDirtyBit()) {
                 version.setWorkflowPath(workflow.getDefaultWorkflowPath());
             }
-        }
+        }https://www.javatpoint.com/java-enummap
         elasticManager.handleIndexUpdate(wf, ElasticMode.UPDATE);
         return wf;
     }
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{workflowId}/users")
     @ApiOperation(value = "Get users of a workflow.", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class, responseContainer = "List")
@@ -667,7 +667,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/published/{workflowId}")
     @ApiOperation(value = "Get a published workflow.", notes = "Hidden versions will not be visible. NO authentication", response = Workflow.class)
     public Workflow getPublishedWorkflow(@ApiParam(value = "Workflow ID", required = true) @PathParam("workflowId") Long workflowId, @ApiParam(value = "Comma-delimited list of fields to include: validations") @QueryParam("include") String include) {
@@ -679,7 +679,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/organization/{organization}/published")
     @ApiOperation(value = "List all published workflows of an organization.", notes = "NO authentication", response = Workflow.class, responseContainer = "List")
     public List<Workflow> getPublishedWorkflowsByOrganization(
@@ -742,7 +742,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("published")
     @ApiOperation(value = "List all published workflows.", tags = {
         "workflows" }, notes = "NO authentication", response = Workflow.class, responseContainer = "List")
@@ -766,7 +766,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("shared")
     @ApiOperation(value = "Retrieve all workflows shared with user.", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, tags = {
@@ -795,7 +795,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/path/workflow/{repository}")
     @ApiOperation(value = "Get a workflow by path.", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Requires full path (including workflow name if applicable).", response = Workflow.class)
@@ -864,7 +864,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/path/workflow/{repository}/permissions")
     @ApiOperation(value = "Get all permissions for a workflow.", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "The user must be the workflow owner.", response = Permission.class, responseContainer = "List")
@@ -877,7 +877,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/path/workflow/{repository}/actions")
     @ApiOperation(value = "Gets all actions a user can perform on a workflow.", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Role.Action.class, responseContainer = "List")
@@ -924,7 +924,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/path/entry/{repository}")
     @ApiOperation(value = "Get an entry by path.", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Requires full path (including entry name if applicable).", response = Entry.class)
@@ -945,7 +945,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/path/entry/{repository}/published")
     @ApiOperation(value = "Get a published entry by path.", notes = "Requires full path (including entry name if applicable).", response = Entry.class)
     public Entry getPublishedEntryByPath(@ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
@@ -961,7 +961,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/path/{repository}")
     @ApiOperation(value = "Get a list of workflows by path.", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Does not require workflow name.", response = Workflow.class, responseContainer = "List")
@@ -975,7 +975,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/path/workflow/{repository}/published")
     @ApiOperation(value = "Get a published workflow by path", notes = "Does not require workflow name.", response = Workflow.class)
     public Workflow getPublishedWorkflowByPath(@ApiParam(value = "repository path", required = true) @PathParam("repository") String path, @ApiParam(value = "Comma-delimited list of fields to include: validations") @QueryParam("include") String include) {
@@ -989,7 +989,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/versions")
     @ApiOperation(value = "List the versions for a published workflow.", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = WorkflowVersion.class, responseContainer = "List", hidden = true)
@@ -1001,7 +1001,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{workflowId}/verifiedSources")
     @ApiOperation(value = "Get a semicolon delimited list of verified sources.", tags = {
         "workflows" }, notes = "NO authentication", response = String.class)
@@ -1038,7 +1038,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{workflowId}/wdl")
     @ApiOperation(value = "Get the primary WDL descriptor file on Github.", tags = {
         "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, authorizations = {
@@ -1050,7 +1050,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{workflowId}/nextflow")
     @ApiOperation(value = "Get the nextflow.config file on Github.", tags = {
         "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, authorizations = {
@@ -1062,7 +1062,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{workflowId}/cwl/{relative-path}")
     @ApiOperation(value = "Get the corresponding CWL descriptor file on Github.", tags = {
         "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, authorizations = {
@@ -1075,7 +1075,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{workflowId}/wdl/{relative-path}")
     @ApiOperation(value = "Get the corresponding WDL descriptor file on Github.", tags = {
         "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, authorizations = {
@@ -1088,7 +1088,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{workflowId}/nextflow/{relative-path}")
     @ApiOperation(value = "Get the corresponding nextflow documents on Github.", tags = {
         "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, authorizations = {
@@ -1102,7 +1102,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{workflowId}/secondaryCwl")
     @ApiOperation(value = "Get the corresponding cwl documents on Github.", tags = {
         "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List", authorizations = {
@@ -1114,7 +1114,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{workflowId}/secondaryWdl")
     @ApiOperation(value = "Get the corresponding wdl documents on Github.", tags = {
         "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List", authorizations = {
@@ -1126,7 +1126,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{workflowId}/secondaryNextflow")
     @ApiOperation(value = "Get the corresponding Nextflow documents on Github.", tags = {
         "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List", authorizations = {
@@ -1138,7 +1138,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{workflowId}/testParameterFiles")
     @ApiOperation(value = "Get the corresponding test parameter files.", tags = {
         "workflows" }, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List", authorizations = {
@@ -1370,7 +1370,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{workflowId}/dag/{workflowVersionId}")
     @ApiOperation(value = "Get the DAG for a given workflow version.", response = String.class, notes = OPTIONAL_AUTH_MESSAGE, authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
@@ -1403,7 +1403,7 @@ public class WorkflowResource
      */
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{workflowId}/tools/{workflowVersionId}")
     @ApiOperation(value = "Get the Tools for a given workflow version.", notes = OPTIONAL_AUTH_MESSAGE, response = String.class, authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
@@ -1516,7 +1516,7 @@ public class WorkflowResource
     @GET
     @Path("/{workflowId}/starredUsers")
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @ApiOperation(value = "Returns list of users who starred the given workflow.", response = User.class, responseContainer = "List")
     public Set<User> getStarredUsers(
         @ApiParam(value = "Workflow to grab starred users for.", required = true) @PathParam("workflowId") Long workflowId) {
@@ -1702,7 +1702,7 @@ public class WorkflowResource
 
     @GET
     @Timed
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Path("/{workflowId}/zip/{workflowVersionId}")
     @ApiOperation(value = "Download a ZIP file of a workflow and all associated files.", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsExtendedApi.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsExtendedApi.java
@@ -58,7 +58,7 @@ public class ToolsExtendedApi {
 
     @GET
     @Path("/tools/{organization}")
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Produces({ "application/json", "text/plain" })
     @ApiOperation(value = "List tools of an organization", notes = "This endpoint returns tools of an organization. ", response = ToolV1.class, responseContainer = "List")
     @ApiResponses(value = {
@@ -71,7 +71,6 @@ public class ToolsExtendedApi {
 
     @POST
     @Path("/tools/entry/_search")
-    @UnitOfWork
     @Produces({ "application/json" })
     @ApiOperation(value = "Search the index of tools", notes = "This endpoint searches the index for all published tools and workflows. Used by utilities that expect to talk to an elastic search endpoint", response = String.class)
     @ApiResponses(value = { @ApiResponse(code = HttpStatus.SC_OK, message = "An elastic search result.", response = String.class) })
@@ -95,7 +94,7 @@ public class ToolsExtendedApi {
 
     @GET
     @Path("/workflows/{organization}")
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Produces({ "application/json", "text/plain" })
     @ApiOperation(value = "List workflows of an organization", notes = "This endpoint returns workflows of an organization. ", response = ToolV1.class, responseContainer = "List")
     @ApiResponses(value = {
@@ -108,7 +107,7 @@ public class ToolsExtendedApi {
 
     @GET
     @Path("/containers/{organization}")
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Produces({ "application/json", "text/plain" })
     @ApiOperation(value = "List entries of an organization", notes = "This endpoint returns entries of an organization. ", response = ToolV1.class, responseContainer = "List")
     @ApiResponses(value = {
@@ -121,7 +120,7 @@ public class ToolsExtendedApi {
 
     @GET
     @Path("/organizations")
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Produces({ "application/json", "text/plain" })
     @ApiOperation(value = "List all organizations", notes = "This endpoint returns list of all organizations. ", response = String.class, responseContainer = "List")
     @ApiResponses(value = {

--- a/dockstore-webservice/src/main/java/io/swagger/api/MetadataApiV1.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/MetadataApiV1.java
@@ -40,7 +40,6 @@ public class MetadataApiV1 {
     private final MetadataApiService delegate = MetadataApiServiceFactory.getMetadataApi();
 
     @GET
-    @UnitOfWork
     @Produces( { "application/json", "text/plain" })
     @io.swagger.annotations.ApiOperation(value = "Return some metadata that is useful for describing this registry", notes = "Return some metadata that is useful for describing this registry", response = MetadataV1.class, tags = {
         "GA4GHV1", })

--- a/dockstore-webservice/src/main/java/io/swagger/api/ToolClassesApiV1.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/ToolClassesApiV1.java
@@ -39,7 +39,7 @@ public class ToolClassesApiV1 {
     private final ToolClassesApiService delegate = ToolClassesApiServiceFactory.getToolClassesApi();
 
     @GET
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Produces( { "application/json", "text/plain" })
     @io.swagger.annotations.ApiOperation(value = "List all tool types", notes = "This endpoint returns all tool-classes available ", response = ToolClass.class, responseContainer = "List", tags = {
         "GA4GHV1", })

--- a/dockstore-webservice/src/main/java/io/swagger/api/ToolsApiV1.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/ToolsApiV1.java
@@ -47,7 +47,7 @@ public class ToolsApiV1 {
     private final ToolsApiService delegate = ToolsApiServiceFactory.getToolsApi();
 
     @GET
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Produces( { "application/json", "text/plain" })
     @io.swagger.annotations.ApiOperation(value = "List all tools", notes = "This endpoint returns all tools available or a filtered subset using metadata query parameters. ", response = ToolV1.class, responseContainer = "List", tags = {
         "GA4GHV1", })
@@ -70,7 +70,7 @@ public class ToolsApiV1 {
 
     @GET
     @Path("/{id}")
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Produces( { "application/json", "text/plain" })
     @io.swagger.annotations.ApiOperation(value = "List one specific tool, acts as an anchor for self references", notes = "This endpoint returns one specific tool (which has ToolVersions nested inside it)", response = ToolV1.class, tags = {
         "GA4GHV1", })
@@ -84,7 +84,7 @@ public class ToolsApiV1 {
 
     @GET
     @Path("/{id}/versions")
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Produces( { "application/json", "text/plain" })
     @io.swagger.annotations.ApiOperation(value = "List versions of a tool", notes = "Returns all versions of the specified tool", response = ToolVersionV1.class, responseContainer = "List", tags = {
         "GA4GHV1", })
@@ -99,7 +99,7 @@ public class ToolsApiV1 {
 
     @GET
     @Path("/{id}/versions/{version_id}/dockerfile")
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Produces( { "application/json", "text/plain" })
     @io.swagger.annotations.ApiOperation(value = "Get the dockerfile for the specified image.", notes = "Returns the dockerfile for the specified image.", response = ToolDockerfile.class, tags = {
         "GA4GHV1", })
@@ -116,7 +116,7 @@ public class ToolsApiV1 {
 
     @GET
     @Path("/{id}/versions/{version_id}")
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Produces( { "application/json", "text/plain" })
     @io.swagger.annotations.ApiOperation(value = "List one specific tool version, acts as an anchor for self references", notes = "This endpoint returns one specific tool version", response = ToolVersionV1.class, tags = {
         "GA4GHV1", })
@@ -131,7 +131,7 @@ public class ToolsApiV1 {
 
     @GET
     @Path("/{id}/versions/{version_id}/{type}/descriptor")
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Produces( { "application/json", "text/plain" })
     @io.swagger.annotations.ApiOperation(value = "Get the tool descriptor (CWL/WDL) for the specified tool.", notes = "Returns the CWL or WDL descriptor for the specified tool.", response = ToolDescriptor.class, tags = {
         "GA4GHV1", })
@@ -150,7 +150,7 @@ public class ToolsApiV1 {
 
     @GET
     @Path("/{id}/versions/{version_id}/{type}/descriptor/{relative_path}")
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Produces( { "application/json", "text/plain" })
     @io.swagger.annotations.ApiOperation(value = "Get additional tool descriptor files (CWL/WDL) relative to the main file", notes = "Returns additional CWL or WDL descriptors for the specified tool in the same or subdirectories", response = ToolDescriptor.class, tags = {
         "GA4GHV1", })
@@ -170,7 +170,7 @@ public class ToolsApiV1 {
 
     @GET
     @Path("/{id}/versions/{version_id}/{type}/tests")
-    @UnitOfWork
+    @UnitOfWork(readOnly = true)
     @Produces( { "application/json", "text/plain" })
     @io.swagger.annotations.ApiOperation(value = "Get an array of test JSONs suitable for use with this descriptor type.", notes = "", response = ToolTestsV1.class, responseContainer = "List", tags = {
         "GA4GHV1", })


### PR DESCRIPTION
This PR adds `readOnly` to appropriate annotations that don't perform a write action and removes hibernate annotations from code that didn't require it.

https://www.dropwizard.io/0.6.2/maven/dropwizard-hibernate/apidocs/com/yammer/dropwizard/hibernate/UnitOfWork.html