### PR TITLE
Feature/2135/script between tests

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -653,17 +653,13 @@ public class Client {
                 .getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
         if (flag(args, "--debug") || flag(args, "--d")) {
             DEBUG.set(true);
-            INFO.set(false);
             // turn on logback
             root.setLevel(Level.DEBUG);
         } else if (flag(args, "--info") || flag(args, "--i")) {
             INFO.set(true);
-            DEBUG.set(false);
             // turn on logback
             root.setLevel(Level.INFO);
         } else {
-            INFO.set(false);
-            DEBUG.set(false);
             root.setLevel(Level.ERROR);
         }
         if (flag(args, "--script") || flag(args, "--s")) {

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -653,17 +653,23 @@ public class Client {
                 .getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
         if (flag(args, "--debug") || flag(args, "--d")) {
             DEBUG.set(true);
+            INFO.set(false);
             // turn on logback
             root.setLevel(Level.DEBUG);
         } else if (flag(args, "--info") || flag(args, "--i")) {
             INFO.set(true);
+            DEBUG.set(false);
             // turn on logback
             root.setLevel(Level.INFO);
         } else {
+            INFO.set(false);
+            DEBUG.set(false);
             root.setLevel(Level.ERROR);
         }
         if (flag(args, "--script") || flag(args, "--s")) {
             SCRIPT.set(true);
+        } else {
+            SCRIPT.set(false);
         }
 
         try {

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
@@ -170,6 +170,7 @@ public class LaunchTestIT {
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
         client.setConfigFile(ResourceHelpers.resourceFilePath("config.withTestPlugin"));
+        client.SCRIPT.set(true);
 
         PluginClient.handleCommand(Lists.newArrayList("download"), Utilities.parseConfig(client.getConfigFile()));
 
@@ -306,6 +307,7 @@ public class LaunchTestIT {
         ContainersApi api = mock(ContainersApi.class);
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
+        client.SCRIPT.set(true);
         // do not use a cache
         runToolThreaded(cwlFile, args, api, usersApi, client);
     }
@@ -728,6 +730,7 @@ public class LaunchTestIT {
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
         client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
+        client.SCRIPT.set(true);
 
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
         workflowClient.checkEntryFile(file.getAbsolutePath(), args, CWL_STRING);
@@ -913,7 +916,7 @@ public class LaunchTestIT {
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
         client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
-
+        client.SCRIPT.set(true);
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
         workflowClient.checkEntryFile(file.getAbsolutePath(), args, null);
 

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
@@ -646,6 +646,7 @@ public class LaunchTestIT {
 
         args.add(0, ResourceHelpers.resourceFilePath(useCache ? "config.withCache" : "config"));
         args.add(0, "--config");
+        Client.SCRIPT.set(true);
         Client.main(args.toArray(new String[0]));
     }
 
@@ -653,6 +654,7 @@ public class LaunchTestIT {
         //used to run client with a specified config file
         args.add(0, config.getPath());
         args.add(0, "--config");
+        Client.SCRIPT.set(true);
         Client.main(args.toArray(new String[0]));
     }
 

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
@@ -100,6 +100,7 @@ public class LaunchTestIT {
         WorkflowsApi api = mock(WorkflowsApi.class);
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
+        client.SCRIPT.set(true);
         client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
 
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
@@ -145,6 +146,7 @@ public class LaunchTestIT {
         WorkflowsApi api = mock(WorkflowsApi.class);
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
+        client.SCRIPT.set(true);
         client.setConfigFile(ResourceHelpers.resourceFilePath("config.withTestPlugin"));
 
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
@@ -169,8 +171,8 @@ public class LaunchTestIT {
         WorkflowsApi api = mock(WorkflowsApi.class);
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
-        client.setConfigFile(ResourceHelpers.resourceFilePath("config.withTestPlugin"));
         client.SCRIPT.set(true);
+        client.setConfigFile(ResourceHelpers.resourceFilePath("config.withTestPlugin"));
 
         PluginClient.handleCommand(Lists.newArrayList("download"), Utilities.parseConfig(client.getConfigFile()));
 
@@ -244,6 +246,7 @@ public class LaunchTestIT {
     private ArrayList<String> getLaunchStringList(String entryType) {
         File descriptorFile = new File(ResourceHelpers.resourceFilePath("hello.wdl"));
             return new ArrayList<String>() {{
+                add("--script");
                 add("--config");
                 add(ResourceHelpers.resourceFilePath("config"));
                 add(entryType);
@@ -307,7 +310,6 @@ public class LaunchTestIT {
         ContainersApi api = mock(ContainersApi.class);
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
-        client.SCRIPT.set(true);
         // do not use a cache
         runToolThreaded(cwlFile, args, api, usersApi, client);
     }
@@ -646,7 +648,7 @@ public class LaunchTestIT {
 
         args.add(0, ResourceHelpers.resourceFilePath(useCache ? "config.withCache" : "config"));
         args.add(0, "--config");
-        Client.SCRIPT.set(true);
+        args.add(0, "--script");
         Client.main(args.toArray(new String[0]));
     }
 
@@ -654,11 +656,12 @@ public class LaunchTestIT {
         //used to run client with a specified config file
         args.add(0, config.getPath());
         args.add(0, "--config");
-        Client.SCRIPT.set(true);
+        args.add(0, "--script");
         Client.main(args.toArray(new String[0]));
     }
 
     private void runToolThreaded(File cwlFile, ArrayList<String> args, ContainersApi api, UsersApi usersApi, Client client) {
+        client.SCRIPT.set(true);
         client.setConfigFile(ResourceHelpers.resourceFilePath("config.withThreads"));
 
         runToolShared(cwlFile, args, api, usersApi, client);
@@ -758,6 +761,7 @@ public class LaunchTestIT {
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
         client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
+        client.SCRIPT.set(true);
 
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
         workflowClient.checkEntryFile(file.getAbsolutePath(), args, null);
@@ -782,6 +786,7 @@ public class LaunchTestIT {
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
         client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
+        client.SCRIPT.set(true);
 
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
         workflowClient.checkEntryFile(file.getAbsolutePath(), args, null);
@@ -806,6 +811,7 @@ public class LaunchTestIT {
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
         client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
+        client.SCRIPT.set(true);
 
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
         workflowClient.checkEntryFile(file.getAbsolutePath(), args, null);
@@ -835,6 +841,7 @@ public class LaunchTestIT {
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
         client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
+        client.SCRIPT.set(true);
 
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
         workflowClient.checkEntryFile(file.getAbsolutePath(), args, WDL_STRING);
@@ -864,6 +871,7 @@ public class LaunchTestIT {
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
         client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
+        client.SCRIPT.set(true);
 
         exit.expectSystemExit();
 
@@ -892,6 +900,7 @@ public class LaunchTestIT {
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
         client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
+        client.SCRIPT.set(true);
 
         exit.expectSystemExit();
 
@@ -945,6 +954,7 @@ public class LaunchTestIT {
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
         client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
+        client.SCRIPT.set(true);
 
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
         workflowClient.checkEntryFile(file.getAbsolutePath(), args, null);
@@ -973,6 +983,7 @@ public class LaunchTestIT {
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
         client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
+        client.SCRIPT.set(true);
 
         exit.expectSystemExit();
         exit.checkAssertionAfterwards(
@@ -1000,6 +1011,7 @@ public class LaunchTestIT {
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
         client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
+        client.SCRIPT.set(true);
 
         exit.expectSystemExit();
         exit.checkAssertionAfterwards(
@@ -1027,6 +1039,7 @@ public class LaunchTestIT {
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
         client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
+        client.SCRIPT.set(true);
 
         exit.expectSystemExit();
         exit.checkAssertionAfterwards(
@@ -1054,6 +1067,7 @@ public class LaunchTestIT {
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
         client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
+        client.SCRIPT.set(true);
 
         exit.expectSystemExit();
         exit.checkAssertionAfterwards(
@@ -1081,6 +1095,7 @@ public class LaunchTestIT {
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
         client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
+        client.SCRIPT.set(true);
 
         exit.expectSystemExit();
         exit.checkAssertionAfterwards(
@@ -1108,6 +1123,7 @@ public class LaunchTestIT {
         UsersApi usersApi = mock(UsersApi.class);
         Client client = new Client();
         client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
+        client.SCRIPT.set(true);
 
         exit.expectSystemExit();
         exit.checkAssertionAfterwards(

--- a/dockstore-client/src/test/java/io/github/collaboratory/cwl/LauncherIT.java
+++ b/dockstore-client/src/test/java/io/github/collaboratory/cwl/LauncherIT.java
@@ -91,6 +91,7 @@ public abstract class LauncherIT {
             expectedEx.expectMessage("Unexpected call of System.exit(1)");
         }
 
+        Client.SCRIPT.set(true);
         Client.main(new String[] { "--config", getConfigFile(), "tool", "launch", "--local-entry",
                 cwlFile.getAbsolutePath(), "--json", jobFile.getAbsolutePath(), "--script" });
 
@@ -113,6 +114,7 @@ public abstract class LauncherIT {
             expectedEx.expectMessage("Unexpected call of System.exit(1)");
         }
 
+        Client.SCRIPT.set(true);
         Client.main(new String[] { "--config", getConfigFileWithExtraParameters(), "tool", "launch", "--local-entry",
                 cwlFile.getAbsolutePath(), "--json", jobFile.getAbsolutePath(), "--script" });
 
@@ -133,6 +135,8 @@ public abstract class LauncherIT {
         if (System.getenv("AWS_ACCESS_KEY") == null || System.getenv("AWS_SECRET_KEY") == null) {
             expectedEx.expectMessage("Unexpected call of System.exit(1)");
         }
+
+        Client.SCRIPT.set(true);
         Client.main(new String[] { "--config", getConfigFile(), "tool", "launch", "--local-entry",
                 cwlFile.getAbsolutePath(), "--json", jobFile.getAbsolutePath(), "--script" });
 
@@ -153,6 +157,8 @@ public abstract class LauncherIT {
         if (System.getenv("AWS_ACCESS_KEY") == null || System.getenv("AWS_SECRET_KEY") == null) {
             expectedEx.expectMessage("Unexpected call of System.exit(1)");
         }
+
+        Client.SCRIPT.set(true);
         Client.main(new String[] { "--config", getConfigFile(), "workflow", "launch", "--local-entry",
                 cwlFile.getAbsolutePath(), "--json", jobFile.getAbsolutePath(), "--script" });
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
@@ -205,7 +205,7 @@ public class ClientIT extends BaseIT {
     @Category(ToilCompatibleTest.class)
     public void launchingCWLToolWithRemoteParameters() throws IOException {
         Client.main(
-            new String[] { "--config", TestUtility.getConfigFileLocation(true), "tool", "launch", "--local-entry", firstTool, "--json",
+            new String[] { "--script", "--config", TestUtility.getConfigFileLocation(true), "tool", "launch", "--local-entry", firstTool, "--json",
                 "https://raw.githubusercontent.com/ga4gh/dockstore/f343bcd6e4465a8ef790208f87740bd4d5a9a4da/dockstore-client/src/test/resources/test.cwl.json" });
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MockedIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MockedIT.java
@@ -176,7 +176,7 @@ public class MockedIT {
         String configFileLocation = TestUtility.getConfigFileLocation(true, true, true);
         when(client.getConfigFile()).thenReturn(configFileLocation);
 
-        Client.main(new String[] { "--clean-cache", "--config", configFileLocation });
+        Client.main(new String[] { "--clean-cache", "--config", configFileLocation, "--script" });
         // this is kind of redundant, it looks like we take the mocked config file no matter what
         Client.main(new String[] { "--config", configFileLocation, "tool", "launch", "--entry", "quay.io/collaboratory/arrays", "--json",
                 ResourceHelpers.resourceFilePath("testArrayLocalInputLocalOutput.json"),

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MockedIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MockedIT.java
@@ -145,7 +145,8 @@ public class MockedIT {
     @Ignore
     public void runLaunchNJson() throws IOException {
         Client.main(new String[] { "--config", TestUtility.getConfigFileLocation(true), "tool", "launch", "--entry",
-                "quay.io/collaboratory/dockstore-tool-linux-sort", "--json", ResourceHelpers.resourceFilePath("testMultipleRun.json") });
+                "quay.io/collaboratory/dockstore-tool-linux-sort", "--json", ResourceHelpers.resourceFilePath("testMultipleRun.json"),
+                "--script" });
     }
 
     /**
@@ -157,7 +158,8 @@ public class MockedIT {
     @Test
     public void runLaunchOneLocalArrayedJson() throws IOException, ApiException {
         Client.main(new String[] { "--config", TestUtility.getConfigFileLocation(true), "tool", "launch", "--entry",
-                "quay.io/collaboratory/arrays", "--json", ResourceHelpers.resourceFilePath("testArrayLocalInputLocalOutput.json") });
+                "quay.io/collaboratory/arrays", "--json", ResourceHelpers.resourceFilePath("testArrayLocalInputLocalOutput.json"),
+                "--script" });
 
         Assert.assertTrue(new File("/tmp/example.bedGraph").exists());
         Assert.assertTrue("output should contain cwltool command", systemOutRule.getLog().contains("Executing: cwltool"));
@@ -177,7 +179,8 @@ public class MockedIT {
         Client.main(new String[] { "--clean-cache", "--config", configFileLocation });
         // this is kind of redundant, it looks like we take the mocked config file no matter what
         Client.main(new String[] { "--config", configFileLocation, "tool", "launch", "--entry", "quay.io/collaboratory/arrays", "--json",
-                ResourceHelpers.resourceFilePath("testArrayLocalInputLocalOutput.json") });
+                ResourceHelpers.resourceFilePath("testArrayLocalInputLocalOutput.json"),
+                "--script" });
 
         Assert.assertTrue(new File("/tmp/example.bedGraph").exists());
         Assert.assertTrue("output should contain cwltool command", systemOutRule.getLog().contains("Executing: cwltool"));
@@ -185,7 +188,8 @@ public class MockedIT {
 
         // try again, things should be cached now
         Client.main(new String[] { "--config", configFileLocation, "tool", "launch", "--entry", "quay.io/collaboratory/arrays", "--json",
-                ResourceHelpers.resourceFilePath("testArrayLocalInputLocalOutput.json") });
+                ResourceHelpers.resourceFilePath("testArrayLocalInputLocalOutput.json"),
+                "--script" });
         Assert.assertEquals("output should contain only hard linking", 6, StringUtils.countMatches(systemOutRule.getLog(), "hard-linking"));
         Assert.assertTrue("output should not contain warnings about skipping files", !systemOutRule.getLog().contains("skipping"));
     }
@@ -199,7 +203,8 @@ public class MockedIT {
     @Test
     public void runLaunchOneHTTPArrayedJson() throws IOException, ApiException {
         Client.main(new String[] { "--config", TestUtility.getConfigFileLocation(true), "tool", "launch", "--entry",
-                "quay.io/collaboratory/arrays", "--json", ResourceHelpers.resourceFilePath("testArrayHttpInputLocalOutput.json") });
+                "quay.io/collaboratory/arrays", "--json", ResourceHelpers.resourceFilePath("testArrayHttpInputLocalOutput.json"),
+                "--script" });
 
         Assert.assertTrue(new File("/tmp/wc1.out").exists());
         Assert.assertTrue(new File("/tmp/wc2.out").exists());


### PR DESCRIPTION
https://github.com/ga4gh/dockstore/issues/2135

--script is now NOT carried between tests.

Edit:
Within the Client, --script is only set if you specify it and call Client.main or Client.run directly. For these tests we simply add --script to the args. Some tests call functions downstream of main/run, which means that script is not being set. So you have to manually do Client.SCRIPT.set(true/false) for these tests.