### PR TITLE
Fix parameters for Arvados endpoint

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WESLauncher.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WESLauncher.java
@@ -23,7 +23,7 @@ import static io.dockstore.client.cli.Client.IO_ERROR;
 
 public class WESLauncher extends BaseLauncher {
     private static final Logger LOG = LoggerFactory.getLogger(WESLauncher.class);
-    private static final String TAGS = "WorkflowExecutionService";
+    private static final String TAGS = "{\"Client\":\"Dockstore\"}";
     private static final String WORKFLOW_TYPE_VERSION = "1.0";
 
     protected List<String> command;
@@ -139,7 +139,7 @@ public class WESLauncher extends BaseLauncher {
 
         try {
             RunId response = clientWorkflowExecutionServiceApi.runWorkflow(jsonInputFile, languageType, workflowTypeVersion, TAGS,
-                    "", workflowURL, workflowAttachment);
+                    "{}", workflowURL, workflowAttachment);
             System.out.println("Launched WES run with id: " + response.toString());
         } catch (io.openapi.wes.client.ApiException e) {
             LOG.error("Error launching WES run", e);


### PR DESCRIPTION
Change 'tags' and 'workflow_engine_parameter' so request to Arvados endpoint to run a workflow is correct.