### PR TITLE
Hotfix for WES so it can run a workflow on Arvados

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WESLauncher.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WESLauncher.java
@@ -101,7 +101,8 @@ public class WESLauncher extends BaseLauncher {
                 workflowAttachment.add(afile);
             }
         } catch (Exception e) {
-            LOG.error("Unable to traverse directory " + tempDir.getName() + " to get workflow attachment files", e);
+            System.out.println("Unable to traverse directory " + tempDir.getName() + " to get workflow "
+                            + "attachment files");
             exceptionMessage(e, "Unable to traverse directory " + tempDir.getName() + " to get workflow "
                     + "attachment files", GENERIC_ERROR);
         }
@@ -131,9 +132,11 @@ public class WESLauncher extends BaseLauncher {
         try {
             jsonString = abstractEntryClient.fileToJSON(jsonInputFilePath);
         } catch (IOException ex) {
-            System.out.println("Could not construct JSON string from " + jsonInputFilePath + ". Request will not be sent to WES endpoint. "
-                    + "Please check that the input file is proper JSON");
-            errorMessage(ex.getMessage(), IO_ERROR);
+            System.out.println("Could not construct JSON from " + jsonInputFilePath + ". Request will not be sent to WES endpoint. "
+                    + "Please check that the input file is proper JSON.");
+            exceptionMessage(ex,"Could not construct JSON from " + jsonInputFilePath + ". Request will not be sent to WES endpoint. "
+                    + "Please check that the input file is proper JSON.", IO_ERROR);
+
         }
 
         String languageType = this.languageType.toString().toUpperCase();

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WESLauncher.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WESLauncher.java
@@ -16,7 +16,6 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.dockstore.client.cli.ArgumentUtility.errorMessage;
 import static io.dockstore.client.cli.ArgumentUtility.exceptionMessage;
 import static io.dockstore.client.cli.Client.GENERIC_ERROR;
 import static io.dockstore.client.cli.Client.IO_ERROR;
@@ -61,7 +60,7 @@ public class WESLauncher extends BaseLauncher {
      * Provisions output files defined in the parameter file
      * @param stdout stdout of running entry
      * @param stderr stderr of running entry
-     * @param wdlOutputTarget
+     * @param wdlOutputTarget remote path to provision outputs files to (ex: s3://oicr.temp/testing-launcher/)
      */
     @Override
     public void provisionOutputFiles(String stdout, String stderr, String wdlOutputTarget) {
@@ -80,8 +79,8 @@ public class WESLauncher extends BaseLauncher {
         try {
             SwaggerUtility.unzipFile(zippedEntry, tempDir);
         } catch (IOException e) {
-            System.out.println("Could not get files from workflow attachment " + zippedEntry.getName() + " Request not sent.");
-            exceptionMessage(e, "Unable to get workflow attachment files from zip file " + zippedEntry.getName(), IO_ERROR);
+            exceptionMessage(e, "Unable to get workflow attachment files from zip file " + zippedEntry.getName()
+                    + " Request not sent.", IO_ERROR);
         }
 
         try {
@@ -101,8 +100,6 @@ public class WESLauncher extends BaseLauncher {
                 workflowAttachment.add(afile);
             }
         } catch (Exception e) {
-            System.out.println("Unable to traverse directory " + tempDir.getName() + " to get workflow "
-                            + "attachment files");
             exceptionMessage(e, "Unable to traverse directory " + tempDir.getName() + " to get workflow "
                     + "attachment files", GENERIC_ERROR);
         }
@@ -132,11 +129,8 @@ public class WESLauncher extends BaseLauncher {
         try {
             jsonString = abstractEntryClient.fileToJSON(jsonInputFilePath);
         } catch (IOException ex) {
-            System.out.println("Could not construct JSON from " + jsonInputFilePath + ". Request will not be sent to WES endpoint. "
-                    + "Please check that the input file is proper JSON.");
-            exceptionMessage(ex,"Could not construct JSON from " + jsonInputFilePath + ". Request will not be sent to WES endpoint. "
-                    + "Please check that the input file is proper JSON.", IO_ERROR);
-
+            exceptionMessage(ex, "Could not construct JSON from " + jsonInputFilePath + ". Request will not be sent to WES "
+                    + "endpoint. Please check that the input file is proper JSON.", IO_ERROR);
         }
 
         String languageType = this.languageType.toString().toUpperCase();

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WESLauncher.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WESLauncher.java
@@ -24,7 +24,7 @@ import static io.dockstore.client.cli.Client.IO_ERROR;
 
 public class WESLauncher extends BaseLauncher {
     private static final Logger LOG = LoggerFactory.getLogger(WESLauncher.class);
-    private static final String TAGS = "WorkflowExecutionService";
+    private static final String TAGS = "{\"Client\":\"Dockstore\"}";
     private static final String WORKFLOW_TYPE_VERSION = "1.0";
 
     // Cromwell currently supports draft-2 of the WDL specification
@@ -142,7 +142,7 @@ public class WESLauncher extends BaseLauncher {
 
         try {
             RunId response = clientWorkflowExecutionServiceApi.runWorkflow(jsonInputFile, languageType, workflowTypeVersion, TAGS,
-                    "", workflowURL, workflowAttachment);
+                    "{}", workflowURL, workflowAttachment);
             System.out.println("Launched WES run with id: " + response.toString());
         } catch (io.openapi.wes.client.ApiException e) {
             LOG.error("Error launching WES run", e);

--- a/openapi-java-wes-client/src/main/resources/workflow-execution_service-1.0.0-oas3-openapi.yaml
+++ b/openapi-java-wes-client/src/main/resources/workflow-execution_service-1.0.0-oas3-openapi.yaml
@@ -199,7 +199,7 @@ paths:
               properties:
                 workflow_params:
                   type: string
-                  format: binary
+                  format: application/json
                 workflow_type:
                   type: string
                 workflow_type_version:


### PR DESCRIPTION
This fixes the WES launch workflow raw HTTP request so the Arvados endpoint will accept it and run the requested workflow. It also brings the WES call into agreement with the official WES schema.

Same PR as an earlier one Fix inputs for WES endpoints #2367 except this one targets the hotfix branch.